### PR TITLE
Enable DB port (3306), to be able to connect to the DB from a GUI app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   carpoolear_db:
     image: mysql:5.6
     container_name: carpoolear_db
+    ports:
+      - 3306:3306
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_DATABASE: carpoolear


### PR DESCRIPTION
A small addition on the `docker-compose.yml` file, to enable the access to the DB container through the 3306 port, to allow connecting to the DB container using a GUI app, and not to depend from phpmyadmin