### PR TITLE
Add conversation:create

### DIFF
--- a/app/Console/Commands/ConversationCreate.php
+++ b/app/Console/Commands/ConversationCreate.php
@@ -44,18 +44,15 @@ class ConversationCreate extends Command
      */
     public function handle()
     {
-		$userTo = User::find($this->argument('to'));
+        $userTo = User::find($this->argument('to'));
         $userFrom = User::find($this->argument('from'));
 
         //Create new conversation
         $conversation = $this->conversation->findOrCreatePrivateConversation($userFrom, $userTo);
-		if ($conversation) {
-			$message = "Conversation has been created.";
-		} else {
-			$message = "Conversation could not be created, maybe none of the users are admin?";
-		}
-		
-		$this->error($message);
-
+        if ($conversation) {
+            $this->info("Conversation has been created.");
+        } else {
+            $this->error("Conversation could not be created, maybe none of the users are admin?");
+        }
     }
 }

--- a/app/Console/Commands/ConversationCreate.php
+++ b/app/Console/Commands/ConversationCreate.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use STS\Entities\Conversation;
+use Carbon\Carbon;
+use STS\User;
+use STS\Services\Logic\ConversationsManager as ConversationManager;
+
+class ConversationCreate extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+
+    protected $signature = 'conversation:create {from} {to}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Initiate a conversarion between users';
+    protected $conversation;
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(ConversationManager $conversation)
+    {
+        parent::__construct();
+        $this->conversation = $conversation;   
+
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+		$userTo = User::find($this->argument('to'));
+        $userFrom = User::find($this->argument('from'));
+
+        //Create new conversation
+        $conversation = $this->conversation->findOrCreatePrivateConversation($userFrom, $userTo);
+		if ($conversation) {
+			$message = "Conversation has been created.";
+		} else {
+			$message = "Conversation could not be created, maybe none of the users are admin?";
+		}
+		
+		$this->error($message);
+
+    }
+}

--- a/app/Console/Commands/ConversationCreate.php
+++ b/app/Console/Commands/ConversationCreate.php
@@ -48,8 +48,8 @@ class ConversationCreate extends Command
         $userFrom = User::find($this->argument('from'));
 
         //Create new conversation
-        $conversation = $this->conversation->findOrCreatePrivateConversation($userFrom, $userTo);
-        if ($conversation) {
+        $newConversation = $this->conversation->findOrCreatePrivateConversation($userFrom, $userTo);
+        if ($newConversation) {
             $this->info("Conversation has been created.");
         } else {
             $this->error("Conversation could not be created, maybe none of the users are admin?");

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,7 +21,6 @@ class Kernel extends ConsoleKernel
         Commands\FacebookImage::class,
         Commands\UpdateUser::class,
         Commands\ConversationCreate::class,
-
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,6 +20,8 @@ class Kernel extends ConsoleKernel
         Commands\DownloadPoints::class,
         Commands\FacebookImage::class,
         Commands\UpdateUser::class,
+        Commands\ConversationCreate::class,
+
     ];
 
     /**


### PR DESCRIPTION
Add artisan command to create conversations
Usage:

`php artisan conversation:create {from} {to}`

Output
```
php artisan conversation:create 25 1
Conversation has been created.
php artisan conversation:create 25 10
Conversation could not be created, maybe none of the users are admin?
```