### PR TITLE
Add Laravel Pint pre-commit hook and document in README

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if [[ ! -f vendor/bin/pint ]]; then
+  echo "pre-commit: vendor/bin/pint not found — run composer install" >&2
+  exit 1
+fi
+
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACM | grep -E '\.php$' || true)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+existing=()
+for f in "${files[@]}"; do
+  [[ -f "$f" ]] && existing+=("$f")
+done
+
+if [[ ${#existing[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+vendor/bin/pint "${existing[@]}"
+git add "${existing[@]}"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Happy coding!
 
 ## Contributing
 
+### Code style (Laravel Pint)
+
+Commits run [Laravel Pint](https://github.com/laravel/pint) on **staged** `.php` files via `.githooks/pre-commit`. Pint fixes style in place and those changes are re-staged so they are included in the same commit.
+
+After `composer install` or `composer update`, the repo’s Git config is updated to use the tracked hooks directory (`core.hooksPath=.githooks`). If hooks are not firing (for example you cloned before this was added), run:
+
+```bash
+composer run setup-git-hooks
+```
+
+You can still run Pint manually anytime:
+
+```bash
+./vendor/bin/pint
+```
 
 ## Troubleshooting
 

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,17 @@
         }
     },
     "scripts": {
+        "setup-git-hooks": "@php -r \"if (file_exists('.git')) { passthru('git config core.hooksPath .githooks'); }\"",
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
+        "post-install-cmd": [
+            "@setup-git-hooks"
+        ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
+            "@setup-git-hooks"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""


### PR DESCRIPTION
- Track .githooks/pre-commit to run Pint on staged PHP files and re-stage fixes
- Wire setup-git-hooks via composer install/update (core.hooksPath=.githooks)
- Document behavior and manual setup in Contributing