### PR TITLE
Add MODULE_CONVERSATION_AVERAGE_DELAY for TripDriver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,7 @@ MODULE_USER_REQUEST_LIMITED_HOURS_RANGE=12 # 12 hours before and after the trip 
 MODULE_SEND_FULL_TRIP_MESSAGE=true # If enabled, the app will send a message to the remaining passengers when the trip is full when accepting a passenger
 MODULE_UNIQUE_DOC_PHONE=true # If enabled, it will prevent users from registering with same phone or DNI than other users
 MODULE_UNASWERED_MESSAGE_LIMIT=false # If enabled, implements a limit on unanswered messages in conversations to maintain active communication between users
+MODULE_CONVERSATION_AVERAGE_DELAY=false # If enabled, the app shows the driver's message response speed and response rate on trip detail (TripDriver)
 MODULE_TRIP_SEATS_PAYMENT=false # If enabled, allows users to make payments for specific seats on a trip, implementing a payment system for trip reservations
 MODULE_VALIDATED_DRIVERS=false # If enabled, users must go through a verification process before they can create trips as drivers, adding a layer of safety and trust to the platform
 MODULE_COORDINATE_BY_MESSAGE=true # Enables the ability to coordinate trip details through messages. When enabled, users can exchange specific trip coordination information through the messaging system.

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -21,6 +21,8 @@ return [
     'module_user_request_limited_hours_range' => (int) env('MODULE_USER_REQUEST_LIMITED_HOURS_RANGE', 2),
     'module_send_full_trip_message' => env('MODULE_SEND_FULL_TRIP_MESSAGE', false),
     'module_unaswered_message_limit' => env('MODULE_UNASWERED_MESSAGE_LIMIT', false),
+    // When true, the Vue app shows response speed and response rate for the driver on trip cards (TripDriver.vue).
+    'module_conversation_average_delay' => env('MODULE_CONVERSATION_AVERAGE_DELAY', false),
     'module_trip_seats_payment' => env('MODULE_TRIP_SEATS_PAYMENT', false),
     'module_unique_doc_phone' => env('MODULE_UNIQUE_DOC_PHONE', false),
     'module_validated_drivers' => env('MODULE_VALIDATED_DRIVERS', false),


### PR DESCRIPTION
Wire module_conversation_average_delay through carpoolear config and document in .env.example so the Vue app can show response speed/rate when enabled.