### PR TITLE
Mesa de ayuda: tweaks

### DIFF
--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -35,7 +35,12 @@ class SupportTicketController extends Controller
 
     public function show(int $id): JsonResponse
     {
-        $ticket = SupportTicket::with(['replies.attachments', 'attachments', 'user'])->findOrFail($id);
+        $ticket = SupportTicket::with([
+            'replies.attachments',
+            'replies.user:id,name',
+            'attachments',
+            'user',
+        ])->findOrFail($id);
 
         return response()->json(['data' => $ticket]);
     }

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -13,6 +13,19 @@ use STS\Services\SupportTicketService;
 
 class SupportTicketController extends Controller
 {
+    /**
+     * @return list<string>
+     */
+    private static function ticketDetailRelationships(): array
+    {
+        return [
+            'replies.attachments',
+            'replies.user:id,name',
+            'attachments',
+            'user',
+        ];
+    }
+
     private static function typeDefaultPriorities(): array
     {
         return [
@@ -35,12 +48,7 @@ class SupportTicketController extends Controller
 
     public function show(int $id): JsonResponse
     {
-        $ticket = SupportTicket::with([
-            'replies.attachments',
-            'replies.user:id,name',
-            'attachments',
-            'user',
-        ])->findOrFail($id);
+        $ticket = SupportTicket::with(self::ticketDetailRelationships())->findOrFail($id);
 
         return response()->json(['data' => $ticket]);
     }

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -61,18 +61,11 @@ class SupportTicketController extends Controller
 
         $user = auth()->user();
 
-        $existingDuplicate = SupportTicket::query()
-            ->where('user_id', $user->id)
-            ->where('subject', $validated['subject'])
-            ->whereExists(function ($query) use ($validated) {
-                $query->selectRaw('1')
-                    ->from('support_ticket_replies as str')
-                    ->whereColumn('str.ticket_id', 'support_tickets.id')
-                    ->where('str.message_markdown', $validated['message_markdown'])
-                    ->whereRaw('str.id = (select min(s.id) from support_ticket_replies as s where s.ticket_id = support_tickets.id)');
-            })
-            ->orderBy('id')
-            ->first();
+        $existingDuplicate = $this->findExistingTicketWithSameOpening(
+            (int) $user->id,
+            $validated['subject'],
+            $validated['message_markdown'],
+        );
         if ($existingDuplicate) {
             return response()->json(['data' => $existingDuplicate->fresh()]);
         }
@@ -106,6 +99,22 @@ class SupportTicketController extends Controller
         });
 
         return response()->json(['data' => $ticket]);
+    }
+
+    private function findExistingTicketWithSameOpening(int $userId, string $subject, string $messageMarkdown): ?SupportTicket
+    {
+        return SupportTicket::query()
+            ->where('user_id', $userId)
+            ->where('subject', $subject)
+            ->whereExists(function ($query) use ($messageMarkdown) {
+                $query->selectRaw('1')
+                    ->from('support_ticket_replies as str')
+                    ->whereColumn('str.ticket_id', 'support_tickets.id')
+                    ->where('str.message_markdown', $messageMarkdown)
+                    ->whereRaw('str.id = (select min(s.id) from support_ticket_replies as s where s.ticket_id = support_tickets.id)');
+            })
+            ->orderBy('id')
+            ->first();
     }
 
     public function reply(int $id, Request $request): JsonResponse

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -60,6 +60,23 @@ class SupportTicketController extends Controller
         ]);
 
         $user = auth()->user();
+
+        $existingDuplicate = SupportTicket::query()
+            ->where('user_id', $user->id)
+            ->where('subject', $validated['subject'])
+            ->whereExists(function ($query) use ($validated) {
+                $query->selectRaw('1')
+                    ->from('support_ticket_replies as str')
+                    ->whereColumn('str.ticket_id', 'support_tickets.id')
+                    ->where('str.message_markdown', $validated['message_markdown'])
+                    ->whereRaw('str.id = (select min(s.id) from support_ticket_replies as s where s.ticket_id = support_tickets.id)');
+            })
+            ->orderBy('id')
+            ->first();
+        if ($existingDuplicate) {
+            return response()->json(['data' => $existingDuplicate->fresh()]);
+        }
+
         $ticket = DB::transaction(function () use ($validated, $user) {
             $ticket = SupportTicket::create([
                 'user_id' => $user->id,

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -117,6 +117,31 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertSame('reply.jpg', $replyWithFile['attachments'][0]['original_name']);
     }
 
+    public function test_show_includes_reply_user_with_id_and_name_for_admin_replies(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner);
+
+        SupportTicketReply::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Respuesta del equipo',
+            'created_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $payload = $this->getJson('api/admin/support/tickets/'.$ticket->id)->assertOk()->json('data');
+        $adminReply = collect($payload['replies'])->firstWhere('is_admin', true);
+        $this->assertNotNull($adminReply);
+        $this->assertIsArray($adminReply['user']);
+        $this->assertSame($admin->id, $adminReply['user']['id']);
+        $this->assertSame($admin->name, $adminReply['user']['name']);
+    }
+
     public function test_reply_without_message_is_unprocessable(): void
     {
         Storage::fake('public');

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -237,6 +237,31 @@ class SupportTicketApiTest extends TestCase
             ->assertExactJson(['error' => 'Ticket not found']);
     }
 
+    public function test_show_does_not_include_reply_user_for_ticket_owner_so_admin_identity_stays_private(): void
+    {
+        $owner = $this->createUser();
+        $admin = $this->createUser(true);
+
+        $this->actingAs($owner, 'api');
+        $ticketId = (int) data_get($this->post('api/support/tickets', [
+            'type' => 'contact',
+            'subject' => 'Need assistance',
+            'message_markdown' => 'Hello support',
+        ])->json(), 'data.id');
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(\STS\Http\Middleware\UserAdmin::class);
+        $this->postJson("api/admin/support/tickets/{$ticketId}/replies", [
+            'message_markdown' => 'Staff answer',
+        ])->assertOk();
+
+        $this->actingAs($owner, 'api');
+        $payload = $this->getJson("api/support/tickets/{$ticketId}")->assertOk()->json('data');
+        $adminReply = collect($payload['replies'])->firstWhere('is_admin', true);
+        $this->assertNotNull($adminReply);
+        $this->assertArrayNotHasKey('user', $adminReply);
+    }
+
     public function test_show_returns_replies_with_nested_attachments_when_present(): void
     {
         $user = $this->createUser();

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -391,6 +391,25 @@ class SupportTicketApiTest extends TestCase
         $this->assertSame($beforeTicketCount + 1, SupportTicket::query()->where('user_id', $user->id)->count());
     }
 
+    public function test_create_duplicate_detection_is_scoped_to_same_user(): void
+    {
+        $payload = [
+            'type' => 'feedback',
+            'subject' => 'Shared wording subject',
+            'message_markdown' => 'Shared opening text.',
+        ];
+
+        $userA = $this->createUser();
+        $this->actingAs($userA, 'api');
+        $idA = (int) data_get($this->postJson('api/support/tickets', $payload)->json(), 'data.id');
+
+        $userB = $this->createUser();
+        $this->actingAs($userB, 'api');
+        $idB = (int) data_get($this->postJson('api/support/tickets', $payload)->json(), 'data.id');
+
+        $this->assertNotSame($idA, $idB);
+    }
+
     public function test_create_persists_created_by_and_last_reply_at(): void
     {
         $user = $this->createUser();

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -360,6 +360,37 @@ class SupportTicketApiTest extends TestCase
         ])->assertStatus(422);
     }
 
+    public function test_create_returns_existing_ticket_when_subject_and_opening_message_duplicate(): void
+    {
+        $user = $this->createUser();
+        $this->actingAs($user, 'api');
+
+        $payload = [
+            'type' => 'contact',
+            'subject' => 'Same title for duplicate check',
+            'message_markdown' => 'Same opening description body.',
+        ];
+
+        $first = $this->postJson('api/support/tickets', $payload);
+        $first->assertOk();
+        $firstId = (int) data_get($first->json(), 'data.id');
+        $this->assertGreaterThan(0, $firstId);
+
+        $beforeTicketCount = SupportTicket::query()->where('user_id', $user->id)->count();
+
+        $second = $this->postJson('api/support/tickets', $payload);
+        $second->assertOk();
+        $this->assertSame($firstId, (int) data_get($second->json(), 'data.id'));
+        $this->assertSame($beforeTicketCount, SupportTicket::query()->where('user_id', $user->id)->count());
+
+        $third = $this->postJson('api/support/tickets', array_merge($payload, [
+            'message_markdown' => 'Different opening body.',
+        ]));
+        $third->assertOk();
+        $this->assertNotSame($firstId, (int) data_get($third->json(), 'data.id'));
+        $this->assertSame($beforeTicketCount + 1, SupportTicket::query()->where('user_id', $user->id)->count());
+    }
+
     public function test_create_persists_created_by_and_last_reply_at(): void
     {
         $user = $this->createUser();


### PR DESCRIPTION
- **Support ticket create dedupe:** Same authenticated user posting again with the **same subject** and **same opening message** (first reply body) returns the **existing ticket** (HTTP 200, same `data` shape); no second ticket/replies row.
- **Dedupe scope:** Only matches tickets **for that user**; other users still get new tickets with identical text.
- **Tests:** Feature coverage for dedupe behavior, cross-user isolation, and existing `SupportTicketApiTest` suite still green.
- **Admin ticket detail API:** `GET api/admin/support/tickets/{id}` **eager-loads** `replies.user` with **`id`** and **`name`** so the admin UI can show who replied (without exposing this on the user-facing ticket API).
- **Regression:** User `GET api/support/tickets/{id}` **does not** include `user` on replies (staff identity stays hidden from end users).
- **Refactor:** Admin controller uses a small **`ticketDetailRelationships()`** helper for the `with([...])` list.
