### PR TITLE
Arreglar banner de upgrade a PWA

### DIFF
--- a/app/Http/Controllers/Api/v1/AuthController.php
+++ b/app/Http/Controllers/Api/v1/AuthController.php
@@ -74,6 +74,7 @@ class AuthController extends Controller
         $isCordova = false;
         if (isset($_SERVER['HTTP_SEC_CH_UA'])) {
             $secChUa = $_SERVER['HTTP_SEC_CH_UA'];
+            $userAgent = $_SERVER['HTTP_USER_AGENT'];
             
             $user = auth()->user();
             
@@ -84,7 +85,7 @@ class AuthController extends Controller
                 \Log::warning('getConfig called without authenticated user');
             }
             
-            if (strpos($secChUa, 'WebView') !== false) {
+            if (strpos($secChUa, 'WebView') !== false && strpos($userAgent, 'Instagram') === false) {
                 $isCordova = true;
             }
         }


### PR DESCRIPTION
Mostrar banner de upgrade a PWA sólo en Cordova apps, no en embedded browser en Instagram