### PR TITLE
Admin fixes

### DIFF
--- a/app/Http/Controllers/Api/v1/UserController.php
+++ b/app/Http/Controllers/Api/v1/UserController.php
@@ -174,6 +174,11 @@ class UserController extends Controller
             throw new ExceptionWithErrors('Users not found.', $this->userLogic->getErrors());
         }
 
+        // UserRepository::show masks private_note by default; admins need it in admin edit flows.
+        if ($me && $me->is_admin) {
+            $profile->private_note = User::query()->whereKey($profile->id)->value('private_note');
+        }
+
         // Set validate_by_date for pre-cutoff users on first /users/me when grace days apply and enforcement is on (not optional-only; new users use cutoff, not this date)
         if ($profile->id === $me->id) {
             $days = (int) config('carpoolear.identity_validation_days_for_current_users', 0);

--- a/app/Http/Controllers/Api/v1/UserController.php
+++ b/app/Http/Controllers/Api/v1/UserController.php
@@ -174,10 +174,7 @@ class UserController extends Controller
             throw new ExceptionWithErrors('Users not found.', $this->userLogic->getErrors());
         }
 
-        // UserRepository::show masks private_note by default; admins need it in admin edit flows.
-        if ($me && $me->is_admin) {
-            $profile->private_note = User::query()->whereKey($profile->id)->value('private_note');
-        }
+        $this->hydratePrivateNoteForAdminViewer($me, $profile);
 
         // Set validate_by_date for pre-cutoff users on first /users/me when grace days apply and enforcement is on (not optional-only; new users use cutoff, not this date)
         if ($profile->id === $me->id) {
@@ -195,6 +192,16 @@ class UserController extends Controller
         }
 
         return $this->item($profile, new ProfileTransformer($me));
+    }
+
+    private function hydratePrivateNoteForAdminViewer(User $viewer, User $profile): void
+    {
+        // UserRepository::show masks private_note by default; admins need it in admin edit flows.
+        if (! $viewer->is_admin) {
+            return;
+        }
+
+        $profile->private_note = User::query()->whereKey($profile->id)->value('private_note');
     }
 
     /**

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -803,6 +803,22 @@ class UserControllerApiTest extends TestCase
         ])->assertStatus(422);
     }
 
+    public function test_admin_can_view_private_note_for_target_user_profile(): void
+    {
+        $admin = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => true]);
+        $target = User::factory()->create([
+            'active' => true,
+            'banned' => false,
+            'private_note' => 'Admin-only note fixture',
+        ]);
+
+        $this->actingAs($admin, 'api');
+
+        $this->getJson('api/users/'.$target->id)
+            ->assertOk()
+            ->assertJsonPath('data.private_note', 'Admin-only note fixture');
+    }
+
     public function test_update_photo_accepts_base64_profile_payload(): void
     {
         $user = User::factory()->create(['active' => true, 'banned' => false]);


### PR DESCRIPTION
- Fixed admin user edit flow so private notes are properly available for admin-driven profile fetches used by edit screens.
- Added regression coverage for admin visibility of `private_note` in user profile API responses.
- Verified full backend suite passes (`php artisan test`).