### PR TITLE
Admin: create support ticket from user detail

### DIFF
--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -13,6 +13,8 @@ use STS\Services\SupportTicketService;
 
 class SupportTicketController extends Controller
 {
+    private const ADMIN_CREATED_TICKET_STATUS = 'Esperando respuesta';
+
     /**
      * @return list<string>
      */
@@ -68,7 +70,7 @@ class SupportTicketController extends Controller
                 'user_id' => (int) $validated['user_id'],
                 'type' => $validated['type'],
                 'subject' => $validated['subject'],
-                'status' => 'Esperando respuesta',
+                'status' => self::ADMIN_CREATED_TICKET_STATUS,
                 'priority' => self::typeDefaultPriorities()[$validated['type']] ?? 'normal',
                 'unread_for_user' => 1,
                 'unread_for_admin' => 0,

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -68,7 +68,7 @@ class SupportTicketController extends Controller
                 'user_id' => (int) $validated['user_id'],
                 'type' => $validated['type'],
                 'subject' => $validated['subject'],
-                'status' => 'Open',
+                'status' => 'Esperando respuesta',
                 'priority' => self::typeDefaultPriorities()[$validated['type']] ?? 'normal',
                 'unread_for_user' => 1,
                 'unread_for_admin' => 0,

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -347,6 +347,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
 
         $this->assertSame($owner->id, (int) $response->json('data.user_id'));
         $this->assertSame('account_verification', $response->json('data.type'));
+        $this->assertSame('Esperando respuesta', $response->json('data.status'));
         $this->assertSame('high', $response->json('data.priority'));
         $this->assertSame(1, (int) $response->json('data.unread_for_user'));
         $this->assertSame(0, (int) $response->json('data.unread_for_admin'));
@@ -355,6 +356,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
             'user_id' => $owner->id,
             'type' => 'account_verification',
             'subject' => 'Verificacion de cuenta',
+            'status' => 'Esperando respuesta',
             'priority' => 'high',
             'created_by' => $admin->id,
         ]);


### PR DESCRIPTION
- Updated admin ticket creation (`Api/Admin/SupportTicketController`) so tickets created by admins start with status **`Esperando respuesta`** (waiting for user response), instead of `Open`.
- Added integration test coverage to lock this default status behavior.
- Minor refactor: extracted a named constant for the initial status to improve clarity and avoid magic strings.
