### PR TITLE
Arreglar checkeo para multiples viajes en un rango de tiempo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,6 @@ BANNER_URL=https://www.carpoolear.com.ar/lucro
 BANNER_IMAGE=https://carpoolear.com.ar/img/lucro.png
 BANNER_URL_CORDOVA=https://www.carpoolear.com.ar/APP_DEBUG
 BANNER_IMAGE_CORDOVA=https://carpoolear.com.ar/img/carpoolear_pwa.png
+
+MODULE_USER_REQUEST_LIMITED_ENABLED=false # if enabled, the user will not be able to request a ride if there are already requests in the same trip date, FOR THE SAME DESTINATION and in the range of hours defined in MODULE_USER_REQUEST_LIMITED_HOURS_RANGE
+MODULE_USER_REQUEST_LIMITED_HOURS_RANGE=12 # 12 hours before and after the trip date

--- a/app/Listeners/Request/ModuleLimitedRequest.php
+++ b/app/Listeners/Request/ModuleLimitedRequest.php
@@ -31,18 +31,29 @@ class ModuleLimitedRequest
         $trip = $event->trip;
         $acceptedUser = $event->to;
 
-        $module_user_request_limited = config('carpoolear.module_user_request_limited', false);
+        $module_user_request_limited_enabled = config('carpoolear.module_user_request_limited_enabled', false);
 
-        if ($module_user_request_limited && $module_user_request_limited->enabled) {
-            $hours_range = $module_user_request_limited->hours_range;
-            $requests = $acceptedUser->pendingRequests($hours_range, $trip->trip_date)->where('trip_id', '<>', $trip->id)->get();
-            if ($requests && count($requests) > 0) {
+        if ($module_user_request_limited_enabled) {
+            $hours_range = (int) config('carpoolear.module_user_request_limited_hours_range', 2);
+            
+            $requests = $acceptedUser->pendingRequests($hours_range, $trip->trip_date)
+            ->where('trip_id', '<>', $trip->id)
+            ->with('trip')  // Eager load the trip relation
+            ->get()
+            ->filter(function($request) use ($trip) {
+                // Check if destination is the same or similar
+                return $request->trip && $request->trip->to_town === $trip->to_town;
+            });
+
+            if ($requests->isNotEmpty()) {
                 foreach ($requests as $request) {
                     $request->request_state = Passenger::STATE_CANCELED;
                     $request->canceled_state = Passenger::CANCELED_SYSTEM;
                     $tripRequest = Trip::find($request->trip_id);
-                    $tripOwnerUser = User::find($tripRequest->user_id);
-                    event(new AutoCancelEvent($tripRequest, $tripOwnerUser, $acceptedUser));
+                    if ($tripRequest) {
+                        $tripOwnerUser = User::find($tripRequest->user_id);
+                        event(new AutoCancelEvent($tripRequest, $tripOwnerUser, $acceptedUser));
+                    }
                     $request->save();
                 }
             }

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -12,4 +12,6 @@ return [
     'banner_image_cordova' => env('BANNER_IMAGE_CORDOVA', ''),
     'target_app' => env('TARGET_APP', 'carpoolear'),
     'module_coordinate_by_message' => env('MODULE_COORDINATE_BY_MESSAGE', false),
+    'module_user_request_limited_enabled' => env('MODULE_USER_REQUEST_LIMITED_ENABLED', false),
+    'module_user_request_limited_hours_range' => (int) env('MODULE_USER_REQUEST_LIMITED_HOURS_RANGE', 2)
 ];


### PR DESCRIPTION
Checkea viajes con el mismo destino dentro de +-12 horas del viaje aceptado y cancela las otras requests que se solapen.

Necesita unas variables en el `.env`:

`MODULE_USER_REQUEST_LIMITED_ENABLED=true`
`MODULE_USER_REQUEST_LIMITED_HOURS_RANGE=12`

Closes https://github.com/STS-Rosario/carpoolear_backend/issues/158