### PR TITLE
Admin ticket: add sender

### DIFF
--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -44,7 +44,10 @@ class SupportTicketController extends Controller
     public function index(): JsonResponse
     {
         return response()->json([
-            'data' => SupportTicket::orderByDesc('id')->get(),
+            'data' => SupportTicket::query()
+                ->with(['user:id,name'])
+                ->orderByDesc('id')
+                ->get(),
         ]);
     }
 

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -28,6 +28,14 @@ class SupportTicketController extends Controller
         ];
     }
 
+    /**
+     * @return list<string>
+     */
+    private static function ticketIndexRelationships(): array
+    {
+        return ['user:id,name'];
+    }
+
     private static function typeDefaultPriorities(): array
     {
         return [
@@ -45,7 +53,7 @@ class SupportTicketController extends Controller
     {
         return response()->json([
             'data' => SupportTicket::query()
-                ->with(['user:id,name'])
+                ->with(self::ticketIndexRelationships())
                 ->orderByDesc('id')
                 ->get(),
         ]);

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -64,6 +64,25 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertLessThan($olderIdx, $newerIdx, 'Higher-id ticket should appear before lower-id (descending order)');
     }
 
+    public function test_index_includes_ticket_owner_user_with_id_and_name(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create(['name' => 'Ticket Owner Person']);
+        $ticket = $this->makeTicket($owner);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $indexResponse = $this->getJson('api/admin/support/tickets')->assertOk();
+        $row = collect($indexResponse->json('data'))->firstWhere('id', $ticket->id);
+
+        $this->assertIsArray($row);
+        $this->assertArrayHasKey('user', $row);
+        $this->assertIsArray($row['user']);
+        $this->assertSame($owner->id, (int) $row['user']['id']);
+        $this->assertSame('Ticket Owner Person', $row['user']['name']);
+    }
+
     public function test_show_includes_user_ticket_attachments_and_reply_attachments(): void
     {
         $admin = $this->adminUser();


### PR DESCRIPTION

- **Admin support ticket index** (`GET api/admin/support/tickets`) now **eager-loads** the ticket owner as `user` with `id` and `name`, so each list row includes the same lightweight user payload as elsewhere.
- **Tests:** `AdminSupportTicketControllerIntegrationTest` asserts the index JSON includes `user.id` and `user.name` for a ticket.
- **Refactor:** `ticketIndexRelationships()` mirrors the existing `ticketDetailRelationships()` pattern on `SupportTicketController`.
