### PR TITLE
Fix conversation issue

### DIFF
--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -36,19 +36,30 @@ class Trip extends Model
     const PRIVACY_FOF = 1;
 
     const STATE_AWAITING_PAYMENT = 'awaiting_payment';
+
     const STATE_PENDING_PAYMENT = 'pending_payment';
+
     const STATE_PAID = 'paid';
+
     const STATE_PAYMENT_FAILED = 'payment_failed';
+
     const STATE_READY = 'ready';
+
     const STATE_CANCELED = 'canceled';
 
     // Weekly schedule bitmask constants
     const DAY_MONDAY = 1;
+
     const DAY_TUESDAY = 2;
+
     const DAY_WEDNESDAY = 4;
+
     const DAY_THURSDAY = 8;
+
     const DAY_FRIDAY = 16;
+
     const DAY_SATURDAY = 32;
+
     const DAY_SUNDAY = 64;
 
     protected $table = 'trips';
@@ -81,7 +92,7 @@ class Trip extends Model
         'allow_animals',
         'state',
         'payment_id',
-        'needs_sellado'
+        'needs_sellado',
     ];
 
     protected $hidden = [
@@ -92,7 +103,7 @@ class Trip extends Model
         'passenger_count',
         'seats_available',
         'is_driver',
-    ]; 
+    ];
 
     protected function casts(): array
     {
@@ -106,9 +117,9 @@ class Trip extends Model
             'deleted_at' => 'datetime',
             'seat_price_cents' => 'integer',
             'recommended_trip_price_cents' => 'integer',
-            'state' => 'string'
+            'state' => 'string',
         ];
-    } 
+    }
 
     public function parentTrip()
     {
@@ -120,7 +131,7 @@ class Trip extends Model
         return $this->belongsTo('STS\Models\User', 'user_id');
     }
 
-    public function userVisibility ()
+    public function userVisibility()
     {
         return $this->hasMany('STS\Models\TripVisibility', 'trip_id');
     }
@@ -135,7 +146,8 @@ class Trip extends Model
         return $this->hasMany('STS\Models\Passenger', 'trip_id')->with('user');
     }
 
-    public function routes () {
+    public function routes()
+    {
         return $this->belongsToMany('STS\Models\Route', 'trip_routes', 'trip_id', 'route_id');
     }
 
@@ -147,8 +159,8 @@ class Trip extends Model
     public function passengerPending()
     {
         return $this->passenger()->whereIn('request_state', [
-            Passenger::STATE_PENDING, 
-            Passenger::STATE_WAITING_PAYMENT
+            Passenger::STATE_PENDING,
+            Passenger::STATE_WAITING_PAYMENT,
         ]);
     }
 
@@ -164,7 +176,7 @@ class Trip extends Model
 
     public function ratings()
     {
-        return $this->hasMany('STS\Models\Rating', 'trip_id')->with(['from','to']);
+        return $this->hasMany('STS\Models\Rating', 'trip_id')->with(['from', 'to']);
     }
 
     public function outbound()
@@ -177,9 +189,14 @@ class Trip extends Model
         return $this->belongsTo('STS\Models\Trip', 'return_trip_id');
     }
 
+    /**
+     * Official trip group thread only. Private DMs can share the same trip_id;
+     * they must not be returned here (see addUserConversation / removeUserConversation).
+     */
     public function conversation()
     {
-        return $this->hasOne('STS\Models\Conversation', 'trip_id');
+        return $this->hasOne(Conversation::class, 'trip_id')
+            ->where('type', Conversation::TYPE_TRIP_CONVERSATION);
     }
 
     public function payments()
@@ -214,7 +231,7 @@ class Trip extends Model
 
     public function setDescriptionAttribute($value)
     {
-        $this->attributes['description'] = $value; //htmlentities($value);
+        $this->attributes['description'] = $value; // htmlentities($value);
     }
 
     public function isAwaitingPayment()
@@ -240,24 +257,28 @@ class Trip extends Model
     public function setStateAwaitingPayment()
     {
         $this->state = self::STATE_AWAITING_PAYMENT;
+
         return $this;
     }
 
     public function setStatePaymentFailed()
     {
         $this->state = self::STATE_PAYMENT_FAILED;
+
         return $this;
     }
 
     public function setStateReady()
     {
         $this->state = self::STATE_READY;
+
         return $this;
     }
 
     public function setStateCanceled()
     {
         $this->state = self::STATE_CANCELED;
+
         return $this;
     }
 
@@ -271,6 +292,7 @@ class Trip extends Model
         if ($this->trip_date === null) {
             return false;
         }
+
         return $this->trip_date->lt(Carbon::now());
     }
 

--- a/app/Repository/ConversationRepository.php
+++ b/app/Repository/ConversationRepository.php
@@ -2,9 +2,9 @@
 
 namespace STS\Repository;
 
-use STS\Models\User;
-use STS\Models\Trip;
 use STS\Models\Conversation;
+use STS\Models\Trip;
+use STS\Models\User;
 
 class ConversationRepository
 {
@@ -35,7 +35,7 @@ class ConversationRepository
         return make_pagination($userConversations, $pageNumber, $pageSize);
     }
 
-    public function getConversationFromId($conversation_id, User $user = null)
+    public function getConversationFromId($conversation_id, ?User $user = null)
     {
         $conversation = Conversation::where('id', $conversation_id)->first();
         if ($conversation == null) {
@@ -50,14 +50,17 @@ class ConversationRepository
         return $conversation;
     }
 
-    public function getConversationByTripId($tripId, User $user = null)
+    public function getConversationByTripId($tripId, ?User $user = null)
     {
-        $conversation = Conversation::where('trip_id', $tripId)->first();
-        if ($user) {
-            $conversation->users()->where('id', $user->id);
+        $query = Conversation::query()
+            ->where('trip_id', $tripId)
+            ->where('type', Conversation::TYPE_TRIP_CONVERSATION);
+
+        if ($user !== null) {
+            $query->whereHas('users', fn ($q) => $q->whereKey($user->id));
         }
 
-        return $conversation->first();
+        return $query->orderByDesc('id')->first();
     }
 
     public function getConversationsByTrip($trip)
@@ -95,26 +98,27 @@ class ConversationRepository
 
         \Log::info('estamos aca');
         /*
-        
+
         select * from `conversations` where exists (
-            select * from `users` inner join `conversations_users` on `users`.`id` = `conversations_users`.`user_id` where `conversations_users`.`conversation_id` = `conversations`.`id` and `id` = '228229') 
-            
+            select * from `users` inner join `conversations_users` on `users`.`id` = `conversations_users`.`user_id` where `conversations_users`.`conversation_id` = `conversations`.`id` and `id` = '228229')
+
             and exists (select * from `users` inner join `conversations_users` on `users`.`id` = `conversations_users`.`user_id` where `conversations_users`.`conversation_id` = `conversations`.`id` and `id` = '215497')
 
         and `type` = '0' and `conversations`.`deleted_at` is null limit 1
         */
-        
+
         $query = Conversation::query();
         // leftJoin('t1 as staff_table', 'staff_table.id','=','t2.s_id')
         $query->join('conversations_users as c1', 'conversations.id', '=', 'c1.conversation_id');
         $query->join('conversations_users as c2', 'conversations.id', '=', 'c2.conversation_id');
-    
+
         $query->where('c1.user_id', $user1ID);
         $query->where('c2.user_id', $user2ID);
-    
+
         $query->where('conversations.type', Conversation::TYPE_PRIVATE_CONVERSATION);
         $query->whereNull('conversations.deleted_at');
         $query->select('conversations.*');
+
         return $query->first();
     }
 
@@ -130,24 +134,25 @@ class ConversationRepository
         return $u->pivot->read;
     }
 
-    public function updateTripId (Conversation $conversation, $tripId)
+    public function updateTripId(Conversation $conversation, $tripId)
     {
         $conversation->trip_id = $tripId;
         $conversation->save();
+
         return $conversation;
     }
 
     public function userList($user, $who = null, $search_text = null)
     {
         $userConversations = $user->conversations()->has('messages')
-        ->orderBy('updated_at', 'desc')
-        ->with('users');
+            ->orderBy('updated_at', 'desc')
+            ->with('users');
 
         $conversations = $userConversations->get();
 
         $users = [];
-        foreach ($conversations as  $conversation) {
-            foreach ($conversation->users as  $userc) {
+        foreach ($conversations as $conversation) {
+            foreach ($conversation->users as $userc) {
                 if ($userc->id !== $user->id) {
                     if (preg_match("/$search_text/i", $userc->name)) {
                         $users[] = $userc;


### PR DESCRIPTION
Fix trip conversation resolution when private DMs share trip_id.Scope Trip::conversation() to TYPE_TRIP_CONVERSATION so passenger accept/cancel listeners attach users to the group thread only. Rewrite getConversationByTripId to query the same type and fix the broken user filter / return logic.