### PR TITLE
User migration: delete or anonymize

### DIFF
--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -118,13 +118,7 @@ class UserMigrationController extends Controller
 
         try {
             $this->userDeletionService->deleteUser($removed);
-
-            AdminActionLog::create([
-                'admin_user_id' => $admin->id,
-                'action' => AdminActionLog::ACTION_USER_DELETE,
-                'target_user_id' => $removedId,
-                'details' => ['source' => 'user_migration'],
-            ]);
+            $this->logAdminAction($admin, $removedId, AdminActionLog::ACTION_USER_DELETE);
 
             return 'deleted';
         } catch (Throwable $e) {
@@ -134,18 +128,24 @@ class UserMigrationController extends Controller
             ]);
 
             $this->anonymizationService->anonymize($removed);
-
-            AdminActionLog::create([
-                'admin_user_id' => $admin->id,
-                'action' => AdminActionLog::ACTION_USER_ANONYMIZE,
-                'target_user_id' => $removedId,
-                'details' => [
-                    'source' => 'user_migration',
-                    'fallback_reason' => $e->getMessage(),
-                ],
+            $this->logAdminAction($admin, $removedId, AdminActionLog::ACTION_USER_ANONYMIZE, [
+                'fallback_reason' => $e->getMessage(),
             ]);
 
             return 'anonymized';
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $extraDetails
+     */
+    private function logAdminAction(User $admin, int $targetUserId, string $action, array $extraDetails = []): void
+    {
+        AdminActionLog::create([
+            'admin_user_id' => $admin->id,
+            'action' => $action,
+            'target_user_id' => $targetUserId,
+            'details' => array_merge(['source' => 'user_migration'], $extraDetails),
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -5,11 +5,24 @@ namespace STS\Http\Controllers\Api\Admin;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
 use STS\Http\Controllers\Controller;
+use STS\Models\AdminActionLog;
+use STS\Models\User;
 use STS\Models\UserMigration;
+use STS\Services\AnonymizationService;
+use STS\Services\Logic\DeviceManager;
+use STS\Services\UserDeletionService;
+use Throwable;
 
 class UserMigrationController extends Controller
 {
+    public function __construct(
+        private readonly UserDeletionService $userDeletionService,
+        private readonly AnonymizationService $anonymizationService,
+        private readonly DeviceManager $deviceLogic,
+    ) {}
+
     public function index(Request $request): JsonResponse
     {
         $perPage = min(max((int) $request->get('per_page', 20), 1), 100);
@@ -54,6 +67,7 @@ class UserMigrationController extends Controller
             'user_id_removed' => 'required|integer|exists:users,id|different:user_id_kept',
         ]);
 
+        $admin = $request->user();
         $keptId = (int) $validated['user_id_kept'];
         $removedId = (int) $validated['user_id_removed'];
 
@@ -62,8 +76,10 @@ class UserMigrationController extends Controller
             'new' => (string) $keptId,
         ]);
 
+        $removalAction = $this->removeOrAnonymize($removedId, $admin);
+
         $row = UserMigration::query()->create([
-            'admin_user_id' => (int) $request->user()->id,
+            'admin_user_id' => (int) $admin->id,
             'user_id_kept' => $keptId,
             'user_id_removed' => $removedId,
         ]);
@@ -80,8 +96,56 @@ class UserMigrationController extends Controller
                 ] : null,
                 'user_id_kept' => $row->user_id_kept,
                 'user_id_removed' => $row->user_id_removed,
+                'removal_action' => $removalAction,
                 'created_at' => $row->created_at?->toAtomString(),
             ],
         ]);
+    }
+
+    /**
+     * Mirror admin profile delete/anonymize flow on the migrated-from user.
+     * Try to delete; if deletion throws (e.g. residual FK constraints), fall back to anonymize.
+     * Returns the action taken: 'deleted' or 'anonymized'.
+     */
+    private function removeOrAnonymize(int $removedId, User $admin): string
+    {
+        $removed = User::find($removedId);
+        if (! $removed) {
+            return 'deleted';
+        }
+
+        $this->deviceLogic->logoutAllDevices($removed);
+
+        try {
+            $this->userDeletionService->deleteUser($removed);
+
+            AdminActionLog::create([
+                'admin_user_id' => $admin->id,
+                'action' => AdminActionLog::ACTION_USER_DELETE,
+                'target_user_id' => $removedId,
+                'details' => ['source' => 'user_migration'],
+            ]);
+
+            return 'deleted';
+        } catch (Throwable $e) {
+            Log::warning('user-migration: deletion failed, falling back to anonymize', [
+                'user_id' => $removedId,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->anonymizationService->anonymize($removed);
+
+            AdminActionLog::create([
+                'admin_user_id' => $admin->id,
+                'action' => AdminActionLog::ACTION_USER_ANONYMIZE,
+                'target_user_id' => $removedId,
+                'details' => [
+                    'source' => 'user_migration',
+                    'fallback_reason' => $e->getMessage(),
+                ],
+            ]);
+
+            return 'anonymized';
+        }
     }
 }

--- a/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
@@ -3,9 +3,12 @@
 namespace Tests\Feature\Http;
 
 use STS\Http\Middleware\UserAdmin;
+use STS\Models\AdminActionLog;
 use STS\Models\Trip;
 use STS\Models\User;
 use STS\Models\UserMigration;
+use STS\Services\Logic\DeviceManager;
+use STS\Services\UserDeletionService;
 use Tests\TestCase;
 
 class AdminUserMigrationControllerIntegrationTest extends TestCase
@@ -110,5 +113,82 @@ class AdminUserMigrationControllerIntegrationTest extends TestCase
             'user_id_kept' => $kept->id,
             'user_id_removed' => $removed->id,
         ]);
+    }
+
+    public function test_store_deletes_removed_user_when_deletion_succeeds(): void
+    {
+        $this->spy(DeviceManager::class);
+
+        $admin = $this->admin();
+        $kept = User::factory()->create();
+        $removed = User::factory()->create();
+        Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.removal_action', 'deleted');
+
+        $this->assertDatabaseMissing('users', ['id' => $removed->id]);
+
+        $this->assertDatabaseHas('admin_action_logs', [
+            'admin_user_id' => $admin->id,
+            'action' => AdminActionLog::ACTION_USER_DELETE,
+            'target_user_id' => $removed->id,
+        ]);
+
+        app(DeviceManager::class)->shouldHaveReceived('logoutAllDevices')->once();
+    }
+
+    public function test_store_falls_back_to_anonymize_when_deletion_throws(): void
+    {
+        $this->spy(DeviceManager::class);
+
+        $this->mock(UserDeletionService::class, function ($mock) {
+            $mock->shouldReceive('deleteUser')->andThrow(new \RuntimeException('cannot delete: foreign key constraint'));
+        });
+
+        $admin = $this->admin();
+        $kept = User::factory()->create();
+        $removed = User::factory()->create([
+            'name' => 'Original Name',
+            'email' => 'original@example.test',
+        ]);
+        Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.removal_action', 'anonymized');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $removed->id,
+            'name' => 'Usuario anónimo',
+            'active' => 0,
+        ]);
+        $this->assertDatabaseMissing('users', [
+            'id' => $removed->id,
+            'email' => 'original@example.test',
+        ]);
+
+        $this->assertDatabaseHas('admin_action_logs', [
+            'admin_user_id' => $admin->id,
+            'action' => AdminActionLog::ACTION_USER_ANONYMIZE,
+            'target_user_id' => $removed->id,
+        ]);
+
+        app(DeviceManager::class)->shouldHaveReceived('logoutAllDevices')->once();
     }
 }


### PR DESCRIPTION
## Summary

Extends **admin user migration** so that after `user:update` runs, the **source user** (`user_id_removed`) is removed the same way as from the admin profile: **hard-delete when allowed**, **anonymize on failure** (e.g. FK constraints), with **admin action logs** and a **`removal_action`** field on the API response.

## Changes

- **`POST /api/admin/user-migrations`** — still runs `Artisan::call('user:update', …)` first; then:
  - `DeviceManager::logoutAllDevices` on the removed user
  - `UserDeletionService::deleteUser` → on success: `admin_action_logs` with `user_delete` + `details.source = user_migration`
  - On **any** `Throwable` from delete: `AnonymizationService::anonymize` + `admin_action_logs` with `user_anonymize` + `fallback_reason` in details
- **Response** — `data.removal_action`: `'deleted' | 'anonymized'`
- **Tests** — integration tests for successful delete path and mocked-delete-throws → anonymize fallback

## Notes

- Behaviour mirrors existing **`POST …/delete`** and **`POST …/anonymize`** admin endpoints (same services + log action constants).
- Requires DB migration from the original **user migration** feature if not already applied (`user_migrations` table).