### PR TITLE
Private note in manual verifications

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -48,30 +48,36 @@ class ManualIdentityValidationController extends Controller
     {
         $item = ManualIdentityValidation::with('user:id,name,nro_doc', 'reviewedBy:id,name')->findOrFail($id);
 
+        return response()->json([
+            'data' => $this->buildShowPayload($item),
+        ]);
+    }
+
+    private function buildShowPayload(ManualIdentityValidation $item): array
+    {
+        $id = $item->id;
         $baseUrl = rtrim(config('app.url'), '/');
         $imageUrl = fn ($type) => $baseUrl.'/api/admin/manual-identity-validations/'.$id.'/image/'.$type;
 
-        return response()->json([
-            'data' => [
-                'id' => $item->id,
-                'user_id' => $item->user_id,
-                'user_name' => $item->user ? $item->user->name : null,
-                'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
-                'paid_at' => $item->paid_at ? $item->paid_at->toDateTimeString() : null,
-                'submitted_at' => $item->submitted_at ? $item->submitted_at->toDateTimeString() : null,
-                'paid' => $item->paid,
-                'review_status' => $item->review_status,
-                'review_note' => $item->review_note,
-                'private_admin_note' => $item->private_admin_note,
-                'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
-                'reviewed_by' => $item->reviewed_by,
-                'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
-                'front_image_url' => $item->front_image_path ? $imageUrl('front') : null,
-                'back_image_url' => $item->back_image_path ? $imageUrl('back') : null,
-                'selfie_image_url' => $item->selfie_image_path ? $imageUrl('selfie') : null,
-                'has_images' => $item->hasImages(),
-            ],
-        ]);
+        return [
+            'id' => $item->id,
+            'user_id' => $item->user_id,
+            'user_name' => $item->user ? $item->user->name : null,
+            'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
+            'paid_at' => $item->paid_at ? $item->paid_at->toDateTimeString() : null,
+            'submitted_at' => $item->submitted_at ? $item->submitted_at->toDateTimeString() : null,
+            'paid' => $item->paid,
+            'review_status' => $item->review_status,
+            'review_note' => $item->review_note,
+            'private_admin_note' => $item->private_admin_note,
+            'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
+            'reviewed_by' => $item->reviewed_by,
+            'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
+            'front_image_url' => $item->front_image_path ? $imageUrl('front') : null,
+            'back_image_url' => $item->back_image_path ? $imageUrl('back') : null,
+            'selfie_image_url' => $item->selfie_image_path ? $imageUrl('selfie') : null,
+            'has_images' => $item->hasImages(),
+        ];
     }
 
     /**
@@ -153,6 +159,9 @@ class ManualIdentityValidationController extends Controller
         return response()->json(['data' => $item->fresh(['user:id,name,nro_doc'])]);
     }
 
+    /**
+     * POST /api/admin/manual-identity-validations/{id}/private-note - set nullable private_admin_note (admin-only context).
+     */
     public function updatePrivateNote(Request $request, int $id): JsonResponse
     {
         $validated = $request->validate([

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -2,11 +2,11 @@
 
 namespace STS\Http\Controllers\Api\Admin;
 
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ManualIdentityValidationController extends Controller
@@ -49,7 +49,7 @@ class ManualIdentityValidationController extends Controller
         $item = ManualIdentityValidation::with('user:id,name,nro_doc', 'reviewedBy:id,name')->findOrFail($id);
 
         $baseUrl = rtrim(config('app.url'), '/');
-        $imageUrl = fn ($type) => $baseUrl . '/api/admin/manual-identity-validations/' . $id . '/image/' . $type;
+        $imageUrl = fn ($type) => $baseUrl.'/api/admin/manual-identity-validations/'.$id.'/image/'.$type;
 
         return response()->json([
             'data' => [
@@ -62,6 +62,7 @@ class ManualIdentityValidationController extends Controller
                 'paid' => $item->paid,
                 'review_status' => $item->review_status,
                 'review_note' => $item->review_note,
+                'private_admin_note' => $item->private_admin_note,
                 'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
                 'reviewed_by' => $item->reviewed_by,
                 'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
@@ -79,7 +80,7 @@ class ManualIdentityValidationController extends Controller
     public function image(int $id, string $type): StreamedResponse|JsonResponse
     {
         $allowed = ['front', 'back', 'selfie'];
-        if (!in_array($type, $allowed, true)) {
+        if (! in_array($type, $allowed, true)) {
             return response()->json(['error' => 'Invalid image type'], 404);
         }
 
@@ -87,11 +88,12 @@ class ManualIdentityValidationController extends Controller
         $pathColumn = $type === 'front' ? 'front_image_path' : ($type === 'back' ? 'back_image_path' : 'selfie_image_path');
         $path = $item->$pathColumn;
 
-        if (!$path || !Storage::disk('local')->exists($path)) {
+        if (! $path || ! Storage::disk('local')->exists($path)) {
             return response()->json(['error' => 'Image not found'], 404);
         }
 
         $mime = Storage::disk('local')->mimeType($path) ?: 'image/jpeg';
+
         return response()->stream(function () use ($path) {
             $stream = Storage::disk('local')->readStream($path);
             if ($stream) {
@@ -116,7 +118,7 @@ class ManualIdentityValidationController extends Controller
 
         $item = ManualIdentityValidation::with('user')->findOrFail($id);
 
-        if (!$item->paid) {
+        if (! $item->paid) {
             return response()->json(['error' => 'Unpaid request cannot be reviewed'], 422);
         }
 
@@ -149,6 +151,19 @@ class ManualIdentityValidationController extends Controller
         }
 
         return response()->json(['data' => $item->fresh(['user:id,name,nro_doc'])]);
+    }
+
+    public function updatePrivateNote(Request $request, int $id): JsonResponse
+    {
+        $validated = $request->validate([
+            'private_admin_note' => 'nullable|string',
+        ]);
+
+        $item = ManualIdentityValidation::findOrFail($id);
+        $item->private_admin_note = $validated['private_admin_note'] ?? null;
+        $item->save();
+
+        return $this->show($id);
     }
 
     /**

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -10,7 +10,9 @@ class ManualIdentityValidation extends Model
     protected $table = 'manual_identity_validations';
 
     const REVIEW_STATUS_PENDING = 'pending';
+
     const REVIEW_STATUS_APPROVED = 'approved';
+
     const REVIEW_STATUS_REJECTED = 'rejected';
 
     protected $fillable = [
@@ -26,6 +28,7 @@ class ManualIdentityValidation extends Model
         'reviewed_by',
         'reviewed_at',
         'review_note',
+        'private_admin_note',
         'manual_validation_started_at',
     ];
 
@@ -52,6 +55,6 @@ class ManualIdentityValidation extends Model
 
     public function hasImages(): bool
     {
-        return !empty($this->front_image_path) || !empty($this->back_image_path) || !empty($this->selfie_image_path);
+        return ! empty($this->front_image_path) || ! empty($this->back_image_path) || ! empty($this->selfie_image_path);
     }
 }

--- a/database/migrations/2026_05_11_120000_add_private_admin_note_to_manual_identity_validations.php
+++ b/database/migrations/2026_05_11_120000_add_private_admin_note_to_manual_identity_validations.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->text('private_admin_note')->nullable()->after('review_note');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->dropColumn('private_admin_note');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -232,6 +232,7 @@ Route::middleware(['api'])->group(function () {
         Route::get('manual-identity-validations/{id}/image/{type}', [AdminManualIdentityValidationController::class, 'image'])->where('type', 'front|back|selfie');
         Route::get('manual-identity-validations/{id}', [AdminManualIdentityValidationController::class, 'show']);
         Route::post('manual-identity-validations/{id}/review', [AdminManualIdentityValidationController::class, 'review']);
+        Route::post('manual-identity-validations/{id}/private-note', [AdminManualIdentityValidationController::class, 'updatePrivateNote']);
         Route::post('manual-identity-validations/{id}/purge', [AdminManualIdentityValidationController::class, 'purge']);
 
         Route::prefix('maintenance')->group(function () {

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -244,4 +244,26 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
         $this->assertNull($fresh->front_image_path);
     }
+
+    public function test_private_note_endpoint_updates_field_and_show_returns_it(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/private-note', [
+            'private_admin_note' => 'Internal follow-up next week.',
+        ])->assertOk()->assertJsonPath('data.private_admin_note', 'Internal follow-up next week.');
+
+        $show = $this->getJson('api/admin/manual-identity-validations/'.$row->id)->assertOk();
+        $this->assertSame('Internal follow-up next week.', $show->json('data.private_admin_note'));
+    }
 }


### PR DESCRIPTION
- Adds nullable `private_admin_note` on `manual_identity_validations` (migration + model `fillable`).
- Exposes `private_admin_note` on `GET /api/admin/manual-identity-validations/{id}`.
- Adds `POST /api/admin/manual-identity-validations/{id}/private-note` with body `{ "private_admin_note": "<string|null>" }`, same pattern as Mercado Pago rejected validations.
- Refactors admin `show` payload into `buildShowPayload()` for clarity.

**Deploy:** run `php artisan migrate`.