### PR TITLE
Contribución máxima

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,17 +103,21 @@ MODULE_MAX_PRICE_KILOMETER_BY_LITER=10
 
 # Manual identity validation cost (in cents). Set to 0 to disable.
 MANUAL_IDENTITY_VALIDATION_COST_CENTS=0
+# Master switch: when false, hide identity validation UI and do not enforce (MP/manual flags below are ignored for UX)
+IDENTITY_VALIDATION_ENABLED=false
+# When true (and enabled), users can use validation flows but are not blocked on restricted actions
+IDENTITY_VALIDATION_OPTIONAL=false
 # Identity validation: enable MP OAuth and/or manual validation (frontend shows only enabled options)
 IDENTITY_VALIDATION_MERCADO_PAGO_ENABLED=false
 IDENTITY_VALIDATION_MANUAL_ENABLED=false
 # QR payment for manual validation: set true to show "Pagar con QR". Requires MERCADO_PAGO_QR_PAYMENT_* and MERCADO_PAGO_QR_PAYMENT_POS_EXTERNAL_ID (see docs/MANUAL_VALIDATION_QR_SETUP.md).
 IDENTITY_VALIDATION_MANUAL_QR_ENABLED=false
 MERCADO_PAGO_QR_PAYMENT_POS_EXTERNAL_ID=
-# Require identity validation for new users to send messages, request seats, accept/reject passengers, create trips
+# When enforcement is active (enabled + not optional), require "new" users (see cutoff) to validate before restricted actions
 IDENTITY_VALIDATION_REQUIRED_NEW_USERS=false
-# Users created on or after this date (Y-m-d) are "new"; if null, no one is considered new by date
+# Users with created_at >= this date (Y-m-d) are "new" for identity validation rules.
 IDENTITY_VALIDATION_NEW_USERS_DATE=
-# When set (e.g. 30), current users without validate_by_date get it set to now + N days when they hit /users/me (deadline banner in frontend)
+# When set (e.g. 30), pre-cutoff users without validate_by_date get it on first /users/me (only while mandatory: enabled and IDENTITY_VALIDATION_OPTIONAL=false)
 IDENTITY_VALIDATION_DAYS_FOR_CURRENT_USERS=
 
 # Mercado Pago OAuth (for identity validation via RENAPER)

--- a/app/Helpers/IdentityValidationHelper.php
+++ b/app/Helpers/IdentityValidationHelper.php
@@ -2,32 +2,104 @@
 
 namespace STS\Helpers;
 
+use Carbon\Carbon;
 use STS\Models\User;
 
 class IdentityValidationHelper
 {
     /**
-     * User is "new" (created on or after identity_validation_new_users_date) and has no validate_by_date (extra-time deadline).
-     * When identity_validation_required_new_users is true, such users must validate before performing restricted actions.
+     * Feature is on and we are in a period where unvalidated users are blocked on restricted actions.
+     */
+    public static function enforcementIsActive(): bool
+    {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            return false;
+        }
+
+        if (config('carpoolear.identity_validation_optional', false)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * New users: created on or after identity_validation_new_users_date.
+     */
+    public static function newUsersCutoffDate(): ?Carbon
+    {
+        $raw = config('carpoolear.identity_validation_new_users_date', null);
+        if (empty($raw)) {
+            return null;
+        }
+
+        return Carbon::parse($raw)->startOfDay();
+    }
+
+    public static function isUserCreatedOnOrAfterCutoff(User $user): bool
+    {
+        $cutoff = self::newUsersCutoffDate();
+        if (! $cutoff) {
+            return false;
+        }
+
+        $createdAt = $user->created_at ? $user->created_at->copy()->startOfDay() : null;
+        if (! $createdAt) {
+            return false;
+        }
+
+        return $createdAt->gte($cutoff);
+    }
+
+    /**
+     * User is "new" and must validate immediately (no validate_by_date grace) when enforcement is on.
      */
     public static function isNewUserRequiringValidation(User $user): bool
     {
+        if (! self::enforcementIsActive()) {
+            return false;
+        }
+
         if (! config('carpoolear.identity_validation_required_new_users', false)) {
             return false;
         }
 
-        $cutoffDate = config('carpoolear.identity_validation_new_users_date');
-        if (empty($cutoffDate)) {
+        if (! self::isUserCreatedOnOrAfterCutoff($user)) {
             return false;
         }
 
-        $cutoff = \Carbon\Carbon::parse($cutoffDate)->startOfDay();
-        $createdAt = $user->created_at ? $user->created_at->startOfDay() : null;
-        if (! $createdAt || $createdAt->lt($cutoff)) {
+        if ($user->identity_validated) {
             return false;
         }
 
-        return $user->validate_by_date === null;
+        // If a grace deadline exists (e.g. admin), use deadline rules instead
+        if ($user->validate_by_date !== null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Pre-cutoff user with a validate_by_date that has passed.
+     */
+    public static function isCurrentUserPastDeadline(User $user): bool
+    {
+        if (! $user->validate_by_date) {
+            return false;
+        }
+
+        if (self::isUserCreatedOnOrAfterCutoff($user)) {
+            return false;
+        }
+
+        if ($user->identity_validated) {
+            return false;
+        }
+
+        $end = $user->validate_by_date->copy()->endOfDay();
+
+        return now()->gt($end);
     }
 
     /**
@@ -39,7 +111,19 @@ class IdentityValidationHelper
             return true;
         }
 
-        return ! self::isNewUserRequiringValidation($user);
+        if (! self::enforcementIsActive()) {
+            return true;
+        }
+
+        if (self::isNewUserRequiringValidation($user)) {
+            return false;
+        }
+
+        if (self::isCurrentUserPastDeadline($user)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/app/Http/Controllers/Api/v1/AuthController.php
+++ b/app/Http/Controllers/Api/v1/AuthController.php
@@ -1,18 +1,18 @@
 <?php
 
 namespace STS\Http\Controllers\Api\v1;
- 
+
+use Illuminate\Http\Request;
 use STS\Helpers\OldCordovaAppHelper;
+use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
 use STS\User;
-use Illuminate\Http\Request;
-use STS\Http\Controllers\Controller; 
-use Tymon\JWTAuth\Exceptions\JWTException; 
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Exceptions\TokenExpiredException;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
 class AuthController extends Controller
@@ -31,16 +31,17 @@ class AuthController extends Controller
         $this->deviceLogic = $devices;
     }
 
-    private function _getConfig ($isCordova = false) {
+    private function _getConfig($isCordova = false)
+    {
 
-        $config = new \stdClass();
-        $config->donation = new \stdClass();
+        $config = new \stdClass;
+        $config->donation = new \stdClass;
         $config->donation->month_days = config('carpoolear.donation_month_days');
         $config->donation->trips_count = config('carpoolear.donation_trips_count');
         $config->donation->trips_offset = config('carpoolear.donation_trips_offset');
         $config->donation->trips_rated = config('carpoolear.donation_trips_rated');
         $config->donation->ammount_needed = config('carpoolear.donation_ammount_needed');
-        $config->banner = new \stdClass();
+        $config->banner = new \stdClass;
         $config->banner->url = $isCordova ? config('carpoolear.banner_url_cordova') : config('carpoolear.banner_url');
         $config->banner->url_mobile = $isCordova ? config('carpoolear.banner_url_cordova_mobile') : config('carpoolear.banner_url_mobile');
         $config->banner->image = $isCordova ? config('carpoolear.banner_image_cordova') : config('carpoolear.banner_image');
@@ -54,7 +55,7 @@ class AuthController extends Controller
             'banner_url',
             'banner_image',
             'qr_payment_pos_external_id', // backend only; frontend gets identity_validation_manual_qr_enabled
-            'identity_validation_new_users_date', // backend only; frontend gets identity_validation_required_new_users
+            'identity_validation_new_users_date', // backend only; profile exposes identity_validation_required_for_user
         ];
         $allConfigs = config('carpoolear');
         \Log::info('Environment Check:', [
@@ -74,12 +75,14 @@ class AuthController extends Controller
         }
         $config->identity_validation_manual_qr_enabled = config('carpoolear.identity_validation_manual_enabled')
             && config('carpoolear.identity_validation_manual_qr_enabled')
-            && !empty(config('services.mercadopago.qr_payment_access_token'))
-            && !empty(config('carpoolear.qr_payment_pos_external_id'));
+            && ! empty(config('services.mercadopago.qr_payment_access_token'))
+            && ! empty(config('carpoolear.qr_payment_pos_external_id'));
+
         return $config;
     }
 
-    public function getConfig (Request $request) {
+    public function getConfig(Request $request)
+    {
         $user = auth()->user();
 
         // Check if user is authenticated before accessing properties
@@ -117,9 +120,10 @@ class AuthController extends Controller
         }
 
         $config = $this->_getConfig();
+
         return response()->json([
             'token' => $token,
-            'config' => $config
+            'config' => $config,
         ]);
     }
 
@@ -141,13 +145,13 @@ class AuthController extends Controller
         }
 
         $data = [
-            'session_id'  => $token,
+            'session_id' => $token,
         ];
         $config = $this->_getConfig();
 
         if ($request->has('app_version')) {
-            $data['app_version'] =$request->get('app_version');
-            $device = $this->deviceLogic->updateBySession($oldToken, $data);    
+            $data['app_version'] = $request->get('app_version');
+            $device = $this->deviceLogic->updateBySession($oldToken, $data);
         }
 
         if (isset($user)) {
@@ -162,7 +166,7 @@ class AuthController extends Controller
                 ]);
             }
         }
-        
+
         return response()->json([
             'token' => $token,
             'config' => $config,
@@ -180,7 +184,7 @@ class AuthController extends Controller
                 $this->deviceLogic->logoutDevice($token, $user);
             }
         }
-        
+
         // Invalidate the JWT token using the correct method
         try {
             $token = JWTAuth::getToken();
@@ -189,7 +193,7 @@ class AuthController extends Controller
                 \Log::info('JWT token invalidated successfully');
             }
         } catch (\Exception $e) {
-            \Log::error('Failed to invalidate JWT token: ' . $e->getMessage());
+            \Log::error('Failed to invalidate JWT token: '.$e->getMessage());
         }
 
         return response()->json('OK');
@@ -210,11 +214,11 @@ class AuthController extends Controller
     {
         // Apply rate limiting
         $request->validate([
-            'email' => 'required|email'
+            'email' => 'required|email',
         ]);
 
         $email = $request->get('email');
-        
+
         try {
             $token = $this->userLogic->resetPassword($email);
             if ($token) {
@@ -222,25 +226,25 @@ class AuthController extends Controller
             } else {
                 // Check if there are specific errors from the user logic
                 $errors = $this->userLogic->getErrors();
-                if (!empty($errors)) {
+                if (! empty($errors)) {
                     $errorMessage = is_array($errors) ? implode(', ', $errors) : $errors;
                     throw new ExceptionWithErrors($errorMessage);
                 }
                 throw new ExceptionWithErrors('User not found');
             }
         } catch (\Exception $e) {
-            \Log::error('Password reset error: ' . $e->getMessage());
-            
+            \Log::error('Password reset error: '.$e->getMessage());
+
             // Check if it's a rate limiting error
             if (strpos($e->getMessage(), '450') !== false || strpos($e->getMessage(), 'rate') !== false) {
                 throw new ExceptionWithErrors('Too many password reset attempts. Please try again later.');
             }
-            
+
             // Check if it's a cooldown error
             if (strpos($e->getMessage(), 'wait') !== false && strpos($e->getMessage(), 'minutes') !== false) {
                 throw new ExceptionWithErrors($e->getMessage());
             }
-            
+
             throw $e;
         }
     }
@@ -256,7 +260,8 @@ class AuthController extends Controller
         }
     }
 
-    public function log() {
+    public function log()
+    {
         return true;
     }
 }

--- a/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
@@ -2,15 +2,15 @@
 
 namespace STS\Http\Controllers\Api\v1;
 
-use STS\Http\Controllers\Controller;
-use STS\Http\ExceptionWithErrors;
-use STS\Models\ManualIdentityValidation;
-use STS\Services\ImageUploadValidator;
-use STS\Services\HeicToJpegConverter;
-use STS\Services\MercadoPagoService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use STS\Http\Controllers\Controller;
+use STS\Http\ExceptionWithErrors;
+use STS\Models\ManualIdentityValidation;
+use STS\Services\HeicToJpegConverter;
+use STS\Services\ImageUploadValidator;
+use STS\Services\MercadoPagoService;
 
 class ManualIdentityValidationController extends Controller
 {
@@ -24,10 +24,14 @@ class ManualIdentityValidationController extends Controller
      */
     public function cost()
     {
-        if (!config('carpoolear.identity_validation_manual_enabled', false)) {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            return response()->json(['cost_cents' => 0]);
+        }
+        if (! config('carpoolear.identity_validation_manual_enabled', false)) {
             return response()->json(['cost_cents' => 0]);
         }
         $costCents = config('carpoolear.manual_identity_validation_cost_cents', 0);
+
         return response()->json(['cost_cents' => $costCents]);
     }
 
@@ -36,12 +40,23 @@ class ManualIdentityValidationController extends Controller
      */
     public function status()
     {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            return response()->json([
+                'has_submission' => false,
+                'request_id' => null,
+                'paid' => null,
+                'paid_at' => null,
+                'review_status' => null,
+                'submitted_at' => null,
+                'review_note' => null,
+            ]);
+        }
         $user = auth()->user();
         $latest = ManualIdentityValidation::where('user_id', $user->id)
             ->orderBy('created_at', 'desc')
             ->first();
 
-        if (!$latest) {
+        if (! $latest) {
             return response()->json([
                 'has_submission' => false,
                 'request_id' => null,
@@ -70,7 +85,10 @@ class ManualIdentityValidationController extends Controller
     public function createPreference(Request $request, MercadoPagoService $mpService)
     {
         $user = auth()->user();
-        if (!config('carpoolear.identity_validation_manual_enabled', false)) {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            throw new ExceptionWithErrors('Identity validation is not available.', [], 503);
+        }
+        if (! config('carpoolear.identity_validation_manual_enabled', false)) {
             throw new ExceptionWithErrors('Manual identity validation is not available.', [], 503);
         }
         $costCents = config('carpoolear.manual_identity_validation_cost_cents', 0);
@@ -84,7 +102,7 @@ class ManualIdentityValidationController extends Controller
             ->orderBy('created_at', 'desc')
             ->first();
 
-        if (!$validationRequest) {
+        if (! $validationRequest) {
             $validationRequest = ManualIdentityValidation::create([
                 'user_id' => $user->id,
                 'paid' => false,
@@ -102,7 +120,7 @@ class ManualIdentityValidationController extends Controller
         }
 
         $initPoint = $preference->init_point ?? $preference->sandbox_init_point ?? null;
-        if (!$initPoint) {
+        if (! $initPoint) {
             if ($validationRequest->wasRecentlyCreated) {
                 $validationRequest->delete();
             }
@@ -123,10 +141,13 @@ class ManualIdentityValidationController extends Controller
     public function createQrOrder(Request $request, MercadoPagoService $mpService)
     {
         $user = auth()->user();
-        if (!config('carpoolear.identity_validation_manual_enabled', false)) {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            throw new ExceptionWithErrors('Identity validation is not available.', [], 503);
+        }
+        if (! config('carpoolear.identity_validation_manual_enabled', false)) {
             throw new ExceptionWithErrors('Manual identity validation is not available.', [], 503);
         }
-        if (!config('carpoolear.identity_validation_manual_qr_enabled', false)) {
+        if (! config('carpoolear.identity_validation_manual_qr_enabled', false)) {
             throw new ExceptionWithErrors('QR payment is not available.', [], 503);
         }
         $posExternalId = config('carpoolear.qr_payment_pos_external_id', '');
@@ -143,7 +164,7 @@ class ManualIdentityValidationController extends Controller
             ->orderBy('created_at', 'desc')
             ->first();
 
-        if (!$validationRequest) {
+        if (! $validationRequest) {
             $validationRequest = ManualIdentityValidation::create([
                 'user_id' => $user->id,
                 'paid' => false,
@@ -181,20 +202,23 @@ class ManualIdentityValidationController extends Controller
     {
         $user = auth()->user();
         $requestId = $request->input('request_id');
-        if (!$requestId) {
+        if (! $requestId) {
             throw new ExceptionWithErrors('request_id is required.', ['request_id' => ['required']]);
         }
 
-        if (!config('carpoolear.identity_validation_manual_enabled', false)) {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            throw new ExceptionWithErrors('Identity validation is not available.', [], 503);
+        }
+        if (! config('carpoolear.identity_validation_manual_enabled', false)) {
             throw new ExceptionWithErrors('Manual identity validation is not available.', [], 503);
         }
 
         $validationRequest = ManualIdentityValidation::where('id', $requestId)->where('user_id', $user->id)->first();
-        if (!$validationRequest) {
+        if (! $validationRequest) {
             throw new ExceptionWithErrors('Invalid request.', [], 404);
         }
 
-        if (!$validationRequest->paid) {
+        if (! $validationRequest->paid) {
             throw new ExceptionWithErrors('Payment is required before submitting images.', [], 422);
         }
 
@@ -214,7 +238,7 @@ class ManualIdentityValidationController extends Controller
             }
         }
 
-        $basePath = 'identity_validations/' . $validationRequest->id;
+        $basePath = 'identity_validations/'.$validationRequest->id;
         $converter = app(HeicToJpegConverter::class);
 
         $frontPath = $this->storeIdentityImage($front, $basePath, $converter);
@@ -240,7 +264,7 @@ class ManualIdentityValidationController extends Controller
     {
         $jpegContent = $converter->convert($file);
         if ($jpegContent !== null) {
-            $path = $basePath . '/' . Str::random(40) . '.jpg';
+            $path = $basePath.'/'.Str::random(40).'.jpg';
             Storage::disk('local')->put($path, $jpegContent);
 
             return $path;

--- a/app/Http/Controllers/Api/v1/UserController.php
+++ b/app/Http/Controllers/Api/v1/UserController.php
@@ -2,29 +2,33 @@
 
 namespace STS\Http\Controllers\Api\v1;
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use STS\Helpers\IdentityValidationHelper;
+use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
 use STS\Http\Resources\UserBadgeResource;
-use STS\Models\Donation;
+use STS\Jobs\SendDeleteAccountRequestEmail;
 use STS\Models\DeleteAccountRequest;
+use STS\Models\Donation;
 use STS\Models\Rating;
 use STS\Models\User;
-use Illuminate\Http\Request;
-use STS\Http\Controllers\Controller;
 use STS\Services\AnonymizationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
+use STS\Services\MercadoPagoOAuthService;
 use STS\Services\UserDeletionService;
 use STS\Transformers\ProfileTransformer;
-use STS\Jobs\SendDeleteAccountRequestEmail;
 use Tymon\JWTAuth\Facades\JWTAuth;
-use STS\Services\MercadoPagoOAuthService;
-use Illuminate\Support\Facades\Cache;
 
 class UserController extends Controller
 {
     protected $userLogic;
+
     protected $deviceLogic;
+
     protected $userDeletionService;
+
     protected $anonymizationService;
 
     public function __construct(
@@ -102,30 +106,31 @@ class UserController extends Controller
         // Check if user's phone number contains any banned numbers
         if (isset($data['mobile_phone'])) {
             $banned_phones = config('carpoolear.banned_phones', []);
-            if (!empty($banned_phones)) {
+            if (! empty($banned_phones)) {
                 $user_phone = $data['mobile_phone'];
                 foreach ($banned_phones as $banned_phone) {
                     if (str_contains($user_phone, $banned_phone)) {
                         $this->userLogic->update($profile, ['banned' => 1]);
-                        \Log::info('User banned due to phone number containing banned number: ' . $user_phone . ' (matched: ' . $banned_phone . ')');
+                        \Log::info('User banned due to phone number containing banned number: '.$user_phone.' (matched: '.$banned_phone.')');
                         break;
                     }
                 }
             }
         }
-        
+
         return $this->item($profile, new ProfileTransformer($me));
     }
-    
-    public function adminUpdate(Request $request) {
+
+    public function adminUpdate(Request $request)
+    {
         $me = auth()->user();
-        if (!$me->is_admin) {
+        if (! $me->is_admin) {
             throw new ExceptionWithErrors('Access denied. Admin privileges required.');
         }
-        
+
         $data = $request->all();
         $user = null;
-        
+
         // Extract user ID from the request
         if (isset($data['user']) && isset($data['user']['id'])) {
             $userId = $data['user']['id'];
@@ -134,16 +139,16 @@ class UserController extends Controller
         } else {
             throw new ExceptionWithErrors('User ID is required for admin update.');
         }
-        
-        if (!$user) {
+
+        if (! $user) {
             throw new ExceptionWithErrors('User not found.');
         }
-        
+
         $profile = $this->userLogic->update($user, $data, false, true);
-        if (!$profile) {
+        if (! $profile) {
             throw new ExceptionWithErrors('Could not update user.', $this->userLogic->getErrors());
         }
-        
+
         return $this->item($profile, new ProfileTransformer($me));
     }
 
@@ -161,7 +166,7 @@ class UserController extends Controller
     public function show($id = null)
     {
         $me = auth()->user();
-        if (!($id > 0)) {
+        if (! ($id > 0)) {
             $id = $me->id;
         }
         $profile = $this->userLogic->show($me, $id);
@@ -169,10 +174,15 @@ class UserController extends Controller
             throw new ExceptionWithErrors('Users not found.', $this->userLogic->getErrors());
         }
 
-        // Set validate_by_date for current users who don't have it when grace days are configured
+        // Set validate_by_date for pre-cutoff users on first /users/me when grace days apply and enforcement is on (not optional-only; new users use cutoff, not this date)
         if ($profile->id === $me->id) {
-            $days = config('carpoolear.identity_validation_days_for_current_users', 0);
-            if ($days > 0 && $profile->validate_by_date === null) {
+            $days = (int) config('carpoolear.identity_validation_days_for_current_users', 0);
+            if (
+                IdentityValidationHelper::enforcementIsActive()
+                && $days > 0
+                && $profile->validate_by_date === null
+                && ! IdentityValidationHelper::isUserCreatedOnOrAfterCutoff($profile)
+            ) {
                 $profile->validate_by_date = now()->addDays($days);
                 $profile->save();
                 $profile = $profile->fresh();
@@ -188,11 +198,11 @@ class UserController extends Controller
     public function badges($id = null)
     {
         $me = auth()->user();
-        if (!($id > 0) || $id === 'me') {
+        if (! ($id > 0) || $id === 'me') {
             $id = $me->id;
         }
         $user = User::find($id);
-        if (!$user) {
+        if (! $user) {
             throw new ExceptionWithErrors('User not found.');
         }
         $badges = $user->badges()
@@ -212,18 +222,21 @@ class UserController extends Controller
 
         return $this->collection($users, new ProfileTransformer(auth()->user()));
     }
-    public function searchUsers (Request $request) {
+
+    public function searchUsers(Request $request)
+    {
         $search_text = null;
         if ($request->has('name')) {
             $search_text = $request->get('name');
         }
         $users = $this->userLogic->searchUsers($search_text);
+
         return $this->collection($users, new ProfileTransformer(auth()->user()));
     }
 
     public function registerDonation(Request $request)
     {
-        $donation = new Donation();
+        $donation = new Donation;
         if ($request->has('has_donated')) {
             $donation->has_donated = $request->get('has_donated');
         }
@@ -238,10 +251,10 @@ class UserController extends Controller
         }
         $user = null;
         if ($request->has('user')) {
-            $user = new \stdClass();
+            $user = new \stdClass;
             $user->id = intval($request->get('user'));
             if (! $user->id > 0) {
-                $user->id = 164619; //donador anonimo
+                $user->id = 164619; // donador anonimo
             }
         } else {
             $user = auth()->user();
@@ -250,6 +263,7 @@ class UserController extends Controller
 
         return $donation;
     }
+
     public function bankData(Request $request)
     {
         $data = $this->userLogic->bankData();
@@ -257,8 +271,7 @@ class UserController extends Controller
         return json_encode($data);
     }
 
-
-    public function terms (Request $request)
+    public function terms(Request $request)
     {
         $lang = $request->has('lang') ? $request->get('lang') : '';
         $data = $this->userLogic->termsText($lang);
@@ -270,7 +283,7 @@ class UserController extends Controller
     {
         $user = auth()->user();
         $profile = $this->userLogic->update($user, [$property => $value > 0 ? 1 : 0], false, false);
-        if (!$profile) {
+        if (! $profile) {
             throw new ExceptionWithErrors('Could not update user.', $this->userLogic->getErrors());
         }
 
@@ -283,7 +296,10 @@ class UserController extends Controller
      */
     public function getMercadoPagoOAuthUrl(Request $request, MercadoPagoOAuthService $oauthService)
     {
-        if (!config('carpoolear.identity_validation_mercado_pago_enabled', false)) {
+        if (! config('carpoolear.identity_validation_enabled', false)) {
+            throw new ExceptionWithErrors('Identity validation is not available.', [], 503);
+        }
+        if (! config('carpoolear.identity_validation_mercado_pago_enabled', false)) {
             throw new ExceptionWithErrors('Identity validation with Mercado Pago is not available.', [], 503);
         }
         $clientId = config('services.mercadopago.client_id');
@@ -302,13 +318,13 @@ class UserController extends Controller
 
         if (is_array($authResult)) {
             $authorizationUrl = $authResult['authorization_url'];
-            Cache::put('mp_oauth_state:' . $state, [
+            Cache::put('mp_oauth_state:'.$state, [
                 'user_id' => $user->id,
                 'code_verifier' => $authResult['code_verifier'],
             ], 600);
         } else {
             $authorizationUrl = $authResult;
-            Cache::put('mp_oauth_state:' . $state, ['user_id' => $user->id], 600);
+            Cache::put('mp_oauth_state:'.$state, ['user_id' => $user->id], 600);
         }
 
         return response()->json(['authorization_url' => $authorizationUrl]);
@@ -319,7 +335,7 @@ class UserController extends Controller
         $user = auth()->user();
 
         // Create a new delete account request
-        $deleteRequest = new DeleteAccountRequest();
+        $deleteRequest = new DeleteAccountRequest;
         $deleteRequest->user_id = $user->id;
         $deleteRequest->date_requested = now();
         $deleteRequest->action_taken = DeleteAccountRequest::ACTION_REQUESTED;
@@ -336,12 +352,12 @@ class UserController extends Controller
 
         \Log::info('Delete account request email queued successfully', [
             'user_id' => $user->id,
-            'admin_email' => $adminEmail
+            'admin_email' => $adminEmail,
         ]);
 
         return response()->json([
             'message' => 'Delete account request created successfully',
-            'request_id' => $deleteRequest->id
+            'request_id' => $deleteRequest->id,
         ], 201);
     }
 
@@ -366,7 +382,7 @@ class UserController extends Controller
             ], 422);
         }
 
-        if (!$hasTrips && !$hasRatings && !$hasReferences) {
+        if (! $hasTrips && ! $hasRatings && ! $hasReferences) {
             // Branch A: Delete user
             $userId = $user->id;
             $this->deviceLogic->logoutAllDevices($user);
@@ -377,7 +393,7 @@ class UserController extends Controller
                     JWTAuth::invalidate($token);
                 }
             } catch (\Exception $e) {
-                \Log::error('Failed to invalidate JWT after delete: ' . $e->getMessage());
+                \Log::error('Failed to invalidate JWT after delete: '.$e->getMessage());
             }
 
             \Log::info('User self-deletion: actual_delete', ['user_id' => $userId]);
@@ -397,7 +413,7 @@ class UserController extends Controller
                 JWTAuth::invalidate($token);
             }
         } catch (\Exception $e) {
-            \Log::error('Failed to invalidate JWT after anonymize: ' . $e->getMessage());
+            \Log::error('Failed to invalidate JWT after anonymize: '.$e->getMessage());
         }
 
         \Log::info('User self-deletion: anonymize', ['user_id' => $user->id]);

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -2,20 +2,21 @@
 
 namespace STS\Transformers;
 
-use STS\Models\User;
 use League\Fractal\TransformerAbstract;
+use STS\Helpers\IdentityValidationHelper;
+use STS\Models\User;
 use STS\Repository\TripRepository;
+use STS\Repository\UserRepository;
+use STS\Services\GeoService;
 use STS\Services\Logic\TripsManager;
 use STS\Services\Logic\UsersManager;
-use STS\Repository\UserRepository;
-use STS\Helpers\IdentityValidationHelper;
-use STS\Services\GeoService;
 use STS\Services\MapboxDirectionsRouteService;
 use STS\Services\MercadoPagoService;
 
 class ProfileTransformer extends TransformerAbstract
 {
     protected $user;
+
     protected $tripLogic;
 
     public function __construct($user)
@@ -57,15 +58,15 @@ class ProfileTransformer extends TransformerAbstract
             'banned' => intval($user->banned),
             'active' => intval($user->active),
             'monthly_donate' => $user->monthly_donate,
-            'do_not_alert_request_seat'       => intval($user->do_not_alert_request_seat),
-            'do_not_alert_accept_passenger'   => intval($user->do_not_alert_accept_passenger),
-            'do_not_alert_pending_rates'      => intval($user->do_not_alert_pending_rates),
-            'do_not_alert_pricing'      => intval($user->do_not_alert_pricing),
+            'do_not_alert_request_seat' => intval($user->do_not_alert_request_seat),
+            'do_not_alert_accept_passenger' => intval($user->do_not_alert_accept_passenger),
+            'do_not_alert_pending_rates' => intval($user->do_not_alert_pending_rates),
+            'do_not_alert_pricing' => intval($user->do_not_alert_pricing),
             'monthly_donate' => intval($user->monthly_donate),
-            'unaswered_messages_limit'    => intval($user->unaswered_messages_limit),
-            'autoaccept_requests'    => intval($user->autoaccept_requests),
-            'driver_is_verified'    => intval($user->driver_is_verified),
-            'driver_data_docs'      => $user->driver_data_docs ? json_decode($user->driver_data_docs) : null,
+            'unaswered_messages_limit' => intval($user->unaswered_messages_limit),
+            'autoaccept_requests' => intval($user->autoaccept_requests),
+            'driver_is_verified' => intval($user->driver_is_verified),
+            'driver_data_docs' => $user->driver_data_docs ? json_decode($user->driver_data_docs) : null,
             'references' => $user->references,
             'data_visibility' => $user->data_visibility,
             'references_data' => $user->referencesReceived,
@@ -76,6 +77,7 @@ class ProfileTransformer extends TransformerAbstract
         ];
 
         if ($this->user && $user->id == $this->user->id) {
+            // True when enforcement is active and this user must validate as a "new" user (created_at >= cutoff).
             $data['identity_validation_required_for_user'] = IdentityValidationHelper::isNewUserRequiringValidation($user);
             $data['validate_by_date'] = $user->validate_by_date ? $user->validate_by_date->format('Y-m-d') : null;
         }
@@ -92,16 +94,16 @@ class ProfileTransformer extends TransformerAbstract
             $data['account_type'] = $user->account_type;
             $data['account_bank'] = $user->account_bank;
             $data['on_boarding_view'] = $user->on_boarding_view;
-            
+
             // Always include car information for admins or the user themselves
             $data['cars'] = $user->cars;
             $data['patente'] = $user->cars->first() ? $user->cars->first()->patente : null;
             $data['car_description'] = $user->cars->first() ? $user->cars->first()->description : null;
         }
-        
+
         switch ($user->data_visibility) {
             case '0':
-                # viaja conmigo
+                // viaja conmigo
                 if ($this->user && $this->tripLogic->shareTrip($this->user, $user)) {
                     $data['nro_doc'] = $user->nro_doc;
                     $data['email'] = $user->email;
@@ -110,14 +112,14 @@ class ProfileTransformer extends TransformerAbstract
                 }
                 break;
             case '1':
-                # publico
+                // publico
                 $data['nro_doc'] = $user->nro_doc;
                 $data['email'] = $user->email;
                 $data['mobile_phone'] = $user->mobile_phone;
                 $data['cars'] = $user->cars;
                 break;
             default:
-                # privado
+                // privado
                 break;
         }
 

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -28,7 +28,7 @@ return [
     'module_validated_drivers' => env('MODULE_VALIDATED_DRIVERS', false),
     'module_trip_creation_payment_enabled' => env('MODULE_TRIP_CREATION_PAYMENT_ENABLED', false),
     'module_trip_creation_payment_amount_cents' => (int) env('MODULE_TRIP_CREATION_PAYMENT_AMOUNT_CENTS', 1500),
-    'module_trip_creation_payment_trips_threshold' => (int)env('MODULE_TRIP_CREATION_PAYMENT_TRIPS_THRESHOLD', 2),
+    'module_trip_creation_payment_trips_threshold' => (int) env('MODULE_TRIP_CREATION_PAYMENT_TRIPS_THRESHOLD', 2),
     // Frontend app base URL (e.g. for payment redirects, OAuth callbacks). Defaults to APP_URL.
     'frontend_url' => env('FRONTEND_URL', env('APP_URL', 'http://localhost:8080')),
 
@@ -45,13 +45,18 @@ return [
 
     'manual_identity_validation_cost_cents' => (int) env('MANUAL_IDENTITY_VALIDATION_COST_CENTS', 0),
 
+    // Master switch: when false, hide identity validation UI and do not enforce (except admin flows).
+    'identity_validation_enabled' => filter_var(env('IDENTITY_VALIDATION_ENABLED', false), FILTER_VALIDATE_BOOLEAN),
+    // When true (and enabled), show flows but do not block restricted actions
+    'identity_validation_optional' => filter_var(env('IDENTITY_VALIDATION_OPTIONAL', false), FILTER_VALIDATE_BOOLEAN),
     // Identity validation: enable/disable MP OAuth and manual validation (frontend shows only enabled options)
     'identity_validation_mercado_pago_enabled' => env('IDENTITY_VALIDATION_MERCADO_PAGO_ENABLED', false),
     'identity_validation_manual_enabled' => env('IDENTITY_VALIDATION_MANUAL_ENABLED', false),
-    // Require identity validation for new users (created on or after identity_validation_new_users_date) to send messages, request seats, accept/reject passengers, create trips
-    'identity_validation_required_new_users' => env('IDENTITY_VALIDATION_REQUIRED_NEW_USERS', false),
+    // New users: created_on_or_after this date (Y-m-d), see IDENTITY_VALIDATION_NEW_USERS_DATE.
     'identity_validation_new_users_date' => env('IDENTITY_VALIDATION_NEW_USERS_DATE', null),
-    // When set (positive integer), current users without validate_by_date get it set to now + N days on /users/me
+    // When enforcement is on: require "new" users (per cutoff) to validate before restricted actions
+    'identity_validation_required_new_users' => filter_var(env('IDENTITY_VALIDATION_REQUIRED_NEW_USERS', false), FILTER_VALIDATE_BOOLEAN),
+    // When set (positive integer), pre-cutoff users without validate_by_date get it on first /users/me only while enforcement is active (enabled and not optional)
     'identity_validation_days_for_current_users' => (int) env('IDENTITY_VALIDATION_DAYS_FOR_CURRENT_USERS', 0),
     // QR payment for manual validation (no physical device needed; see docs in config or README)
     'identity_validation_manual_qr_enabled' => env('IDENTITY_VALIDATION_MANUAL_QR_ENABLED', false),
@@ -74,16 +79,16 @@ return [
         'staff',
         'system',
         'robot',
-        'carpy'
+        'carpy',
     ],
 
     'banned_words_trip_description' => [
-        'carpy'
+        'carpy',
     ],
 
     // List of banned phone numbers that will trigger user ban if found in their profile or in trip descriptions
     'banned_phones' => [
-        '1151415054'
+        '1151415054',
     ],
 
     'trip_creation_limits' => [

--- a/database/migrations/2026_02_26_100000_add_validate_by_date_to_users_table.php
+++ b/database/migrations/2026_02_26_100000_add_validate_by_date_to_users_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
-     * validate_by_date: optional deadline for existing users to complete identity validation; null for new users (created after identity_validation_new_users_date).
+     * validate_by_date: optional deadline for pre-cutoff users to complete identity validation; null for new users (created on or after identity_validation_new_users_date).
      */
     public function up(): void
     {

--- a/tests/Feature/Http/ManualIdentityValidationApiTest.php
+++ b/tests/Feature/Http/ManualIdentityValidationApiTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature\Http;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\User;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ManualIdentityValidationApiTest extends TestCase
 {
@@ -17,7 +17,10 @@ class ManualIdentityValidationApiTest extends TestCase
     {
         parent::setUp();
         Storage::fake('local');
-        config(['carpoolear.identity_validation_manual_enabled' => true]);
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_manual_enabled' => true,
+        ]);
     }
 
     protected function createPaidValidationRequest(User $user): ManualIdentityValidation

--- a/tests/Feature/Http/UserMeValidateByDateTest.php
+++ b/tests/Feature/Http/UserMeValidateByDateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use STS\Models\User;
+use Tests\TestCase;
+
+class UserMeValidateByDateTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_sets_validate_by_for_pre_cutoff_user_on_first_me(): void
+    {
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_optional' => false,
+            'carpoolear.identity_validation_days_for_current_users' => 30,
+            'carpoolear.identity_validation_new_users_date' => '2025-06-01',
+        ]);
+
+        $user = User::factory()->create([
+            'identity_validated' => false,
+            'validate_by_date' => null,
+        ]);
+        DB::table('users')->where('id', $user->id)->update(['created_at' => '2020-01-01 00:00:00']);
+        $user->refresh();
+
+        $this->actingAs($user, 'api');
+        $response = $this->get('api/users/me');
+        $response->assertStatus(200);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertNotNull($data['data']['validate_by_date'] ?? null);
+
+        $user->refresh();
+        $this->assertNotNull($user->validate_by_date);
+    }
+
+    public function test_does_not_set_validate_by_for_new_user_after_cutoff(): void
+    {
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_optional' => false,
+            'carpoolear.identity_validation_days_for_current_users' => 30,
+            'carpoolear.identity_validation_new_users_date' => '2020-01-01',
+        ]);
+
+        $user = User::factory()->create([
+            'identity_validated' => false,
+            'validate_by_date' => null,
+        ]);
+        DB::table('users')->where('id', $user->id)->update(['created_at' => '2025-06-15 00:00:00']);
+        $user->refresh();
+
+        $this->actingAs($user, 'api');
+        $response = $this->get('api/users/me');
+        $response->assertStatus(200);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertNull($data['data']['validate_by_date'] ?? null);
+
+        $user->refresh();
+        $this->assertNull($user->validate_by_date);
+    }
+
+    public function test_does_not_set_validate_by_when_optional_even_for_pre_cutoff_user(): void
+    {
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_optional' => true,
+            'carpoolear.identity_validation_days_for_current_users' => 30,
+            'carpoolear.identity_validation_new_users_date' => '2025-06-01',
+        ]);
+
+        $user = User::factory()->create([
+            'identity_validated' => false,
+            'validate_by_date' => null,
+        ]);
+        DB::table('users')->where('id', $user->id)->update(['created_at' => '2020-01-01 00:00:00']);
+        $user->refresh();
+
+        $this->actingAs($user, 'api');
+        $response = $this->get('api/users/me');
+        $response->assertStatus(200);
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertNull($data['data']['validate_by_date'] ?? null);
+
+        $user->refresh();
+        $this->assertNull($user->validate_by_date);
+    }
+}

--- a/tests/Unit/IdentityValidationHelperTest.php
+++ b/tests/Unit/IdentityValidationHelperTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use STS\Helpers\IdentityValidationHelper;
+use STS\Models\User;
+use Tests\TestCase;
+
+class IdentityValidationHelperTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_when_optional_enforcement_is_off_all_unvalidated_users_can_act(): void
+    {
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_optional' => true,
+        ]);
+
+        $user = User::factory()->create(['identity_validated' => false, 'validate_by_date' => null]);
+
+        $this->assertTrue(IdentityValidationHelper::canPerformRestrictedActions($user));
+    }
+
+    public function test_new_user_is_blocked_when_enforced_and_required_flag_on(): void
+    {
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_optional' => false,
+            'carpoolear.identity_validation_required_new_users' => true,
+            'carpoolear.identity_validation_new_users_date' => '2020-01-01',
+        ]);
+
+        $user = User::factory()->create(['identity_validated' => false, 'validate_by_date' => null]);
+        DB::table('users')->where('id', $user->id)->update(['created_at' => '2021-06-15 00:00:00']);
+        $user->refresh();
+
+        $this->assertTrue(IdentityValidationHelper::isUserCreatedOnOrAfterCutoff($user));
+        $this->assertTrue(IdentityValidationHelper::isNewUserRequiringValidation($user));
+        $this->assertFalse(IdentityValidationHelper::canPerformRestrictedActions($user));
+    }
+
+    public function test_pre_cutoff_user_with_past_validate_by_is_blocked(): void
+    {
+        config([
+            'carpoolear.identity_validation_enabled' => true,
+            'carpoolear.identity_validation_optional' => false,
+            'carpoolear.identity_validation_required_new_users' => true,
+            'carpoolear.identity_validation_new_users_date' => '2020-01-01',
+        ]);
+
+        $user = User::factory()->create([
+            'identity_validated' => false,
+            'validate_by_date' => Carbon::now()->subDays(2)->toDateString(),
+        ]);
+        DB::table('users')->where('id', $user->id)->update(['created_at' => '2019-06-15 00:00:00']);
+        $user->refresh();
+
+        $this->assertFalse(IdentityValidationHelper::isUserCreatedOnOrAfterCutoff($user));
+        $this->assertFalse(IdentityValidationHelper::isNewUserRequiringValidation($user));
+        $this->assertTrue(IdentityValidationHelper::isCurrentUserPastDeadline($user));
+        $this->assertFalse(IdentityValidationHelper::canPerformRestrictedActions($user));
+    }
+
+    public function test_is_user_created_on_or_after_cutoff_respects_date(): void
+    {
+        config(['carpoolear.identity_validation_new_users_date' => '2024-01-01']);
+
+        $old = User::factory()->create();
+        DB::table('users')->where('id', $old->id)->update(['created_at' => '2020-01-01 00:00:00']);
+        $old->refresh();
+
+        $new = User::factory()->create();
+        DB::table('users')->where('id', $new->id)->update(['created_at' => '2024-02-01 00:00:00']);
+        $new->refresh();
+
+        $this->assertFalse(IdentityValidationHelper::isUserCreatedOnOrAfterCutoff($old));
+        $this->assertTrue(IdentityValidationHelper::isUserCreatedOnOrAfterCutoff($new));
+    }
+}


### PR DESCRIPTION
- Add IDENTITY_VALIDATION_ENABLED and IDENTITY_VALIDATION_OPTIONAL. 
- Use IDENTITY_VALIDATION_NEW_USERS_DATE for new-user cohort. 
- Enforce restricted actions only when enabled and not optional; block new users and pre-date users past validate_by_date. 
- Set validate_by_date on first /users/me only for pre-cutoff users when enforcement is active (not during optional period). 
- Gate Mercado Pago OAuth and manual identity APIs on the feature flag. 
- Add unit and feature tests.