### PR TITLE
Verificación: tweaks

### DIFF
--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -2,10 +2,10 @@
 
 namespace STS\Http\Controllers\Api\Admin;
 
-use STS\Http\Controllers\Controller;
-use STS\Models\MercadoPagoRejectedValidation;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\MercadoPagoRejectedValidation;
 
 class MercadoPagoRejectedValidationController extends Controller
 {
@@ -57,6 +57,7 @@ class MercadoPagoRejectedValidationController extends Controller
                 'approved_by_name' => $item->approvedBy ? $item->approvedBy->name : null,
                 'review_status' => $item->review_status,
                 'review_note' => $item->review_note,
+                'private_admin_note' => $item->private_admin_note,
                 'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
                 'reviewed_by' => $item->reviewed_by,
                 'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
@@ -77,7 +78,7 @@ class MercadoPagoRejectedValidationController extends Controller
 
         $item = MercadoPagoRejectedValidation::with('user')->findOrFail($id);
         $user = $item->user;
-        if (!$user) {
+        if (! $user) {
             return response()->json(['error' => 'User not found.'], 404);
         }
 
@@ -123,6 +124,7 @@ class MercadoPagoRejectedValidationController extends Controller
             'approved_by_name' => $item->approvedBy ? $item->approvedBy->name : null,
             'review_status' => $item->review_status,
             'review_note' => $item->review_note,
+            'private_admin_note' => $item->private_admin_note,
             'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
             'reviewed_by' => $item->reviewed_by,
             'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
@@ -131,12 +133,26 @@ class MercadoPagoRejectedValidationController extends Controller
         return response()->json(['data' => $data]);
     }
 
+    public function updatePrivateNote(Request $request, int $id): JsonResponse
+    {
+        $validated = $request->validate([
+            'private_admin_note' => 'nullable|string',
+        ]);
+
+        $item = MercadoPagoRejectedValidation::findOrFail($id);
+        $item->private_admin_note = $validated['private_admin_note'] ?? null;
+        $item->save();
+
+        return $this->show($id);
+    }
+
     /**
      * POST /api/admin/mercado-pago-rejected-validations/{id}/approve - validate the user manually (legacy shortcut; use review with action=approve).
      */
     public function approve(Request $request, int $id): JsonResponse
     {
         $request->merge(['action' => 'approve', 'note' => '']);
+
         return $this->review($request, $id);
     }
 }

--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -42,26 +42,7 @@ class MercadoPagoRejectedValidationController extends Controller
             ->findOrFail($id);
 
         return response()->json([
-            'data' => [
-                'id' => $item->id,
-                'user_id' => $item->user_id,
-                'user_name' => $item->user ? $item->user->name : null,
-                'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
-                'user_email' => $item->user ? $item->user->email : null,
-                'user_identity_validated' => $item->user ? (bool) $item->user->identity_validated : false,
-                'reject_reason' => $item->reject_reason,
-                'created_at' => $item->created_at->toDateTimeString(),
-                'mp_payload' => $item->mp_payload,
-                'approved_at' => $item->approved_at ? $item->approved_at->toDateTimeString() : null,
-                'approved_by' => $item->approved_by,
-                'approved_by_name' => $item->approvedBy ? $item->approvedBy->name : null,
-                'review_status' => $item->review_status,
-                'review_note' => $item->review_note,
-                'private_admin_note' => $item->private_admin_note,
-                'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
-                'reviewed_by' => $item->reviewed_by,
-                'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
-            ],
+            'data' => $this->serializeItem($item),
         ]);
     }
 
@@ -109,28 +90,7 @@ class MercadoPagoRejectedValidationController extends Controller
         $item->save();
         $item->load(['user:id,name,nro_doc,email,identity_validated', 'approvedBy:id,name', 'reviewedBy:id,name']);
 
-        $data = [
-            'id' => $item->id,
-            'user_id' => $item->user_id,
-            'user_name' => $item->user ? $item->user->name : null,
-            'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
-            'user_email' => $item->user ? $item->user->email : null,
-            'user_identity_validated' => $item->user ? (bool) $item->user->identity_validated : false,
-            'reject_reason' => $item->reject_reason,
-            'created_at' => $item->created_at->toDateTimeString(),
-            'mp_payload' => $item->mp_payload,
-            'approved_at' => $item->approved_at ? $item->approved_at->toDateTimeString() : null,
-            'approved_by' => $item->approved_by,
-            'approved_by_name' => $item->approvedBy ? $item->approvedBy->name : null,
-            'review_status' => $item->review_status,
-            'review_note' => $item->review_note,
-            'private_admin_note' => $item->private_admin_note,
-            'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
-            'reviewed_by' => $item->reviewed_by,
-            'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
-        ];
-
-        return response()->json(['data' => $data]);
+        return response()->json(['data' => $this->serializeItem($item)]);
     }
 
     public function updatePrivateNote(Request $request, int $id): JsonResponse
@@ -154,5 +114,29 @@ class MercadoPagoRejectedValidationController extends Controller
         $request->merge(['action' => 'approve', 'note' => '']);
 
         return $this->review($request, $id);
+    }
+
+    private function serializeItem(MercadoPagoRejectedValidation $item): array
+    {
+        return [
+            'id' => $item->id,
+            'user_id' => $item->user_id,
+            'user_name' => $item->user ? $item->user->name : null,
+            'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
+            'user_email' => $item->user ? $item->user->email : null,
+            'user_identity_validated' => $item->user ? (bool) $item->user->identity_validated : false,
+            'reject_reason' => $item->reject_reason,
+            'created_at' => $item->created_at->toDateTimeString(),
+            'mp_payload' => $item->mp_payload,
+            'approved_at' => $item->approved_at ? $item->approved_at->toDateTimeString() : null,
+            'approved_by' => $item->approved_by,
+            'approved_by_name' => $item->approvedBy ? $item->approvedBy->name : null,
+            'review_status' => $item->review_status,
+            'review_note' => $item->review_note,
+            'private_admin_note' => $item->private_admin_note,
+            'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
+            'reviewed_by' => $item->reviewed_by,
+            'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
+        ];
     }
 }

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -13,6 +13,17 @@ use STS\Services\SupportTicketService;
 
 class SupportTicketController extends Controller
 {
+    private static function typeDefaultPriorities(): array
+    {
+        return [
+            'report' => 'high',
+            'bug_report' => 'normal',
+            'contact' => 'normal',
+            'feedback' => 'low',
+            'account_verification' => 'high',
+        ];
+    }
+
     public function __construct(private readonly SupportTicketService $supportTicketService) {}
 
     public function index(): JsonResponse
@@ -45,7 +56,7 @@ class SupportTicketController extends Controller
                 'type' => $validated['type'],
                 'subject' => $validated['subject'],
                 'status' => 'Open',
-                'priority' => $validated['type'] === 'account_verification' ? 'high' : 'normal',
+                'priority' => self::typeDefaultPriorities()[$validated['type']] ?? 'normal',
                 'unread_for_user' => 1,
                 'unread_for_admin' => 0,
                 'created_by' => $admin->id,

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -29,6 +29,53 @@ class SupportTicketController extends Controller
         return response()->json(['data' => $ticket]);
     }
 
+    public function create(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'user_id' => 'required|integer|exists:users,id',
+            'type' => 'required|in:bug_report,contact,feedback,report,account_verification',
+            'subject' => 'required|string|min:3|max:160',
+            'message_markdown' => 'required|string|min:1',
+        ]);
+
+        $admin = auth()->user();
+        $ticket = DB::transaction(function () use ($validated, $admin) {
+            $ticket = SupportTicket::create([
+                'user_id' => (int) $validated['user_id'],
+                'type' => $validated['type'],
+                'subject' => $validated['subject'],
+                'status' => 'Open',
+                'priority' => $validated['type'] === 'account_verification' ? 'high' : 'normal',
+                'unread_for_user' => 1,
+                'unread_for_admin' => 0,
+                'created_by' => $admin->id,
+                'updated_by' => $admin->id,
+                'last_reply_at' => now(),
+            ]);
+
+            SupportTicketReply::create([
+                'ticket_id' => $ticket->id,
+                'user_id' => $admin->id,
+                'is_admin' => true,
+                'message_markdown' => $validated['message_markdown'],
+                'created_by' => $admin->id,
+            ]);
+
+            return $ticket->fresh();
+        });
+
+        $notification = new SupportTicketReplyNotification;
+        $notification->setAttribute('ticket', $ticket);
+        $notification->setAttribute('from', $admin);
+        try {
+            $notification->notify($ticket->user);
+        } catch (\Throwable $e) {
+            report($e);
+        }
+
+        return response()->json(['data' => $ticket]);
+    }
+
     public function reply(int $id, Request $request): JsonResponse
     {
         $validated = $request->validate([

--- a/app/Http/Controllers/Api/v1/MercadoPagoOAuthController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoOAuthController.php
@@ -2,12 +2,12 @@
 
 namespace STS\Http\Controllers\Api\v1;
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use STS\Http\Controllers\Controller;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\User;
 use STS\Services\MercadoPagoOAuthService;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 
 class MercadoPagoOAuthController extends Controller
 {
@@ -26,20 +26,23 @@ class MercadoPagoOAuthController extends Controller
 
         if ($error) {
             \Log::warning('MercadoPago OAuth callback: MP error param', ['error' => $error]);
+
             return redirect($oauthService->getFrontendRedirectUrl('error'));
         }
 
-        if (!$code || !$state) {
-            \Log::warning('MercadoPago OAuth callback: missing code or state', ['has_code' => !empty($code), 'has_state' => !empty($state)]);
+        if (! $code || ! $state) {
+            \Log::warning('MercadoPago OAuth callback: missing code or state', ['has_code' => ! empty($code), 'has_state' => ! empty($state)]);
+
             return redirect($oauthService->getFrontendRedirectUrl('error'));
         }
 
-        $cacheKey = 'mp_oauth_state:' . $state;
+        $cacheKey = 'mp_oauth_state:'.$state;
         $cached = Cache::get($cacheKey);
         Cache::forget($cacheKey);
 
-        if (!$cached || !isset($cached['user_id'])) {
+        if (! $cached || ! isset($cached['user_id'])) {
             \Log::warning('MercadoPago OAuth callback: invalid or expired state', ['state' => $state]);
+
             return redirect($oauthService->getFrontendRedirectUrl('error'));
         }
 
@@ -47,66 +50,73 @@ class MercadoPagoOAuthController extends Controller
         $codeVerifier = $cached['code_verifier'] ?? null;
         $user = User::find($userId);
 
-        if (!$user) {
+        if (! $user) {
             \Log::warning('MercadoPago OAuth callback: user not found', ['user_id' => $userId]);
+
             return redirect($oauthService->getFrontendRedirectUrl('error'));
         }
 
         try {
             $tokenResponse = $oauthService->exchangeCodeForToken($code, $codeVerifier);
             $accessToken = $tokenResponse['access_token'] ?? null;
-            if (!$accessToken) {
+            if (! $accessToken) {
                 \Log::warning('MercadoPago OAuth callback: no access_token in token response', ['user_id' => $userId]);
+
                 return redirect($oauthService->getFrontendRedirectUrl('error'));
             }
 
             $me = $oauthService->getUserMe($accessToken);
             \Log::info('MercadoPago OAuth users/me response', ['user_id' => $userId, 'me' => $me]);
 
-            // Name comparison: our user name must include MP first_name and last_name (avoids false positives when user omits middle name)
-            if (!MercadoPagoOAuthService::nameMatches($me, $user->name ?? '')) {
-                $user->identity_validated = false;
-                $user->identity_validated_at = null;
-                $user->identity_validation_type = null;
-                $user->identity_validation_rejected_at = now();
-                $user->identity_validation_reject_reason = 'name_mismatch';
-                $user->save();
-                MercadoPagoRejectedValidation::create([
-                    'user_id' => $user->id,
-                    'reject_reason' => 'name_mismatch',
-                    'mp_payload' => MercadoPagoOAuthService::filterMePayloadForStorage($me),
-                ]);
-                \Log::info('MercadoPago OAuth callback: name mismatch', ['user_id' => $userId]);
-                return redirect($oauthService->getFrontendRedirectUrl('name_mismatch'));
-            }
+            $userName = trim((string) ($user->name ?? ''));
+            $mpName = trim((string) (($me['first_name'] ?? '').' '.($me['last_name'] ?? '')));
+            $nameMismatch = ! MercadoPagoOAuthService::nameMatches($me, $userName);
 
             $identification = $me['identification'] ?? null;
-            if (!$identification || !isset($identification['number'])) {
+            if (! $identification || ! isset($identification['number'])) {
                 \Log::warning('MercadoPago OAuth callback: no identification in users/me', ['user_id' => $userId]);
+
                 return redirect($oauthService->getFrontendRedirectUrl('error'));
             }
 
             $mpDni = MercadoPagoOAuthService::extractDniForComparison($identification);
             $userDni = MercadoPagoOAuthService::normalizeDni($user->nro_doc);
+            $dniMismatch = $userDni === '' || $mpDni === '' || $mpDni !== $userDni;
 
-            if ($userDni === '' || $mpDni === '' || $mpDni !== $userDni) {
+            if ($nameMismatch || $dniMismatch) {
+                $rejectReason = $nameMismatch && $dniMismatch
+                    ? 'both_mismatch'
+                    : ($nameMismatch ? 'name_mismatch' : 'dni_mismatch');
                 $user->identity_validated = false;
                 $user->identity_validated_at = null;
                 $user->identity_validation_type = null;
                 $user->identity_validation_rejected_at = now();
-                $user->identity_validation_reject_reason = 'dni_mismatch';
+                $user->identity_validation_reject_reason = $rejectReason;
                 $user->save();
                 MercadoPagoRejectedValidation::create([
                     'user_id' => $user->id,
-                    'reject_reason' => 'dni_mismatch',
+                    'reject_reason' => $rejectReason,
                     'mp_payload' => MercadoPagoOAuthService::filterMePayloadForStorage($me),
                 ]);
-                \Log::info('MercadoPago OAuth callback: DNI mismatch', [
+                \Log::info('MercadoPago OAuth callback: mismatch', [
                     'user_id' => $userId,
+                    'reject_reason' => $rejectReason,
+                    'user_name' => $userName,
+                    'mp_name' => $mpName,
                     'user_dni_normalized' => $userDni,
                     'mp_dni_normalized' => $mpDni,
                 ]);
-                return redirect($oauthService->getFrontendRedirectUrl('dni_mismatch'));
+                $details = [];
+                if ($nameMismatch) {
+                    $details['user_name'] = $userName;
+                    $details['mp_name'] = $mpName;
+                }
+                if ($dniMismatch) {
+                    $details['user_dni'] = $userDni;
+                    $details['mp_dni'] = $mpDni;
+                }
+
+                return redirect($oauthService->getFrontendRedirectUrl($rejectReason, $details));
             }
 
             $user->identity_validated = true;
@@ -116,9 +126,11 @@ class MercadoPagoOAuthController extends Controller
             $user->identity_validation_reject_reason = null;
             $user->save();
             \Log::info('MercadoPago OAuth callback: success', ['user_id' => $userId]);
+
             return redirect($oauthService->getFrontendRedirectUrl('success'));
         } catch (\Exception $e) {
             \Log::error('MercadoPago OAuth callback exception', ['message' => $e->getMessage()]);
+
             return redirect($oauthService->getFrontendRedirectUrl('error'));
         }
     }

--- a/app/Http/Controllers/Api/v1/MercadoPagoOAuthController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoOAuthController.php
@@ -84,9 +84,7 @@ class MercadoPagoOAuthController extends Controller
             $dniMismatch = $userDni === '' || $mpDni === '' || $mpDni !== $userDni;
 
             if ($nameMismatch || $dniMismatch) {
-                $rejectReason = $nameMismatch && $dniMismatch
-                    ? 'both_mismatch'
-                    : ($nameMismatch ? 'name_mismatch' : 'dni_mismatch');
+                $rejectReason = $this->resolveRejectReason($nameMismatch, $dniMismatch);
                 $user->identity_validated = false;
                 $user->identity_validated_at = null;
                 $user->identity_validation_type = null;
@@ -106,15 +104,14 @@ class MercadoPagoOAuthController extends Controller
                     'user_dni_normalized' => $userDni,
                     'mp_dni_normalized' => $mpDni,
                 ]);
-                $details = [];
-                if ($nameMismatch) {
-                    $details['user_name'] = $userName;
-                    $details['mp_name'] = $mpName;
-                }
-                if ($dniMismatch) {
-                    $details['user_dni'] = $userDni;
-                    $details['mp_dni'] = $mpDni;
-                }
+                $details = $this->buildMismatchRedirectDetails(
+                    $nameMismatch,
+                    $dniMismatch,
+                    $userName,
+                    $mpName,
+                    $userDni,
+                    $mpDni
+                );
 
                 return redirect($oauthService->getFrontendRedirectUrl($rejectReason, $details));
             }
@@ -133,5 +130,38 @@ class MercadoPagoOAuthController extends Controller
 
             return redirect($oauthService->getFrontendRedirectUrl('error'));
         }
+    }
+
+    private function resolveRejectReason(bool $nameMismatch, bool $dniMismatch): string
+    {
+        if ($nameMismatch && $dniMismatch) {
+            return 'both_mismatch';
+        }
+        if ($nameMismatch) {
+            return 'name_mismatch';
+        }
+
+        return 'dni_mismatch';
+    }
+
+    private function buildMismatchRedirectDetails(
+        bool $nameMismatch,
+        bool $dniMismatch,
+        string $userName,
+        string $mpName,
+        string $userDni,
+        string $mpDni
+    ): array {
+        $details = [];
+        if ($nameMismatch) {
+            $details['user_name'] = $userName;
+            $details['mp_name'] = $mpName;
+        }
+        if ($dniMismatch) {
+            $details['user_dni'] = $userDni;
+            $details['mp_dni'] = $mpDni;
+        }
+
+        return $details;
     }
 }

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -19,6 +19,7 @@ class SupportTicketController extends Controller
             'bug_report' => 'normal',
             'contact' => 'normal',
             'feedback' => 'low',
+            'account_verification' => 'high',
         ];
     }
 
@@ -51,7 +52,7 @@ class SupportTicketController extends Controller
     public function create(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'type' => 'required|in:bug_report,contact,feedback,report',
+            'type' => 'required|in:bug_report,contact,feedback,report,account_verification',
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',

--- a/app/Models/MercadoPagoRejectedValidation.php
+++ b/app/Models/MercadoPagoRejectedValidation.php
@@ -17,6 +17,7 @@ class MercadoPagoRejectedValidation extends Model
         'approved_by',
         'review_status',
         'review_note',
+        'private_admin_note',
         'reviewed_at',
         'reviewed_by',
     ];

--- a/app/Notifications/SupportTicketReplyNotification.php
+++ b/app/Notifications/SupportTicketReplyNotification.php
@@ -34,7 +34,7 @@ class SupportTicketReplyNotification extends BaseNotification
 
         return [
             'message' => 'Tenes una nueva respuesta de Carpoolear',
-            'url' => '/tickets/'.($ticket ? $ticket->id : ''),
+            'url' => '/soporte/'.($ticket ? $ticket->id : ''),
             'type' => 'ticket',
             'extras' => [
                 'id' => $ticket ? $ticket->id : null,

--- a/app/Services/MercadoPagoOAuthService.php
+++ b/app/Services/MercadoPagoOAuthService.php
@@ -302,10 +302,12 @@ class MercadoPagoOAuthService
     }
 
     /**
-     * Build frontend redirect URL with result query param.
+     * Build frontend redirect URL with result and optional details.
      */
-    public function getFrontendRedirectUrl(string $result): string
+    public function getFrontendRedirectUrl(string $result, array $details = []): string
     {
-        return $this->frontendRedirectBase.'/setting/identity-validation?result='.urlencode($result);
+        $query = array_merge(['result' => $result], $details);
+
+        return $this->frontendRedirectBase.'/setting/identity-validation?'.http_build_query($query);
     }
 }

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -35,7 +35,9 @@ class SupportTicketService
 
     public function applyUserReplyTransition(SupportTicket $ticket, int $actorUserId): void
     {
-        $ticket->status = 'Esperando respuesta';
+        if (! in_array($ticket->status, ['Resuelto', 'Cerrado'], true)) {
+            $ticket->status = 'En revision';
+        }
         $ticket->unread_for_admin++;
         $ticket->unread_for_user = 0;
         $ticket->last_reply_at = now();
@@ -44,8 +46,8 @@ class SupportTicketService
 
     public function applyAdminReplyTransition(SupportTicket $ticket, int $actorUserId): void
     {
-        if (in_array($ticket->status, ['Open', 'Esperando respuesta'], true)) {
-            $ticket->status = 'En revision';
+        if (in_array($ticket->status, ['Open', 'Esperando respuesta', 'En revision'], true)) {
+            $ticket->status = 'Esperando respuesta';
         }
         $ticket->unread_for_user++;
         $ticket->unread_for_admin = 0;

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -10,6 +10,15 @@ use STS\Models\SupportTicketAttachment;
 
 class SupportTicketService
 {
+    /** Statuses where neither party may add replies via normal flows. */
+    private const TERMINAL_USER_REPLY_STATUSES = ['Resuelto', 'Cerrado'];
+
+    /**
+     * Open conversation states: after an admin reply we wait on the ticket owner.
+     * {@see applyAdminReplyTransition}
+     */
+    private const ADMIN_REPLY_SETS_WAITING_FOR_USER = ['Open', 'Esperando respuesta', 'En revision'];
+
     public function storeReplyAttachments(array $files, int $userId, int $replyId): void
     {
         foreach ($files as $file) {
@@ -33,9 +42,10 @@ class SupportTicketService
         }
     }
 
+    /** Marks unread for admins and moves active tickets to pending team review. */
     public function applyUserReplyTransition(SupportTicket $ticket, int $actorUserId): void
     {
-        if (! in_array($ticket->status, ['Resuelto', 'Cerrado'], true)) {
+        if (! in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true)) {
             $ticket->status = 'En revision';
         }
         $ticket->unread_for_admin++;
@@ -44,9 +54,10 @@ class SupportTicketService
         $ticket->updated_by = $actorUserId;
     }
 
+    /** Bumps unread for the ticket owner and sets waiting-for-user when applicable. */
     public function applyAdminReplyTransition(SupportTicket $ticket, int $actorUserId): void
     {
-        if (in_array($ticket->status, ['Open', 'Esperando respuesta', 'En revision'], true)) {
+        if (in_array($ticket->status, self::ADMIN_REPLY_SETS_WAITING_FOR_USER, true)) {
             $ticket->status = 'Esperando respuesta';
         }
         $ticket->unread_for_user++;

--- a/database/migrations/2026_05_06_130000_add_private_admin_note_to_mercado_pago_rejected_validations.php
+++ b/database/migrations/2026_05_06_130000_add_private_admin_note_to_mercado_pago_rejected_validations.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mercado_pago_rejected_validations', function (Blueprint $table) {
+            $table->text('private_admin_note')->nullable()->after('review_note');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mercado_pago_rejected_validations', function (Blueprint $table) {
+            $table->dropColumn('private_admin_note');
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,13 +21,14 @@
     </source>
     <php>
         <ini name="memory_limit" value="1024M"/>
-        <env name="APP_ENV" value="testing"/>
+        <!-- force=true: shell/IDE must not inherit DB_DATABASE from .env and wipe the wrong schema -->
+        <env name="APP_ENV" value="testing" force="true"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
         <!-- MySQL required (migrations use stored procedures). Host/credentials from .env. Default schema `testing`; override from the shell for a second concurrent run (separate flock file + schema), e.g. DB_DATABASE=testing1 ./vendor/bin/pest … -->
-        <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_DATABASE" value="testing" force="false"/>
+        <env name="DB_CONNECTION" value="mysql" force="true"/>
+        <env name="DB_DATABASE" value="testing" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -236,6 +236,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('mercado-pago-rejected-validations/{id}/approve', [AdminMercadoPagoRejectedValidationController::class, 'approve']);
 
         Route::get('support/tickets', [AdminSupportTicketController::class, 'index']);
+        Route::post('support/tickets', [AdminSupportTicketController::class, 'create']);
         Route::get('support/tickets/{id}', [AdminSupportTicketController::class, 'show']);
         Route::post('support/tickets/{id}/replies', [AdminSupportTicketController::class, 'reply'])->middleware('throttle:support-ticket-admin-reply');
         Route::match(['patch', 'put'], 'support/tickets/{id}/status', [AdminSupportTicketController::class, 'updateStatus']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -232,6 +232,7 @@ Route::middleware(['api'])->group(function () {
         Route::get('mercado-pago-rejected-validations', [AdminMercadoPagoRejectedValidationController::class, 'index']);
         Route::get('mercado-pago-rejected-validations/{id}', [AdminMercadoPagoRejectedValidationController::class, 'show']);
         Route::post('mercado-pago-rejected-validations/{id}/review', [AdminMercadoPagoRejectedValidationController::class, 'review']);
+        Route::post('mercado-pago-rejected-validations/{id}/private-note', [AdminMercadoPagoRejectedValidationController::class, 'updatePrivateNote']);
         Route::post('mercado-pago-rejected-validations/{id}/approve', [AdminMercadoPagoRejectedValidationController::class, 'approve']);
 
         Route::get('support/tickets', [AdminSupportTicketController::class, 'index']);

--- a/tests/Feature/Http/AdminMercadoPagoRejectedValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminMercadoPagoRejectedValidationControllerIntegrationTest.php
@@ -90,6 +90,7 @@ class AdminMercadoPagoRejectedValidationControllerIntegrationTest extends TestCa
         $this->assertNull($data['reviewed_at']);
         $this->assertNull($data['reviewed_by']);
         $this->assertNull($data['reviewed_by_name']);
+        $this->assertNull($data['private_admin_note']);
         $this->assertFalse($data['user_identity_validated']);
 
         $approved = $this->postJson('api/admin/mercado-pago-rejected-validations/'.$row->id.'/review', [
@@ -302,5 +303,26 @@ class AdminMercadoPagoRejectedValidationControllerIntegrationTest extends TestCa
             ->assertJsonPath('data.review_status', 'approved');
 
         $this->assertTrue($user->fresh()->identity_validated);
+    }
+
+    public function test_private_note_can_be_updated_by_admin_and_returned_in_show(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'dni_mismatch',
+            'mp_payload' => [],
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/mercado-pago-rejected-validations/'.$row->id.'/private-note', [
+            'private_admin_note' => 'Contacto por telefono, revisar en 48hs.',
+        ])->assertOk()->assertJsonPath('data.private_admin_note', 'Contacto por telefono, revisar en 48hs.');
+
+        $show = $this->getJson('api/admin/mercado-pago-rejected-validations/'.$row->id)->assertOk();
+        $this->assertSame('Contacto por telefono, revisar en 48hs.', $show->json('data.private_admin_note'));
     }
 }

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -181,7 +181,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
 
         $this->assertSame(['data'], array_keys($response->json()));
         $this->assertSame($ticket->id, $response->json('data.id'));
-        $this->assertSame('En revision', $response->json('data.status'));
+        $this->assertSame('Esperando respuesta', $response->json('data.status'));
 
         $this->assertDatabaseHas('support_ticket_replies', [
             'ticket_id' => $ticket->id,
@@ -215,7 +215,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         ])->assertOk();
 
         $this->assertSame(['data'], array_keys($response->json()));
-        $this->assertSame('En revision', $response->json('data.status'));
+        $this->assertSame('Esperando respuesta', $response->json('data.status'));
         $this->assertDatabaseHas('support_ticket_replies', [
             'ticket_id' => $ticket->id,
             'user_id' => $admin->id,

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -305,6 +305,45 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertNull($ticket->fresh()->internal_note_markdown);
     }
 
+    public function test_admin_can_create_account_verification_ticket_for_user_with_high_priority(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/support/tickets', [
+            'user_id' => $owner->id,
+            'type' => 'account_verification',
+            'subject' => 'Verificacion de cuenta',
+            'message_markdown' => 'Te pedimos actualizar tu documentacion.',
+        ])->assertOk();
+
+        $this->assertSame($owner->id, (int) $response->json('data.user_id'));
+        $this->assertSame('account_verification', $response->json('data.type'));
+        $this->assertSame('high', $response->json('data.priority'));
+        $this->assertSame(1, (int) $response->json('data.unread_for_user'));
+        $this->assertSame(0, (int) $response->json('data.unread_for_admin'));
+
+        $this->assertDatabaseHas('support_tickets', [
+            'user_id' => $owner->id,
+            'type' => 'account_verification',
+            'subject' => 'Verificacion de cuenta',
+            'priority' => 'high',
+            'created_by' => $admin->id,
+        ]);
+
+        $ticketId = (int) $response->json('data.id');
+        $this->assertDatabaseHas('support_ticket_replies', [
+            'ticket_id' => $ticketId,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Te pedimos actualizar tu documentacion.',
+            'created_by' => $admin->id,
+        ]);
+    }
+
     public function test_resolve_with_message_creates_admin_reply(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
+++ b/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
@@ -290,7 +290,10 @@ class MercadoPagoOAuthCallbackTest extends TestCase
         ]);
 
         $this->get('/api/mercadopago/oauth/callback?code=auth-code&state=name-empty-state')
-            ->assertRedirect($this->identityRedirect('name_mismatch'));
+            ->assertRedirect($this->identityRedirectWith('name_mismatch', [
+                'user_name' => '',
+                'mp_name' => 'Jane Doe',
+            ]));
     }
 
     public function test_redirects_dni_mismatch_and_records_rejection(): void

--- a/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
+++ b/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
@@ -265,8 +265,9 @@ class MercadoPagoOAuthCallbackTest extends TestCase
         })->once();
 
         Log::shouldHaveReceived('info')->withArgs(function (...$args) use ($user): bool {
-            return ($args[0] ?? null) === 'MercadoPago OAuth callback: name mismatch'
-                && (int) ($args[1]['user_id'] ?? 0) === $user->id;
+            return ($args[0] ?? null) === 'MercadoPago OAuth callback: mismatch'
+                && (int) ($args[1]['user_id'] ?? 0) === $user->id
+                && ($args[1]['reject_reason'] ?? null) === 'name_mismatch';
         })->once();
     }
 
@@ -328,8 +329,9 @@ class MercadoPagoOAuthCallbackTest extends TestCase
         ]);
 
         Log::shouldHaveReceived('info')->withArgs(function (...$args) use ($user): bool {
-            return ($args[0] ?? null) === 'MercadoPago OAuth callback: DNI mismatch'
+            return ($args[0] ?? null) === 'MercadoPago OAuth callback: mismatch'
                 && (int) ($args[1]['user_id'] ?? 0) === $user->id
+                && ($args[1]['reject_reason'] ?? null) === 'dni_mismatch'
                 && ($args[1]['user_dni_normalized'] ?? null) === '30123456'
                 && ($args[1]['mp_dni_normalized'] ?? null) === '30999999';
         })->once();

--- a/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
+++ b/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
@@ -35,6 +35,13 @@ class MercadoPagoOAuthCallbackTest extends TestCase
         return 'https://app.example/setting/identity-validation?result='.urlencode($result);
     }
 
+    private function identityRedirectWith(string $result, array $params): string
+    {
+        $query = array_merge(['result' => $result], $params);
+
+        return 'https://app.example/setting/identity-validation?'.http_build_query($query);
+    }
+
     public function test_redirects_to_error_when_mp_error_query_is_present(): void
     {
         Log::spy();
@@ -237,7 +244,10 @@ class MercadoPagoOAuthCallbackTest extends TestCase
         Log::spy();
 
         $this->get('/api/mercadopago/oauth/callback?code=auth-code&state=name-state')
-            ->assertRedirect($this->identityRedirect('name_mismatch'));
+            ->assertRedirect($this->identityRedirectWith('name_mismatch', [
+                'user_name' => 'Jane Doe',
+                'mp_name' => 'Other Person',
+            ]));
 
         $user->refresh();
         $this->assertFalse($user->identity_validated);
@@ -303,7 +313,10 @@ class MercadoPagoOAuthCallbackTest extends TestCase
         Log::spy();
 
         $this->get('/api/mercadopago/oauth/callback?code=auth-code&state=dni-state')
-            ->assertRedirect($this->identityRedirect('dni_mismatch'));
+            ->assertRedirect($this->identityRedirectWith('dni_mismatch', [
+                'user_dni' => '30123456',
+                'mp_dni' => '30999999',
+            ]));
 
         $user->refresh();
         $this->assertFalse($user->identity_validated);
@@ -379,5 +392,32 @@ class MercadoPagoOAuthCallbackTest extends TestCase
             ->assertRedirect($this->identityRedirect('success'));
 
         $this->assertTrue($user->fresh()->identity_validated);
+    }
+
+    public function test_redirects_both_mismatch_when_name_and_dni_do_not_match(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Jane Doe',
+            'nro_doc' => '30123456',
+            'identity_validated' => false,
+        ]);
+        Cache::put('mp_oauth_state:both-state', ['user_id' => $user->id], 600);
+
+        Http::fake([
+            '*oauth/token*' => Http::response(['access_token' => 'tok'], 200),
+            '*users/me*' => Http::response([
+                'first_name' => 'Other',
+                'last_name' => 'Person',
+                'identification' => ['type' => 'DNI', 'number' => '30999999'],
+            ], 200),
+        ]);
+
+        $this->get('/api/mercadopago/oauth/callback?code=auth-code&state=both-state')
+            ->assertRedirect($this->identityRedirectWith('both_mismatch', [
+                'user_name' => 'Jane Doe',
+                'mp_name' => 'Other Person',
+                'user_dni' => '30123456',
+                'mp_dni' => '30999999',
+            ]));
     }
 }

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -504,6 +504,23 @@ class SupportTicketApiTest extends TestCase
         $contactTicket->assertJsonPath('data.priority', 'normal');
     }
 
+    public function test_account_verification_type_is_allowed_and_forced_to_high_priority(): void
+    {
+        $user = $this->createUser();
+        $this->actingAs($user, 'api');
+
+        $ticket = $this->post('api/support/tickets', [
+            'type' => 'account_verification',
+            'subject' => 'Validacion de identidad',
+            'message_markdown' => 'Necesito ayuda con mi verificacion.',
+            'priority' => 'low',
+        ]);
+
+        $ticket->assertStatus(200);
+        $ticket->assertJsonPath('data.type', 'account_verification');
+        $ticket->assertJsonPath('data.priority', 'high');
+    }
+
     private function createUser(bool $isAdmin = false): User
     {
         return User::query()->create([

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -135,7 +135,7 @@ class SupportTicketApiTest extends TestCase
             'message_markdown' => 'We are reviewing it.',
         ]);
         $adminReply->assertStatus(200);
-        $adminReply->assertJsonPath('data.status', 'En revision');
+        $adminReply->assertJsonPath('data.status', 'Esperando respuesta');
         $adminReply->assertJsonPath('data.unread_for_user', 1);
         $adminReply->assertJsonPath('data.unread_for_admin', 0);
     }
@@ -410,7 +410,7 @@ class SupportTicketApiTest extends TestCase
         $replyIds = SupportTicketReply::query()->where('ticket_id', $ticketId)->pluck('id');
         $this->assertGreaterThan(0, SupportTicketAttachment::query()->whereIn('reply_id', $replyIds)->count());
 
-        $this->assertSame('Esperando respuesta', SupportTicket::query()->findOrFail($ticketId)->status);
+        $this->assertSame('En revision', SupportTicket::query()->findOrFail($ticketId)->status);
     }
 
     public function test_close_without_message_does_not_add_second_reply(): void

--- a/tests/Unit/Notifications/SupportTicketReplyNotificationTest.php
+++ b/tests/Unit/Notifications/SupportTicketReplyNotificationTest.php
@@ -45,13 +45,13 @@ class SupportTicketReplyNotificationTest extends TestCase
 
         $pushWithTicket = $withTicket->toPush(null, null);
         $this->assertSame('Tenes una nueva respuesta de Carpoolear', $pushWithTicket['message']);
-        $this->assertSame('/tickets/987', $pushWithTicket['url']);
+        $this->assertSame('/soporte/987', $pushWithTicket['url']);
         $this->assertSame('ticket', $pushWithTicket['type']);
         $this->assertSame(987, $pushWithTicket['extras']['id']);
         $this->assertSame('https://carpoolear.com.ar/app/static/img/carpoolear_logo.png', $pushWithTicket['image']);
 
         $pushWithoutTicket = $notification->toPush(null, null);
-        $this->assertSame('/tickets/', $pushWithoutTicket['url']);
+        $this->assertSame('/soporte/', $pushWithoutTicket['url']);
         $this->assertNull($pushWithoutTicket['extras']['id']);
         $this->assertSame('https://carpoolear.com.ar/app/static/img/carpoolear_logo.png', $pushWithoutTicket['image']);
     }

--- a/tests/Unit/Repository/RatingRepositoryTest.php
+++ b/tests/Unit/Repository/RatingRepositoryTest.php
@@ -13,12 +13,26 @@ use Tests\TestCase;
 
 class RatingRepositoryTest extends TestCase
 {
+    private static bool $availablesRatingsViewPrepared = false;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         // `getRatingsCount` queries `availables_ratings`, which is not shipped in repo migrations (production view).
-        DB::statement('CREATE OR REPLACE VIEW availables_ratings AS SELECT id, user_id_to, rating FROM rating WHERE available = 1');
+        // Create once per process, and recreate only if a database refresh dropped it.
+        if (! self::$availablesRatingsViewPrepared || ! $this->hasAvailablesRatingsView()) {
+            DB::statement('CREATE OR REPLACE VIEW availables_ratings AS SELECT id, user_id_to, rating FROM rating WHERE available = 1');
+            self::$availablesRatingsViewPrepared = true;
+        }
+    }
+
+    private function hasAvailablesRatingsView(): bool
+    {
+        return DB::table('information_schema.VIEWS')
+            ->where('TABLE_SCHEMA', DB::getDatabaseName())
+            ->where('TABLE_NAME', 'availables_ratings')
+            ->exists();
     }
 
     /**

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -160,14 +160,14 @@ class SupportTicketServiceTest extends TestCase
         $service = new SupportTicketService;
         $service->applyAdminReplyTransition($ticket, 99);
 
-        $this->assertSame('En revision', $ticket->status);
+        $this->assertSame('Esperando respuesta', $ticket->status);
         $this->assertSame(1, $ticket->unread_for_user);
         $this->assertSame(0, $ticket->unread_for_admin);
         $this->assertSame(99, (int) $ticket->updated_by);
         $this->assertNotNull($ticket->last_reply_at);
     }
 
-    public function test_apply_admin_reply_transition_from_waiting_status_sets_en_revision(): void
+    public function test_apply_admin_reply_transition_when_waiting_for_user_stays_esperando_respuesta(): void
     {
         $ticket = new SupportTicket([
             'status' => 'Esperando respuesta',
@@ -178,7 +178,7 @@ class SupportTicketServiceTest extends TestCase
         $service = new SupportTicketService;
         $service->applyAdminReplyTransition($ticket, 22);
 
-        $this->assertSame('En revision', $ticket->status);
+        $this->assertSame('Esperando respuesta', $ticket->status);
         $this->assertSame(3, $ticket->unread_for_user);
         $this->assertSame(0, $ticket->unread_for_admin);
         $this->assertSame(22, (int) $ticket->updated_by);
@@ -203,7 +203,7 @@ class SupportTicketServiceTest extends TestCase
         $this->assertNotNull($ticket->last_reply_at);
     }
 
-    public function test_apply_user_reply_transition_sets_waiting_status_and_admin_unread(): void
+    public function test_apply_user_reply_transition_sets_en_revision_and_admin_unread(): void
     {
         $ticket = new SupportTicket([
             'status' => 'En revision',
@@ -214,14 +214,14 @@ class SupportTicketServiceTest extends TestCase
         $service = new SupportTicketService;
         $service->applyUserReplyTransition($ticket, 77);
 
-        $this->assertSame('Esperando respuesta', $ticket->status);
+        $this->assertSame('En revision', $ticket->status);
         $this->assertSame(2, $ticket->unread_for_admin);
         $this->assertSame(0, $ticket->unread_for_user);
         $this->assertSame(77, (int) $ticket->updated_by);
         $this->assertNotNull($ticket->last_reply_at);
     }
 
-    public function test_apply_user_reply_transition_from_open_still_sets_waiting_status(): void
+    public function test_apply_user_reply_transition_from_open_sets_en_revision(): void
     {
         $ticket = new SupportTicket([
             'status' => 'Open',
@@ -232,7 +232,7 @@ class SupportTicketServiceTest extends TestCase
         $service = new SupportTicketService;
         $service->applyUserReplyTransition($ticket, 101);
 
-        $this->assertSame('Esperando respuesta', $ticket->status);
+        $this->assertSame('En revision', $ticket->status);
         $this->assertSame(1, $ticket->unread_for_admin);
         $this->assertSame(0, $ticket->unread_for_user);
         $this->assertSame(101, (int) $ticket->updated_by);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,8 +9,9 @@ declare(strict_types=1);
 |
 | Loads Composer autoload and ensures the MySQL schema named by DB_DATABASE exists.
 | Without this, the first PDO connection to DB_DATABASE can fail with "Unknown database".
-| PHPUnit’s phpunit.xml sets a default DB_DATABASE (`testing`) unless the variable is
-| already set in the environment (force=false). Prefix commands with DB_DATABASE=testing1
+| PHPUnit’s phpunit.xml forces DB_DATABASE=`testing` (force=true) so a developer shell
+| or IDE cannot inherit DB_DATABASE from `.env` and accidentally DROP the app schema.
+| Prefix commands with DB_DATABASE=testing1
 | (or any safe identifier) to run a second suite/mutate in parallel without blocking on
 | the same phpunit-mysql-*.lock file as another process using `testing`.
 | Dotenv loads .env / .env.testing so host, username, and password match local MySQL
@@ -74,6 +75,13 @@ if ($dbDriver !== 'mysql' || $dbName === '' || $dbName === ':memory:') {
 
 if (! preg_match('/^[a-zA-Z0-9_-]+$/', $dbName)) {
     fwrite(STDERR, "tests/bootstrap: refusing unsafe DB_DATABASE identifier.\n");
+
+    exit(1);
+}
+
+// Never DROP a schema that is not clearly dedicated to automated tests (blocks .env names like `carpoolear`).
+if (! preg_match('/^testing[a-zA-Z0-9_-]*$/', $dbName)) {
+    fwrite(STDERR, 'tests/bootstrap: refusing DROP/CREATE on `'.$dbName.'`: DB_DATABASE must match /^testing[a-zA-Z0-9_-]*$/ so app databases from .env are never wiped.'.PHP_EOL);
 
     exit(1);
 }


### PR DESCRIPTION
- Adds admin-driven account verification support tickets (priority + deep links)
- Fixes support-ticket reply states so “Esperando respuesta” applies after admin replies
- Improves Mercado Pago identity mismatch handling (redirect details + combined mismatch) plus private admin notes on MP rejections
- Hardens PHPUnit DB safety and trims redundant rating view setup in tests.