### PR TITLE
Maintenance mode

### DIFF
--- a/app/Casts/UtcDatetime.php
+++ b/app/Casts/UtcDatetime.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace STS\Casts;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Naive DATETIME columns are stored and read as UTC wall times (product requirement).
+ */
+class UtcDatetime implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?Carbon
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return Carbon::parse((string) $value, 'UTC');
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): array
+    {
+        if ($value === null) {
+            return [$key => null];
+        }
+
+        if ($value instanceof Carbon) {
+            return [$key => $value->copy()->utc()->format('Y-m-d H:i:s')];
+        }
+
+        return [$key => Carbon::parse($value, 'UTC')->format('Y-m-d H:i:s')];
+    }
+}

--- a/app/Console/Commands/MaintenanceTick.php
+++ b/app/Console/Commands/MaintenanceTick.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use STS\Services\Maintenance\MaintenanceStateService;
+
+class MaintenanceTick extends Command
+{
+    protected $signature = 'maintenance:tick';
+
+    protected $description = 'Apply scheduled maintenance windows (start/end)';
+
+    public function handle(MaintenanceStateService $maintenanceStateService): int
+    {
+        $maintenanceStateService->tick();
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/MaintenanceController.php
+++ b/app/Http/Controllers/Api/Admin/MaintenanceController.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use STS\Http\Controllers\Controller;
+use STS\Models\MaintenanceAuditLog;
+use STS\Models\MaintenanceSchedule;
+use STS\Services\Maintenance\MaintenanceStateService;
+
+class MaintenanceController extends Controller
+{
+    public function __construct(
+        protected MaintenanceStateService $maintenanceStateService
+    ) {}
+
+    public function schedulesIndex(): JsonResponse
+    {
+        $schedules = MaintenanceSchedule::query()
+            ->pending()
+            ->orderBy('starts_at')
+            ->get();
+
+        return response()->json(['data' => $schedules]);
+    }
+
+    public function schedulesStore(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'starts_at' => ['required', 'date'],
+            'ends_at' => ['nullable', 'date'],
+            'message' => ['required', 'string'],
+            'mode' => ['required', 'string', 'in:strict,flexible'],
+        ]);
+
+        $startsAt = $this->parseUtcInstant($validated['starts_at']);
+        $endsAt = isset($validated['ends_at']) && $validated['ends_at'] !== null
+            ? $this->parseUtcInstant($validated['ends_at'])
+            : null;
+
+        $this->assertEndsAfterStart($startsAt, $endsAt);
+
+        if ($this->maintenanceStateService->overlapsPendingSchedule($startsAt, $endsAt, null)) {
+            throw ValidationException::withMessages([
+                'starts_at' => ['Overlaps an existing maintenance schedule.'],
+            ]);
+        }
+
+        $schedule = MaintenanceSchedule::query()->create([
+            'starts_at' => $startsAt,
+            'ends_at' => $endsAt,
+            'message' => $validated['message'],
+            'mode' => $validated['mode'],
+        ]);
+
+        $this->maintenanceStateService->writeAudit((int) auth()->id(), 'schedule_create', [
+            'schedule_id' => $schedule->id,
+        ]);
+
+        return response()->json(['data' => $schedule->fresh()], 201);
+    }
+
+    public function schedulesUpdate(Request $request, MaintenanceSchedule $schedule): JsonResponse
+    {
+        if (! $schedule->isPending()) {
+            throw ValidationException::withMessages([
+                'schedule' => ['This schedule can no longer be edited.'],
+            ]);
+        }
+
+        $validated = $request->validate([
+            'starts_at' => ['sometimes', 'required', 'date'],
+            'ends_at' => ['sometimes', 'nullable', 'date'],
+            'message' => ['sometimes', 'required', 'string'],
+            'mode' => ['sometimes', 'required', 'string', 'in:strict,flexible'],
+        ]);
+
+        $startsAt = isset($validated['starts_at'])
+            ? $this->parseUtcInstant($validated['starts_at'])
+            : $schedule->starts_at;
+
+        $endsAt = array_key_exists('ends_at', $validated)
+            ? ($validated['ends_at'] !== null ? $this->parseUtcInstant($validated['ends_at']) : null)
+            : $schedule->ends_at;
+
+        $this->assertEndsAfterStart($startsAt, $endsAt);
+
+        if ($this->maintenanceStateService->overlapsPendingSchedule($startsAt, $endsAt, (int) $schedule->id)) {
+            throw ValidationException::withMessages([
+                'starts_at' => ['Overlaps an existing maintenance schedule.'],
+            ]);
+        }
+
+        $attributes = [];
+        if (isset($validated['starts_at'])) {
+            $attributes['starts_at'] = $startsAt;
+        }
+        if (array_key_exists('ends_at', $validated)) {
+            $attributes['ends_at'] = $endsAt;
+        }
+        if (array_key_exists('message', $validated)) {
+            $attributes['message'] = $validated['message'];
+        }
+        if (array_key_exists('mode', $validated)) {
+            $attributes['mode'] = $validated['mode'];
+        }
+
+        $schedule->update($attributes);
+
+        $schedule->refresh();
+
+        $this->maintenanceStateService->writeAudit((int) auth()->id(), 'schedule_update', [
+            'schedule_id' => $schedule->id,
+        ]);
+
+        return response()->json(['data' => $schedule]);
+    }
+
+    public function schedulesCancel(MaintenanceSchedule $schedule): JsonResponse
+    {
+        $this->maintenanceStateService->cancelSchedule($schedule, auth()->id() ? (int) auth()->id() : null);
+
+        return response()->json(['data' => ['schedule_id' => $schedule->id, 'cancelled' => true]]);
+    }
+
+    public function stateShow(): JsonResponse
+    {
+        $state = $this->maintenanceStateService->state();
+
+        return response()->json([
+            'data' => [
+                'is_active' => $state->is_active,
+                'mode' => $state->mode,
+                'message' => $state->message,
+                'ends_at' => $state->ends_at?->toIso8601String(),
+                'source' => $state->source,
+                'active_schedule_id' => $state->active_schedule_id,
+            ],
+        ]);
+    }
+
+    public function stateUpdate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'active' => ['required', 'boolean'],
+            'mode' => ['required_if:active,true', 'nullable', 'string', 'in:strict,flexible'],
+            'message' => ['nullable', 'string'],
+            'ends_at' => ['nullable', 'date'],
+        ]);
+
+        $endsAt = null;
+        if ($validated['active'] && ! empty($validated['ends_at'])) {
+            $endsAt = $this->parseUtcInstant($validated['ends_at']);
+        }
+
+        $message = $validated['active'] ? ($validated['message'] ?? '') : '';
+
+        $this->maintenanceStateService->applyManualActive(
+            (bool) $validated['active'],
+            $validated['mode'] ?? null,
+            $message,
+            $endsAt,
+            'manual',
+            null,
+            auth()->id() ? (int) auth()->id() : null
+        );
+
+        return response()->json(['data' => $this->maintenanceStateService->state()->fresh()]);
+    }
+
+    public function auditLogs(): JsonResponse
+    {
+        $logs = MaintenanceAuditLog::query()
+            ->orderByDesc('id')
+            ->limit(100)
+            ->get();
+
+        return response()->json(['data' => $logs]);
+    }
+
+    private function parseUtcInstant(string $value): Carbon
+    {
+        return Carbon::parse($value, 'UTC');
+    }
+
+    private function assertEndsAfterStart(Carbon $startsAt, ?Carbon $endsAt): void
+    {
+        if ($endsAt !== null && $endsAt->lte($startsAt)) {
+            throw ValidationException::withMessages([
+                'ends_at' => ['Must be after starts_at.'],
+            ]);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/v1/AuthController.php
+++ b/app/Http/Controllers/Api/v1/AuthController.php
@@ -9,6 +9,7 @@ use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
+use STS\Services\Maintenance\MaintenanceStateService;
 use STS\User;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
@@ -78,6 +79,15 @@ class AuthController extends Controller
             && config('carpoolear.identity_validation_manual_qr_enabled')
             && ! empty(config('services.mercadopago.qr_payment_access_token'))
             && ! empty(config('carpoolear.qr_payment_pos_external_id'));
+
+        $maintenancePayload = app(MaintenanceStateService::class)->publicPayload();
+        $config->maintenance = (object) [
+            'enabled' => $maintenancePayload['enabled'],
+            'mode' => $maintenancePayload['mode'],
+            'message' => $maintenancePayload['message'],
+            'ends_at' => $maintenancePayload['ends_at'],
+            'admin_path' => config('carpoolear.maintenance_admin_path'),
+        ];
 
         return $config;
     }

--- a/app/Http/Middleware/CheckMaintenanceMode.php
+++ b/app/Http/Middleware/CheckMaintenanceMode.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace STS\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use STS\Models\User;
+use STS\Services\Maintenance\MaintenanceStateService;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class CheckMaintenanceMode
+{
+    public function __construct(
+        protected MaintenanceStateService $maintenanceStateService
+    ) {}
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if ($this->shouldBypass($request)) {
+            return $next($request);
+        }
+
+        $state = $this->maintenanceStateService->state();
+
+        if (! $state->is_active) {
+            return $next($request);
+        }
+
+        $user = $this->resolvePassengerApiUser();
+
+        if ($state->mode === 'flexible' && $user && $user->is_admin) {
+            return $next($request);
+        }
+
+        return response()->json([
+            'maintenance' => true,
+            'enabled' => true,
+            'mode' => $state->mode,
+            'message' => $state->message,
+            'ends_at' => $state->ends_at?->toIso8601String(),
+        ], 503);
+    }
+
+    private function shouldBypass(Request $request): bool
+    {
+        if ($request->is('api/admin') || $request->is('api/admin/*')) {
+            return true;
+        }
+
+        $literal = [
+            'api/config',
+            'api/login',
+            'api/retoken',
+            'api/log',
+            'api/reset-password',
+            'api/mercadopago/oauth/callback',
+            'api/mercadopago/manual-validation-success',
+        ];
+
+        foreach ($literal as $pattern) {
+            if ($request->is($pattern)) {
+                return true;
+            }
+        }
+
+        if ($request->is('api/activate') || $request->is('api/activate/*')) {
+            return true;
+        }
+
+        if ($request->is('api/change-password') || $request->is('api/change-password/*')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function resolvePassengerApiUser(): ?User
+    {
+        $user = null;
+
+        try {
+            $authUser = JWTAuth::parseToken()->authenticate();
+            if ($authUser instanceof User) {
+                $user = $authUser;
+            }
+        } catch (\Throwable) {
+            // Missing or invalid token — acceptable before logged middleware runs.
+        }
+
+        if (! $user && auth()->user() instanceof User) {
+            $user = auth()->user();
+        }
+
+        if (! $user || $user->banned || ! $user->active) {
+            return null;
+        }
+
+        return $user;
+    }
+}

--- a/app/Models/MaintenanceAuditLog.php
+++ b/app/Models/MaintenanceAuditLog.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MaintenanceAuditLog extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'maintenance_audit_logs';
+
+    protected $fillable = [
+        'user_id',
+        'action',
+        'meta',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'meta' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/MaintenanceSchedule.php
+++ b/app/Models/MaintenanceSchedule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use STS\Casts\UtcDatetime;
+
+class MaintenanceSchedule extends Model
+{
+    protected $table = 'maintenance_schedules';
+
+    protected $fillable = [
+        'starts_at',
+        'ends_at',
+        'message',
+        'mode',
+        'cancelled_at',
+        'completed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => UtcDatetime::class,
+            'ends_at' => UtcDatetime::class,
+            'cancelled_at' => UtcDatetime::class,
+            'completed_at' => UtcDatetime::class,
+        ];
+    }
+
+    /**
+     * Still eligible for overlap checks and cron activation.
+     */
+    public function scopePending($query)
+    {
+        return $query->whereNull('cancelled_at')->whereNull('completed_at');
+    }
+
+    public function isPending(): bool
+    {
+        return $this->cancelled_at === null && $this->completed_at === null;
+    }
+}

--- a/app/Models/MaintenanceState.php
+++ b/app/Models/MaintenanceState.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use STS\Casts\UtcDatetime;
+
+class MaintenanceState extends Model
+{
+    protected $table = 'maintenance_state';
+
+    public $incrementing = false;
+
+    protected $keyType = 'int';
+
+    protected $fillable = [
+        'is_active',
+        'mode',
+        'message',
+        'ends_at',
+        'source',
+        'active_schedule_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'ends_at' => UtcDatetime::class,
+        ];
+    }
+
+    public function activeSchedule(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceSchedule::class, 'active_schedule_id');
+    }
+}

--- a/app/Services/Maintenance/MaintenanceInterval.php
+++ b/app/Services/Maintenance/MaintenanceInterval.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace STS\Services\Maintenance;
+
+use Carbon\Carbon;
+
+final class MaintenanceInterval
+{
+    /**
+     * Half-open intervals [start, end): they overlap iff they share any instant.
+     * Null end means unbounded forward (treated as far-future for comparison).
+     */
+    public static function overlap(Carbon $startA, ?Carbon $endA, Carbon $startB, ?Carbon $endB): bool
+    {
+        $farFuture = Carbon::create(9999, 12, 31, 23, 59, 59, 'UTC');
+        $effEndA = $endA ?? $farFuture;
+        $effEndB = $endB ?? $farFuture;
+
+        return $startA->lt($effEndB) && $startB->lt($effEndA);
+    }
+}

--- a/app/Services/Maintenance/MaintenanceStateService.php
+++ b/app/Services/Maintenance/MaintenanceStateService.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace STS\Services\Maintenance;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use STS\Models\MaintenanceAuditLog;
+use STS\Models\MaintenanceSchedule;
+use STS\Models\MaintenanceState;
+
+class MaintenanceStateService
+{
+    public function state(): MaintenanceState
+    {
+        return MaintenanceState::query()->findOrFail(1);
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    public function writeAudit(?int $userId, string $action, array $meta = []): void
+    {
+        MaintenanceAuditLog::query()->create([
+            'user_id' => $userId,
+            'action' => $action,
+            'meta' => $meta ?: null,
+            'created_at' => Carbon::now('UTC'),
+        ]);
+    }
+
+    public function tick(?Carbon $now = null): void
+    {
+        $now = $now ?? Carbon::now('UTC');
+
+        DB::transaction(function () use ($now): void {
+            /** @var MaintenanceState $state */
+            $state = MaintenanceState::query()->lockForUpdate()->findOrFail(1);
+
+            if ($state->is_active && $state->ends_at && $state->ends_at->lte($now)) {
+                $scheduleId = $state->active_schedule_id;
+                $state->update([
+                    'is_active' => false,
+                    'mode' => null,
+                    'message' => null,
+                    'ends_at' => null,
+                    'source' => null,
+                    'active_schedule_id' => null,
+                ]);
+                if ($scheduleId !== null) {
+                    MaintenanceSchedule::query()->whereKey($scheduleId)->update(['completed_at' => $now]);
+                }
+                $this->writeAudit(null, 'cron_deactivate', ['schedule_id' => $scheduleId]);
+
+                $state->refresh();
+            }
+
+            if ($state->is_active) {
+                return;
+            }
+
+            $schedule = MaintenanceSchedule::query()
+                ->pending()
+                ->where('starts_at', '<=', $now)
+                ->where(function ($q) use ($now): void {
+                    $q->whereNull('ends_at')->orWhere('ends_at', '>', $now);
+                })
+                ->orderBy('starts_at')
+                ->lockForUpdate()
+                ->first();
+
+            if ($schedule === null) {
+                return;
+            }
+
+            $state->update([
+                'is_active' => true,
+                'mode' => $schedule->mode,
+                'message' => $schedule->message,
+                'ends_at' => $schedule->ends_at,
+                'source' => 'schedule',
+                'active_schedule_id' => $schedule->id,
+            ]);
+
+            $this->writeAudit(null, 'cron_activate', ['schedule_id' => $schedule->id]);
+        });
+    }
+
+    /**
+     * Whether a pending schedule window overlaps any other pending schedule.
+     */
+    public function overlapsPendingSchedule(Carbon $startsAt, ?Carbon $endsAt, ?int $exceptScheduleId = null): bool
+    {
+        $schedules = MaintenanceSchedule::query()
+            ->pending()
+            ->when($exceptScheduleId !== null, fn ($q) => $q->where('id', '!=', $exceptScheduleId))
+            ->get(['id', 'starts_at', 'ends_at', 'cancelled_at', 'completed_at']);
+
+        foreach ($schedules as $existing) {
+            if (MaintenanceInterval::overlap($startsAt, $endsAt, $existing->starts_at, $existing->ends_at)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  'manual'|'schedule'  $source
+     */
+    public function applyManualActive(bool $active, ?string $mode, ?string $message, ?Carbon $endsAt, string $source, ?int $activeScheduleId, ?int $actorUserId): void
+    {
+        DB::transaction(function () use ($active, $mode, $message, $endsAt, $source, $activeScheduleId, $actorUserId): void {
+            $state = MaintenanceState::query()->lockForUpdate()->findOrFail(1);
+
+            if (! $active) {
+                $linkedScheduleId = $state->active_schedule_id;
+                $state->update([
+                    'is_active' => false,
+                    'mode' => null,
+                    'message' => null,
+                    'ends_at' => null,
+                    'source' => null,
+                    'active_schedule_id' => null,
+                ]);
+                if ($linkedScheduleId !== null) {
+                    MaintenanceSchedule::query()->whereKey($linkedScheduleId)->update([
+                        'cancelled_at' => Carbon::now('UTC'),
+                    ]);
+                }
+                $this->writeAudit($actorUserId, 'manual_disable', [
+                    'had_active_schedule_id' => $linkedScheduleId,
+                ]);
+
+                return;
+            }
+
+            $state->update([
+                'is_active' => true,
+                'mode' => $mode,
+                'message' => $message ?? '',
+                'ends_at' => $endsAt,
+                'source' => $source,
+                'active_schedule_id' => $activeScheduleId,
+            ]);
+
+            $this->writeAudit($actorUserId, 'manual_enable', [
+                'mode' => $mode,
+                'source' => $source,
+                'active_schedule_id' => $activeScheduleId,
+            ]);
+        });
+    }
+
+    public function cancelSchedule(MaintenanceSchedule $schedule, ?int $actorUserId): void
+    {
+        DB::transaction(function () use ($schedule, $actorUserId): void {
+            $schedule = MaintenanceSchedule::query()->whereKey($schedule->id)->lockForUpdate()->firstOrFail();
+
+            if ($schedule->cancelled_at !== null) {
+                return;
+            }
+
+            $schedule->update(['cancelled_at' => Carbon::now('UTC')]);
+
+            $state = MaintenanceState::query()->lockForUpdate()->findOrFail(1);
+            if ($state->active_schedule_id === (int) $schedule->id) {
+                $state->update([
+                    'is_active' => false,
+                    'mode' => null,
+                    'message' => null,
+                    'ends_at' => null,
+                    'source' => null,
+                    'active_schedule_id' => null,
+                ]);
+            }
+
+            $this->writeAudit($actorUserId, 'schedule_cancel', ['schedule_id' => $schedule->id]);
+        });
+    }
+
+    /**
+     * @return array{enabled: bool, mode: ?string, message: ?string, ends_at: ?string}
+     */
+    public function publicPayload(): array
+    {
+        $state = $this->state();
+
+        if (! $state->is_active) {
+            return [
+                'enabled' => false,
+                'mode' => null,
+                'message' => null,
+                'ends_at' => null,
+            ];
+        }
+
+        return [
+            'enabled' => true,
+            'mode' => $state->mode,
+            'message' => $state->message,
+            'ends_at' => $state->ends_at?->toIso8601String(),
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,8 +3,8 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use STS\Http\Middleware\UserLoggin;
 use STS\Http\Middleware\AuthOptional;
+use STS\Http\Middleware\UserLoggin;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -20,8 +20,8 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'update.connection' => \STS\Http\Middleware\UpdateConnection::class,
             'check.userbanned' => \STS\Http\Middleware\CheckUserBanned::class,
-            'throttle'    => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-            'user.admin'  => \STS\Http\Middleware\UserAdmin::class,
+            'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+            'user.admin' => \STS\Http\Middleware\UserAdmin::class,
         ]);
 
         $middleware->group('logged', [
@@ -34,6 +34,10 @@ return Application::configure(basePath: dirname(__DIR__))
             AuthOptional::class,
             \STS\Http\Middleware\UpdateConnection::class,
             \STS\Http\Middleware\CheckUserBanned::class,
+        ]);
+
+        $middleware->appendToGroup('api', [
+            \STS\Http\Middleware\CheckMaintenanceMode::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -135,6 +135,9 @@ return [
     'google_routes_api_key' => env('GOOGLE_ROUTES_API_KEY', ''),
     'google_routes_region_code' => env('GOOGLE_ROUTES_REGION_CODE', 'AR'),
 
+    // SPA route (hash router) for maintenance admin settings — exposed on api/config.
+    'maintenance_admin_path' => env('MAINTENANCE_ADMIN_PATH', '/#/admin/maintenance'),
+
     // User edit property security: allowlist-based filtering for all user update paths
     'user_edit_properties' => [
         // NEVER editable by anyone (including admins)

--- a/database/migrations/2026_05_08_100000_create_maintenance_schedules_table.php
+++ b/database/migrations/2026_05_08_100000_create_maintenance_schedules_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maintenance_schedules', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('starts_at');
+            $table->timestamp('ends_at')->nullable();
+            $table->text('message');
+            $table->string('mode', 16);
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['starts_at', 'cancelled_at']);
+            $table->index(['cancelled_at', 'completed_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_schedules');
+    }
+};

--- a/database/migrations/2026_05_08_100001_create_maintenance_state_table.php
+++ b/database/migrations/2026_05_08_100001_create_maintenance_state_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maintenance_state', function (Blueprint $table) {
+            $table->unsignedTinyInteger('id')->primary();
+            $table->boolean('is_active')->default(false);
+            $table->string('mode', 16)->nullable();
+            $table->text('message')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->string('source', 16)->nullable();
+            $table->foreignId('active_schedule_id')->nullable()->constrained('maintenance_schedules')->nullOnDelete();
+            $table->timestamps();
+        });
+
+        DB::table('maintenance_state')->insert([
+            'id' => 1,
+            'is_active' => false,
+            'mode' => null,
+            'message' => null,
+            'ends_at' => null,
+            'source' => null,
+            'active_schedule_id' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_state');
+    }
+};

--- a/database/migrations/2026_05_08_100002_create_maintenance_audit_logs_table.php
+++ b/database/migrations/2026_05_08_100002_create_maintenance_audit_logs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maintenance_audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id')->nullable();
+            $table->string('action', 64);
+            $table->json('meta')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index('user_id');
+            $table->index('action');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_audit_logs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use STS\Http\Controllers\Api\Admin\CampaignDonationController;
 use STS\Http\Controllers\Api\Admin\CampaignMilestoneController;
 use STS\Http\Controllers\Api\Admin\CampaignRewardController;
 use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
+use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
 use STS\Http\Controllers\Api\Admin\MercadoPagoRejectedValidationController as AdminMercadoPagoRejectedValidationController;
 use STS\Http\Controllers\Api\Admin\SupportReplyTemplateController as AdminSupportReplyTemplateController;
@@ -232,6 +233,17 @@ Route::middleware(['api'])->group(function () {
         Route::get('manual-identity-validations/{id}', [AdminManualIdentityValidationController::class, 'show']);
         Route::post('manual-identity-validations/{id}/review', [AdminManualIdentityValidationController::class, 'review']);
         Route::post('manual-identity-validations/{id}/purge', [AdminManualIdentityValidationController::class, 'purge']);
+
+        Route::prefix('maintenance')->group(function () {
+            Route::get('schedules', [MaintenanceController::class, 'schedulesIndex']);
+            Route::post('schedules', [MaintenanceController::class, 'schedulesStore']);
+            Route::patch('schedules/{schedule}', [MaintenanceController::class, 'schedulesUpdate']);
+            Route::delete('schedules/{schedule}', [MaintenanceController::class, 'schedulesCancel']);
+            Route::get('state', [MaintenanceController::class, 'stateShow']);
+            Route::put('state', [MaintenanceController::class, 'stateUpdate']);
+            Route::get('audit-logs', [MaintenanceController::class, 'auditLogs']);
+        });
+
         // Mercado Pago rejected validations (OAuth validation failures)
         Route::get('mercado-pago-rejected-validations', [AdminMercadoPagoRejectedValidationController::class, 'index']);
         Route::get('mercado-pago-rejected-validations/{id}', [AdminMercadoPagoRejectedValidationController::class, 'show']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -16,6 +16,8 @@ Schedule::command('trip:remainder')->hourly();
 
 Schedule::command('rating:availables')->everyMinute();
 
+Schedule::command('maintenance:tick')->everyMinute();
+
 Schedule::command('trip:request')->dailyAt('12:00')->timezone('America/Argentina/Buenos_Aires');
 
 Schedule::command('trip:request')->dailyAt('19:00')->timezone('America/Argentina/Buenos_Aires');

--- a/tests/Feature/Commands/MaintenanceTickCommandTest.php
+++ b/tests/Feature/Commands/MaintenanceTickCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Carbon\Carbon;
+use STS\Models\MaintenanceSchedule;
+use STS\Models\MaintenanceState;
+use Tests\TestCase;
+
+class MaintenanceTickCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_maintenance_tick_invokes_scheduler_tick(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-10 12:00:00 UTC'));
+
+        MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-05-10 11:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-05-10 14:00:00 UTC'),
+            'message' => 'Cmd test',
+            'mode' => 'strict',
+        ]);
+
+        $this->artisan('maintenance:tick')->assertSuccessful();
+
+        $this->assertTrue(MaintenanceState::query()->find(1)->is_active);
+    }
+}

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -62,6 +62,12 @@ class ScheduleTest extends TestCase
         $this->assertEquals('* * * * *', $event->expression);
     }
 
+    public function test_maintenance_tick_is_scheduled_every_minute()
+    {
+        $event = $this->findEvent('maintenance:tick');
+        $this->assertEquals('* * * * *', $event->expression);
+    }
+
     public function test_messages_email_is_scheduled_every_ten_minutes()
     {
         $event = $this->findEvent('messages:email');
@@ -125,6 +131,7 @@ class ScheduleTest extends TestCase
             'rate:create',
             'trip:remainder',
             'rating:availables',
+            'maintenance:tick',
             'trip:request',
             'trip:visibilityclean',
             'node:buildweights',

--- a/tests/Feature/Http/AdminMaintenanceApiTest.php
+++ b/tests/Feature/Http/AdminMaintenanceApiTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Carbon\Carbon;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\MaintenanceAuditLog;
+use STS\Models\MaintenanceSchedule;
+use STS\Models\MaintenanceState;
+use STS\Models\User;
+use STS\Services\Maintenance\MaintenanceStateService;
+use Tests\TestCase;
+
+class AdminMaintenanceApiTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(ThrottleRequests::class);
+    }
+
+    public function test_store_schedule_success_and_audits(): void
+    {
+        $admin = $this->admin();
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $payload = [
+            'starts_at' => '2026-06-01T10:00:00Z',
+            'ends_at' => '2026-06-01T12:00:00Z',
+            'message' => 'DB work',
+            'mode' => 'strict',
+        ];
+
+        $response = $this->postJson('api/admin/maintenance/schedules', $payload);
+        $response->assertCreated();
+        $this->assertDatabaseHas('maintenance_schedules', [
+            'message' => 'DB work',
+            'mode' => 'strict',
+        ]);
+
+        $this->assertTrue(
+            MaintenanceAuditLog::query()->where('action', 'schedule_create')->where('user_id', $admin->id)->exists()
+        );
+    }
+
+    public function test_store_rejects_overlap(): void
+    {
+        MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-06-01 10:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-06-01 11:00:00 UTC'),
+            'message' => 'First',
+            'mode' => 'strict',
+        ]);
+
+        $admin = $this->admin();
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/maintenance/schedules', [
+            'starts_at' => '2026-06-01T10:30:00Z',
+            'ends_at' => '2026-06-01T12:00:00Z',
+            'message' => 'Overlap',
+            'mode' => 'flexible',
+        ])->assertStatus(422)->assertJsonValidationErrors(['starts_at']);
+    }
+
+    public function test_adjacent_schedule_allowed(): void
+    {
+        MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-06-01 10:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-06-01 11:00:00 UTC'),
+            'message' => 'First',
+            'mode' => 'strict',
+        ]);
+
+        $admin = $this->admin();
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/maintenance/schedules', [
+            'starts_at' => '2026-06-01T11:00:00Z',
+            'ends_at' => '2026-06-01T12:00:00Z',
+            'message' => 'Second',
+            'mode' => 'strict',
+        ])->assertCreated();
+    }
+
+    public function test_cancel_schedule_sets_cancelled_at(): void
+    {
+        $schedule = MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-06-01 14:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-06-01 15:00:00 UTC'),
+            'message' => 'X',
+            'mode' => 'strict',
+        ]);
+
+        $admin = $this->admin();
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->deleteJson('api/admin/maintenance/schedules/'.$schedule->id)->assertOk();
+
+        $schedule->refresh();
+        $this->assertNotNull($schedule->cancelled_at);
+
+        $this->assertTrue(
+            MaintenanceAuditLog::query()->where('action', 'schedule_cancel')->where('user_id', $admin->id)->exists()
+        );
+    }
+
+    public function test_put_state_disables_maintenance(): void
+    {
+        app(MaintenanceStateService::class)->applyManualActive(true, 'strict', 'x', null, 'manual', null, null);
+
+        $admin = $this->admin();
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->putJson('api/admin/maintenance/state', ['active' => false])->assertOk();
+
+        $this->assertFalse(MaintenanceState::query()->find(1)->is_active);
+    }
+}

--- a/tests/Feature/Http/AuthControllerApiTest.php
+++ b/tests/Feature/Http/AuthControllerApiTest.php
@@ -76,6 +76,44 @@ class AuthControllerApiTest extends TestCase
         $this->assertArrayNotHasKey('banner_url', $response->json());
         $this->assertArrayNotHasKey('banner_image', $response->json());
         $this->assertArrayNotHasKey('identity_validation_new_users_date', $response->json());
+        $this->assertArrayHasKey('maintenance', $response->json());
+        $maintenance = $response->json('maintenance');
+        $this->assertFalse($maintenance['enabled']);
+        $this->assertNull($maintenance['mode']);
+        $this->assertNull($maintenance['message']);
+        $this->assertNull($maintenance['ends_at']);
+        $this->assertSame(config('carpoolear.maintenance_admin_path'), $maintenance['admin_path']);
+    }
+
+    public function test_get_config_reflects_active_maintenance_payload(): void
+    {
+        app(\STS\Services\Maintenance\MaintenanceStateService::class)->applyManualActive(
+            true,
+            'flexible',
+            'DB upgrade',
+            null,
+            'manual',
+            null,
+            null
+        );
+
+        $response = $this->getJson('api/config');
+
+        $response->assertOk();
+        $this->assertTrue($response->json('maintenance.enabled'));
+        $this->assertSame('flexible', $response->json('maintenance.mode'));
+        $this->assertSame('DB upgrade', $response->json('maintenance.message'));
+        $this->assertNull($response->json('maintenance.ends_at'));
+
+        app(\STS\Services\Maintenance\MaintenanceStateService::class)->applyManualActive(
+            false,
+            null,
+            null,
+            null,
+            'manual',
+            null,
+            null
+        );
     }
 
     public function test_get_config_uses_cordova_banner_urls_when_old_webview_headers_present(): void

--- a/tests/Feature/Http/AuthControllerApiTest.php
+++ b/tests/Feature/Http/AuthControllerApiTest.php
@@ -15,6 +15,7 @@ use STS\Jobs\SendPasswordResetEmail;
 use STS\Models\User;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
+use STS\Services\Maintenance\MaintenanceStateService;
 use Tests\TestCase;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Tymon\JWTAuth\Facades\JWTAuth;
@@ -87,7 +88,7 @@ class AuthControllerApiTest extends TestCase
 
     public function test_get_config_reflects_active_maintenance_payload(): void
     {
-        app(\STS\Services\Maintenance\MaintenanceStateService::class)->applyManualActive(
+        app(MaintenanceStateService::class)->applyManualActive(
             true,
             'flexible',
             'DB upgrade',
@@ -105,7 +106,7 @@ class AuthControllerApiTest extends TestCase
         $this->assertSame('DB upgrade', $response->json('maintenance.message'));
         $this->assertNull($response->json('maintenance.ends_at'));
 
-        app(\STS\Services\Maintenance\MaintenanceStateService::class)->applyManualActive(
+        app(MaintenanceStateService::class)->applyManualActive(
             false,
             null,
             null,

--- a/tests/Feature/Http/MaintenanceMiddlewareTest.php
+++ b/tests/Feature/Http/MaintenanceMiddlewareTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use STS\Models\User;
+use STS\Services\Logic\NotificationManager;
+use STS\Services\Maintenance\MaintenanceStateService;
+use Tests\TestCase;
+
+class MaintenanceMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(ThrottleRequests::class);
+
+        $this->mock(NotificationManager::class, function ($mock): void {
+            $mock->shouldReceive('getNotifications')->byDefault()->andReturn([]);
+            $mock->shouldReceive('getUnreadCount')->byDefault()->andReturn(0);
+            $mock->shouldReceive('delete')->byDefault()->andReturn(true);
+        });
+    }
+
+    private function makeAdmin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->save();
+
+        return $user->fresh();
+    }
+
+    public function test_strict_returns_503_for_logged_route_and_leaves_config_public(): void
+    {
+        app(MaintenanceStateService::class)->applyManualActive(true, 'strict', ' outage ', null, 'manual', null, null);
+
+        $user = User::factory()->create();
+        $this->actingAsApiUser($user);
+
+        $this->getJson('api/notifications')
+            ->assertStatus(503)
+            ->assertJson([
+                'maintenance' => true,
+                'enabled' => true,
+                'mode' => 'strict',
+                'message' => ' outage ',
+            ]);
+
+        $this->getJson('api/config')->assertOk()->assertJsonPath('maintenance.enabled', true);
+
+        app(MaintenanceStateService::class)->applyManualActive(false, null, null, null, 'manual', null, null);
+    }
+
+    public function test_flexible_allows_admin_through_logged_route(): void
+    {
+        app(MaintenanceStateService::class)->applyManualActive(true, 'flexible', 'warn', null, 'manual', null, null);
+
+        $admin = $this->makeAdmin();
+        $this->actingAsApiUser($admin);
+
+        $this->getJson('api/notifications')->assertOk();
+
+        app(MaintenanceStateService::class)->applyManualActive(false, null, null, null, 'manual', null, null);
+    }
+
+    public function test_flexible_blocks_non_admin_on_logged_route(): void
+    {
+        app(MaintenanceStateService::class)->applyManualActive(true, 'flexible', 'warn', null, 'manual', null, null);
+
+        $user = User::factory()->create();
+        $this->actingAsApiUser($user);
+
+        $this->getJson('api/notifications')->assertStatus(503);
+
+        app(MaintenanceStateService::class)->applyManualActive(false, null, null, null, 'manual', null, null);
+    }
+
+    public function test_strict_blocks_admin_on_logged_route(): void
+    {
+        app(MaintenanceStateService::class)->applyManualActive(true, 'strict', 'full', null, 'manual', null, null);
+
+        $admin = $this->makeAdmin();
+        $this->actingAsApiUser($admin);
+
+        $this->getJson('api/notifications')->assertStatus(503);
+
+        app(MaintenanceStateService::class)->applyManualActive(false, null, null, null, 'manual', null, null);
+    }
+}

--- a/tests/Feature/Services/MaintenanceStateServiceTest.php
+++ b/tests/Feature/Services/MaintenanceStateServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use Carbon\Carbon;
+use STS\Models\MaintenanceAuditLog;
+use STS\Models\MaintenanceSchedule;
+use STS\Models\MaintenanceState;
+use STS\Services\Maintenance\MaintenanceStateService;
+use Tests\TestCase;
+
+class MaintenanceStateServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_tick_activates_due_pending_schedule(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-10 12:00:00 UTC'));
+
+        MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-05-10 11:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-05-10 14:00:00 UTC'),
+            'message' => 'Planned work',
+            'mode' => 'strict',
+        ]);
+
+        $service = app(MaintenanceStateService::class);
+        $service->tick();
+
+        $state = MaintenanceState::query()->find(1);
+        $this->assertTrue($state->is_active);
+        $this->assertSame('strict', $state->mode);
+        $this->assertSame('Planned work', $state->message);
+        $this->assertSame('schedule', $state->source);
+
+        $this->assertDatabaseHas('maintenance_audit_logs', [
+            'action' => 'cron_activate',
+        ]);
+    }
+
+    public function test_tick_skips_cancelled_schedule(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-10 12:00:00 UTC'));
+
+        MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-05-10 11:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-05-10 14:00:00 UTC'),
+            'message' => 'Cancelled',
+            'mode' => 'strict',
+            'cancelled_at' => Carbon::parse('2026-05-10 10:00:00 UTC'),
+        ]);
+
+        app(MaintenanceStateService::class)->tick();
+
+        $this->assertFalse(MaintenanceState::query()->find(1)->is_active);
+    }
+
+    public function test_tick_deactivates_when_end_reached_and_marks_completed(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-10 12:00:00 UTC'));
+
+        $schedule = MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-05-10 11:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-05-10 12:30:00 UTC'),
+            'message' => 'Done soon',
+            'mode' => 'flexible',
+        ]);
+
+        MaintenanceState::query()->whereKey(1)->update([
+            'is_active' => true,
+            'mode' => 'flexible',
+            'message' => 'Done soon',
+            'ends_at' => $schedule->ends_at,
+            'source' => 'schedule',
+            'active_schedule_id' => $schedule->id,
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2026-05-10 12:31:00 UTC'));
+
+        app(MaintenanceStateService::class)->tick();
+
+        $state = MaintenanceState::query()->find(1);
+        $this->assertFalse($state->is_active);
+
+        $schedule->refresh();
+        $this->assertNotNull($schedule->completed_at);
+
+        $this->assertTrue(
+            MaintenanceAuditLog::query()->where('action', 'cron_deactivate')->exists()
+        );
+    }
+
+    public function test_overlaps_pending_schedule_detects_conflict(): void
+    {
+        MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-05-10 10:00:00 UTC'),
+            'ends_at' => Carbon::parse('2026-05-10 11:00:00 UTC'),
+            'message' => 'A',
+            'mode' => 'strict',
+        ]);
+
+        $this->assertSame(1, MaintenanceSchedule::query()->pending()->count());
+
+        $service = app(MaintenanceStateService::class);
+
+        $this->assertTrue($service->overlapsPendingSchedule(
+            Carbon::parse('2026-05-10 10:30:00 UTC'),
+            Carbon::parse('2026-05-10 12:00:00 UTC'),
+            null
+        ));
+
+        $this->assertFalse($service->overlapsPendingSchedule(
+            Carbon::parse('2026-05-10 11:00:00 UTC'),
+            Carbon::parse('2026-05-10 12:00:00 UTC'),
+            null
+        ));
+    }
+
+    public function test_manual_disable_cancels_active_linked_schedule(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-10 12:00:00 UTC'));
+
+        $schedule = MaintenanceSchedule::query()->create([
+            'starts_at' => Carbon::parse('2026-05-10 11:00:00 UTC'),
+            'ends_at' => null,
+            'message' => 'Live',
+            'mode' => 'flexible',
+        ]);
+
+        MaintenanceState::query()->whereKey(1)->update([
+            'is_active' => true,
+            'mode' => 'flexible',
+            'message' => 'Live',
+            'ends_at' => null,
+            'source' => 'schedule',
+            'active_schedule_id' => $schedule->id,
+        ]);
+
+        $service = app(MaintenanceStateService::class);
+        $service->applyManualActive(false, null, null, null, 'manual', null, 1);
+
+        $schedule->refresh();
+        $this->assertNotNull($schedule->cancelled_at);
+        $this->assertFalse(MaintenanceState::query()->find(1)->is_active);
+    }
+}

--- a/tests/Unit/Services/Maintenance/MaintenanceScheduleOverlapTest.php
+++ b/tests/Unit/Services/Maintenance/MaintenanceScheduleOverlapTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Services\Maintenance;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+use STS\Services\Maintenance\MaintenanceInterval;
+
+class MaintenanceScheduleOverlapTest extends TestCase
+{
+    public function test_adjacent_windows_do_not_overlap_half_open(): void
+    {
+        $aStart = Carbon::parse('2026-05-10 10:00:00 UTC');
+        $aEnd = Carbon::parse('2026-05-10 11:00:00 UTC');
+        $bStart = Carbon::parse('2026-05-10 11:00:00 UTC');
+        $bEnd = Carbon::parse('2026-05-10 12:00:00 UTC');
+
+        $this->assertFalse(MaintenanceInterval::overlap($aStart, $aEnd, $bStart, $bEnd));
+    }
+
+    public function test_overlapping_windows_detected(): void
+    {
+        $aStart = Carbon::parse('2026-05-10 10:00:00 UTC');
+        $aEnd = Carbon::parse('2026-05-10 11:30:00 UTC');
+        $bStart = Carbon::parse('2026-05-10 11:00:00 UTC');
+        $bEnd = Carbon::parse('2026-05-10 12:00:00 UTC');
+
+        $this->assertTrue(MaintenanceInterval::overlap($aStart, $aEnd, $bStart, $bEnd));
+    }
+
+    public function test_open_ended_overlaps_later_bounded_window(): void
+    {
+        $openStart = Carbon::parse('2026-05-10 10:00:00 UTC');
+        $boundedStart = Carbon::parse('2026-05-10 11:00:00 UTC');
+        $boundedEnd = Carbon::parse('2026-05-10 12:00:00 UTC');
+
+        $this->assertTrue(MaintenanceInterval::overlap($openStart, null, $boundedStart, $boundedEnd));
+    }
+
+    public function test_bounded_before_open_ended_start_does_not_overlap(): void
+    {
+        $boundedStart = Carbon::parse('2026-05-10 09:00:00 UTC');
+        $boundedEnd = Carbon::parse('2026-05-10 09:59:59 UTC');
+        $openStart = Carbon::parse('2026-05-10 10:00:00 UTC');
+
+        $this->assertFalse(MaintenanceInterval::overlap($boundedStart, $boundedEnd, $openStart, null));
+    }
+}


### PR DESCRIPTION
### Summary
Adds **scheduled and manual maintenance mode**: Laravel evaluates state on each request and exposes config to clients; admins manage schedules and overrides via API.

### Changes (high level)
- **Schema**: `maintenance_schedules`, `maintenance_state`, `maintenance_audit_logs` (plus casts/helpers as implemented).
- **Domain**: service to apply schedules vs manual state, overlap handling, audit trail.
- **Console**: `maintenance:tick` registered on the scheduler (e.g. every minute) to advance scheduled windows.
- **HTTP**: middleware blocks normal API use according to mode (**strict** vs **flexible**); allowlisted routes (auth, config, password recovery, etc.) unchanged.
- **Config API**: `_getConfig` (or equivalent) includes **`maintenance`** payload for the app gate/banner.
- **Admin API**: CRUD for schedules, manual toggle, audit listing under `api/admin/maintenance/*` (with auth/admin middleware).

### Verification
- `composer test` (`php artisan test`)