### PR TITLE
Migrate users from admin

### DIFF
--- a/app/Http/Controllers/Api/Admin/UserController.php
+++ b/app/Http/Controllers/Api/Admin/UserController.php
@@ -15,6 +15,7 @@ use STS\Models\User;
 use STS\Services\AnonymizationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\UserDeletionService;
+use STS\Support\UserSearchFilter;
 use STS\Transformers\ProfileTransformer;
 
 class UserController extends Controller
@@ -54,12 +55,7 @@ class UserController extends Controller
         $query = User::query();
 
         if ($name) {
-            $query->where(function ($q) use ($name) {
-                $q->where('name', 'like', '%'.$name.'%')
-                    ->orWhere('email', 'like', '%'.$name.'%')
-                    ->orWhere('nro_doc', 'like', '%'.$name.'%')
-                    ->orWhere('mobile_phone', 'like', '%'.$name.'%');
-            });
+            UserSearchFilter::apply($query, $name);
         }
 
         $query->orderBy($sort, $direction);

--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use STS\Http\Controllers\Controller;
+use STS\Models\UserMigration;
+
+class UserMigrationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = min(max((int) $request->get('per_page', 20), 1), 100);
+
+        $paginator = UserMigration::query()
+            ->with(['admin:id,name'])
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->paginate($perPage);
+
+        $items = collect($paginator->items())->map(function (UserMigration $m) {
+            return [
+                'id' => $m->id,
+                'admin_user_id' => $m->admin_user_id,
+                'admin' => $m->admin ? [
+                    'id' => $m->admin->id,
+                    'name' => $m->admin->name,
+                ] : null,
+                'user_id_kept' => $m->user_id_kept,
+                'user_id_removed' => $m->user_id_removed,
+                'created_at' => $m->created_at?->toAtomString(),
+            ];
+        })->values()->all();
+
+        return response()->json([
+            'data' => $items,
+            'meta' => [
+                'pagination' => [
+                    'current_page' => $paginator->currentPage(),
+                    'per_page' => $paginator->perPage(),
+                    'total' => $paginator->total(),
+                    'total_pages' => $paginator->lastPage(),
+                ],
+            ],
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'user_id_kept' => 'required|integer|exists:users,id',
+            'user_id_removed' => 'required|integer|exists:users,id|different:user_id_kept',
+        ]);
+
+        $keptId = (int) $validated['user_id_kept'];
+        $removedId = (int) $validated['user_id_removed'];
+
+        Artisan::call('user:update', [
+            'original' => (string) $removedId,
+            'new' => (string) $keptId,
+        ]);
+
+        $row = UserMigration::query()->create([
+            'admin_user_id' => (int) $request->user()->id,
+            'user_id_kept' => $keptId,
+            'user_id_removed' => $removedId,
+        ]);
+
+        $row->load('admin:id,name');
+
+        return response()->json([
+            'data' => [
+                'id' => $row->id,
+                'admin_user_id' => $row->admin_user_id,
+                'admin' => $row->admin ? [
+                    'id' => $row->admin->id,
+                    'name' => $row->admin->name,
+                ] : null,
+                'user_id_kept' => $row->user_id_kept,
+                'user_id_removed' => $row->user_id_removed,
+                'created_at' => $row->created_at?->toAtomString(),
+            ],
+        ]);
+    }
+}

--- a/app/Models/UserMigration.php
+++ b/app/Models/UserMigration.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserMigration extends Model
+{
+    protected $table = 'user_migrations';
+
+    protected $fillable = [
+        'admin_user_id',
+        'user_id_kept',
+        'user_id_removed',
+    ];
+
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_user_id');
+    }
+}

--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -7,6 +7,7 @@ use DB;
 use STS\Models\Conversation;
 use STS\Models\Passenger;
 use STS\Models\User;
+use STS\Support\UserSearchFilter;
 
 class UserRepository
 {
@@ -78,15 +79,16 @@ class UserRepository
 
     public function searchUsers($name)
     {
-
-        if ($name) {
-            $users = User::where('name', 'like', '%'.$name.'%');
-            $users->orWhere('email', 'like', '%'.$name.'%');
-            $users->orWhere('nro_doc', 'like', '%'.$name.'%');
-            $users->orWhere('mobile_phone', 'like', '%'.$name.'%');
-        } else {
+        if (! is_string($name)) {
             return null;
         }
+        $term = trim($name);
+        if ($term === '') {
+            return null;
+        }
+
+        $users = User::query();
+        UserSearchFilter::apply($users, $term);
         $users->with(['accounts', 'cars']);
         $users->orderBy('name');
         $users->limit(9);

--- a/app/Support/UserSearchFilter.php
+++ b/app/Support/UserSearchFilter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace STS\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Branched user search for admin list and /api/users/search:
+ * - Numeric-only term: id (as string), nro_doc, mobile_phone — LIKE.
+ * - Otherwise: name, email, nro_doc — LIKE (mobile_phone excluded).
+ */
+final class UserSearchFilter
+{
+    public static function apply(Builder $query, string $term): void
+    {
+        $term = trim($term);
+        if ($term === '') {
+            return;
+        }
+
+        $like = '%'.$term.'%';
+
+        if (ctype_digit($term)) {
+            $query->where(function (Builder $q) use ($like) {
+                $q->whereRaw('CAST(id AS CHAR) LIKE ?', [$like])
+                    ->orWhere('nro_doc', 'like', $like)
+                    ->orWhere('mobile_phone', 'like', $like);
+            });
+        } else {
+            $query->where(function (Builder $q) use ($like) {
+                $q->where('name', 'like', $like)
+                    ->orWhere('email', 'like', $like)
+                    ->orWhere('nro_doc', 'like', $like);
+            });
+        }
+    }
+}

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -94,6 +94,9 @@ class ProfileTransformer extends TransformerAbstract
             $data['email'] = $user->email;
             $data['mobile_phone'] = $user->mobile_phone;
             $data['nro_doc'] = $user->nro_doc;
+            $data['created_at'] = $user->created_at instanceof Carbon
+                ? $user->created_at->toDateTimeString()
+                : null;
             // bank data
             $data['account_number'] = $user->account_number;
             $data['account_type'] = $user->account_type;

--- a/database/migrations/2026_05_07_160000_create_user_migrations_table.php
+++ b/database/migrations/2026_05_07_160000_create_user_migrations_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_migrations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('admin_user_id');
+            $table->unsignedInteger('user_id_kept');
+            $table->unsignedInteger('user_id_removed');
+            $table->timestamps();
+
+            $table->index('admin_user_id');
+            $table->index('user_id_kept');
+            $table->index('user_id_removed');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_migrations');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use STS\Http\Controllers\Api\Admin\MercadoPagoRejectedValidationController as Ad
 use STS\Http\Controllers\Api\Admin\SupportReplyTemplateController as AdminSupportReplyTemplateController;
 use STS\Http\Controllers\Api\Admin\SupportTicketController as AdminSupportTicketController;
 use STS\Http\Controllers\Api\Admin\UserController as AdminUserController;
+use STS\Http\Controllers\Api\Admin\UserMigrationController as AdminUserMigrationController;
 use STS\Http\Controllers\Api\v1\AuthController;
 use STS\Http\Controllers\Api\v1\CampaignController as ApiCampaignController;
 use STS\Http\Controllers\Api\v1\CampaignRewardController as ApiCampaignRewardController;
@@ -214,6 +215,8 @@ Route::middleware(['api'])->group(function () {
         // Car management routes
         Route::apiResource('cars', AdminCarController::class);
         Route::get('users', [AdminUserController::class, 'index']);
+        Route::get('user-migrations', [AdminUserMigrationController::class, 'index']);
+        Route::post('user-migrations', [AdminUserMigrationController::class, 'store']);
         Route::get('users/account-delete-list', [AdminUserController::class, 'accountDeleteList']);
         Route::post('users/account-delete-update', [AdminUserController::class, 'accountDeleteUpdate']);
         Route::get('banned-users', [AdminUserController::class, 'bannedUsersList']);

--- a/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Models\UserMigration;
+use Tests\TestCase;
+
+class AdminUserMigrationControllerIntegrationTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_index_returns_user_migrations_newest_first_with_admin(): void
+    {
+        $admin = $this->admin();
+        $u1 = User::factory()->create();
+        $u2 = User::factory()->create();
+        $u3 = User::factory()->create();
+        $u4 = User::factory()->create();
+
+        UserMigration::query()->create([
+            'admin_user_id' => $admin->id,
+            'user_id_kept' => $u1->id,
+            'user_id_removed' => $u2->id,
+        ]);
+        UserMigration::query()->create([
+            'admin_user_id' => $admin->id,
+            'user_id_kept' => $u3->id,
+            'user_id_removed' => $u4->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/user-migrations?per_page=10');
+        $response->assertOk();
+
+        $data = $response->json('data');
+        $this->assertIsArray($data);
+        $this->assertGreaterThanOrEqual(2, count($data));
+        $first = $data[0];
+        $this->assertArrayHasKey('id', $first);
+        $this->assertArrayHasKey('user_id_kept', $first);
+        $this->assertArrayHasKey('user_id_removed', $first);
+        $this->assertArrayHasKey('admin', $first);
+        $this->assertSame($admin->id, $first['admin']['id']);
+        $newest = UserMigration::query()->orderByDesc('id')->first();
+        $this->assertSame($newest->user_id_kept, (int) $first['user_id_kept']);
+    }
+
+    public function test_store_rejects_when_kept_and_removed_are_equal(): void
+    {
+        $admin = $this->admin();
+        $u = User::factory()->create();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $u->id,
+            'user_id_removed' => $u->id,
+        ])->assertUnprocessable();
+    }
+
+    public function test_store_rejects_when_user_does_not_exist(): void
+    {
+        $admin = $this->admin();
+        $u = User::factory()->create();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $u->id,
+            'user_id_removed' => 999_999_998,
+        ])->assertUnprocessable();
+    }
+
+    public function test_store_runs_user_update_artisan_and_persists_migration_row(): void
+    {
+        $admin = $this->admin();
+        $kept = User::factory()->create();
+        $removed = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.user_id_kept', $kept->id);
+        $response->assertJsonPath('data.user_id_removed', $removed->id);
+
+        $this->assertSame($kept->id, (int) $trip->fresh()->user_id);
+
+        $this->assertDatabaseHas('user_migrations', [
+            'admin_user_id' => $admin->id,
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+    }
+}

--- a/tests/Unit/Models/UserMigrationTest.php
+++ b/tests/Unit/Models/UserMigrationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use STS\Models\User;
+use STS\Models\UserMigration;
+use Tests\TestCase;
+
+class UserMigrationTest extends TestCase
+{
+    public function test_persists_admin_kept_and_removed_user_ids(): void
+    {
+        $admin = User::factory()->create();
+        $kept = User::factory()->create();
+        $removed = User::factory()->create();
+
+        $row = UserMigration::query()->create([
+            'admin_user_id' => $admin->id,
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $row = $row->fresh();
+        $this->assertSame($admin->id, (int) $row->admin_user_id);
+        $this->assertSame($kept->id, (int) $row->user_id_kept);
+        $this->assertSame($removed->id, (int) $row->user_id_removed);
+    }
+
+    public function test_admin_relation_loads_admin_user(): void
+    {
+        $admin = User::factory()->create(['name' => 'Admin Person']);
+        $kept = User::factory()->create();
+        $removed = User::factory()->create();
+
+        $row = UserMigration::query()->create([
+            'admin_user_id' => $admin->id,
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $row->load('admin');
+        $this->assertNotNull($row->admin);
+        $this->assertSame('Admin Person', $row->admin->name);
+    }
+
+    public function test_table_name_is_user_migrations(): void
+    {
+        $this->assertSame('user_migrations', (new UserMigration)->getTable());
+    }
+}

--- a/tests/Unit/Repository/UserRepositoryTest.php
+++ b/tests/Unit/Repository/UserRepositoryTest.php
@@ -221,6 +221,7 @@ class UserRepositoryTest extends TestCase
     {
         $this->assertNull($this->repo()->searchUsers(null));
         $this->assertNull($this->repo()->searchUsers(''));
+        $this->assertNull($this->repo()->searchUsers('   '));
 
         $needle = 'SearchNeedleXy'.substr(uniqid('', true), 0, 8);
         User::factory()->count(10)->create(['name' => $needle.' Person']);
@@ -234,9 +235,13 @@ class UserRepositoryTest extends TestCase
         $uByName = User::factory()->create(['name' => 'AlphaNeedleName']);
         $uByEmail = User::factory()->create(['email' => 'needle-email-777@example.com']);
         $uByDoc = User::factory()->create(['nro_doc' => 'DOC-NEEDLE-777']);
-        $uByPhone = User::factory()->create(['mobile_phone' => '+54911-NEEDLE-777']);
+        $phoneDigits = '998877'.str_pad((string) random_int(0, 999999), 6, '0', STR_PAD_LEFT);
+        $uByPhone = User::factory()->create([
+            'mobile_phone' => '+54911-'.$phoneDigits,
+            'nro_doc' => '10000002',
+        ]);
 
-        // Mutation intent: preserve each OR where in searchUsers(name/email/nro_doc/mobile_phone).
+        // Alpha branch: name, email, nro_doc (not mobile_phone).
         $byName = $this->repo()->searchUsers('NeedleName');
         $this->assertCount(1, $byName);
         $this->assertSame($uByName->id, $byName->first()->id);
@@ -249,8 +254,64 @@ class UserRepositoryTest extends TestCase
         $this->assertCount(1, $byDoc);
         $this->assertSame($uByDoc->id, $byDoc->first()->id);
 
-        $byPhone = $this->repo()->searchUsers('NEEDLE-777');
+        // Numeric branch: mobile_phone only (digit-only term).
+        $byPhone = $this->repo()->searchUsers($phoneDigits);
         $this->assertTrue($byPhone->pluck('id')->contains($uByPhone->id));
+    }
+
+    public function test_search_users_numeric_term_matches_user_id_fragment(): void
+    {
+        $u = User::factory()->create(['name' => 'UnrelatedNameForIdSearch']);
+        $idStr = (string) $u->id;
+
+        $rows = $this->repo()->searchUsers($idStr);
+
+        $this->assertTrue($rows->pluck('id')->contains($u->id));
+    }
+
+    public function test_search_users_numeric_term_does_not_match_email_only_substring(): void
+    {
+        $digits = '884422'.str_pad((string) random_int(100000, 999999), 6, '0', STR_PAD_LEFT);
+        User::factory()->create([
+            'name' => 'EmailOnlyNumeric',
+            'email' => 'zzz'.$digits.'@only-in-email.example.com',
+            'nro_doc' => '11111111',
+            'mobile_phone' => '0000000000',
+        ]);
+
+        $rows = $this->repo()->searchUsers($digits);
+
+        $this->assertCount(0, $rows);
+    }
+
+    public function test_search_users_alpha_term_matches_name_email_and_nro_doc(): void
+    {
+        $t = 'tok'.substr(preg_replace('/\D/', '', uniqid('', true)), 0, 5);
+        $uName = User::factory()->create(['name' => 'P'.$t.'N']);
+        $uEmail = User::factory()->create(['email' => $t.'@ma.example.com']);
+        $uDoc = User::factory()->create(['nro_doc' => 'X'.$t.'Y']);
+
+        $rows = $this->repo()->searchUsers($t);
+        $ids = $rows->pluck('id');
+
+        $this->assertTrue($ids->contains($uName->id));
+        $this->assertTrue($ids->contains($uEmail->id));
+        $this->assertTrue($ids->contains($uDoc->id));
+    }
+
+    public function test_search_users_alpha_term_does_not_match_mobile_phone_only(): void
+    {
+        $t = 'onlyMobTok'.substr(uniqid('', true), 0, 10);
+        User::factory()->create([
+            'name' => 'PlainJane',
+            'email' => 'pj-'.uniqid('', true).'@example.com',
+            'nro_doc' => '22222222',
+            'mobile_phone' => '+54911_'.$t.'_99',
+        ]);
+
+        $rows = $this->repo()->searchUsers($t);
+
+        $this->assertCount(0, $rows);
     }
 
     public function test_search_users_returns_empty_collection_when_no_matches(): void

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -219,6 +219,30 @@ class ProfileTransformerTest extends TestCase
         $this->assertSame('30123456', $payload['nro_doc']);
     }
 
+    public function test_transform_exposes_created_at_for_admin_viewing_other_user(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $subject = User::factory()->create([
+            'email' => 'with-created-at@example.test',
+            'created_at' => '2024-03-15 12:34:56',
+        ]);
+
+        $payload = (new ProfileTransformer($admin))->transform($subject->fresh());
+
+        $this->assertArrayHasKey('created_at', $payload);
+        $this->assertSame('2024-03-15 12:34:56', $payload['created_at']);
+    }
+
+    public function test_transform_does_not_expose_created_at_for_non_admin_viewing_other_user(): void
+    {
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $subject = User::factory()->create(['data_visibility' => '2']);
+
+        $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
+
+        $this->assertArrayNotHasKey('created_at', $payload);
+    }
+
     public function test_transform_admin_branch_uses_loose_id_equality_for_string_subject_id(): void
     {
         $admin = User::factory()->create(['is_admin' => true]);


### PR DESCRIPTION
## Summary

Admin-only API to run the existing `user:update` Artisan flow from the panel and to audit migrations.

## Changes

- **`user_migrations` table** — logs `admin_user_id`, `user_id_kept`, `user_id_removed`, timestamps; `UserMigration` model and relations.
- **`POST /api/admin/user-migrations`** — validates IDs, calls `Artisan::call('user:update', …)` **without** `--remove` (source user stays active), persists a log row.
- **`GET /api/admin/user-migrations`** — paginated list, newest first, includes admin name.
- **User search** — shared `UserSearchFilter`: numeric terms → ID / `nro_doc` / `mobile_phone` (LIKE); alpha/mixed → name / email / `nro_doc` (LIKE). Wired into admin user list and repository search used by `/api/users/search`.
- **`ProfileTransformer`** — exposes `created_at` when the viewer is admin (for migration preview).
- **Tests** — model, repository search branches, admin migration controller integration, transformer.

## Notes

- Requires **`php artisan migrate`** for `user_migrations`.