### PR TITLE
Require complete profile for trip creation

### DIFF
--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -76,12 +76,29 @@ class TripsManager extends BaseManager
 
     public function create($user, array $data)
     {
+        $this->assignDriverCarWhenPossible($user, $data);
         $v = $this->validator($data, $user->id);
         if ($v->fails()) {
             $this->setErrors($v->errors());
 
             return;
         } else {
+            if (! $this->userHasRequiredProfileFields($user)) {
+                $messageBag = new MessageBag;
+                $messageBag->add('profile_required', 'The user profile must be complete.');
+                $this->setErrors($messageBag);
+
+                return;
+            }
+
+            if ($this->isDriverTrip($data) && ! $this->driverTripHasPlate($user, $data)) {
+                $messageBag = new MessageBag;
+                $messageBag->add('car_id', 'The driver must have a car with a plate.');
+                $this->setErrors($messageBag);
+
+                return;
+            }
+
             if (config('carpoolear.module_validated_drivers', false) && ! $user->driver_is_verified && $data['is_passenger'] == 0) {
                 $messageBag = new MessageBag;
                 $messageBag->add('driver_is_verified', 'The driver must be verified.');
@@ -169,6 +186,59 @@ class TripsManager extends BaseManager
 
             return $trip;
         }
+    }
+
+    private function assignDriverCarWhenPossible($user, array &$data): void
+    {
+        if (! $this->isDriverTrip($data) || ! empty($data['car_id'])) {
+            return;
+        }
+
+        $car = $this->firstUserCarWithPlate($user);
+        if ($car) {
+            $data['car_id'] = $car->id;
+        }
+    }
+
+    private function isDriverTrip(array $data): bool
+    {
+        return array_key_exists('is_passenger', $data) && (string) $data['is_passenger'] === '0';
+    }
+
+    private function userHasRequiredProfileFields($user): bool
+    {
+        foreach (['image', 'description', 'nro_doc', 'mobile_phone'] as $field) {
+            if (! $this->hasValue($user->{$field} ?? null)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function driverTripHasPlate($user, array $data): bool
+    {
+        if (! empty($data['car_id'])) {
+            $car = $user->cars()->whereKey($data['car_id'])->first();
+
+            return $car && $this->hasValue($car->patente);
+        }
+
+        return (bool) $this->firstUserCarWithPlate($user);
+    }
+
+    private function firstUserCarWithPlate($user)
+    {
+        return $user->cars()
+            ->get()
+            ->first(function ($car) {
+                return $this->hasValue($car->patente);
+            });
+    }
+
+    private function hasValue($value): bool
+    {
+        return $value !== null && trim((string) $value) !== '';
     }
 
     public function update($user, $trip_id, array $data)

--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use STS\Helpers\IdentityValidationHelper;
+use STS\Models\Car;
 use STS\Models\NodeGeo;
 use STS\Models\Passenger;
 use STS\Models\RouteCache;
@@ -231,12 +232,101 @@ class TripControllerIntegrationTest extends TestCase
     public function test_create_returns_unprocessable_when_validation_fails(): void
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
-        $user = User::factory()->create(['identity_validated' => true]);
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ]);
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'OK123',
+        ]);
 
         $this->actingAs($user, 'api')
             ->postJson('/api/trips', [])
             ->assertUnprocessable()
             ->assertJsonPath('message', 'Could not create new trip.');
+
+        Carbon::setTestNow();
+    }
+
+    public function test_create_returns_unprocessable_when_required_profile_fields_are_missing(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $this->seedRouteCacheForMinimalCreatePoints();
+        Http::fake();
+
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => null,
+            'mobile_phone' => null,
+        ]);
+
+        $this->actingAs($user, 'api')
+            ->postJson('/api/trips', array_merge($this->minimalCreatePayload(), [
+                'is_passenger' => 1,
+            ]))
+            ->assertUnprocessable()
+            ->assertJsonPath('message', 'Could not create new trip.')
+            ->assertJsonPath('errors.profile_required.0', 'The user profile must be complete.');
+
+        Carbon::setTestNow();
+    }
+
+    public function test_create_returns_unprocessable_when_driver_has_no_plate(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $this->seedRouteCacheForMinimalCreatePoints();
+        Http::fake();
+
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ]);
+
+        $this->actingAs($user, 'api')
+            ->postJson('/api/trips', $this->minimalCreatePayload())
+            ->assertUnprocessable()
+            ->assertJsonPath('message', 'Could not create new trip.')
+            ->assertJsonPath('errors.car_id.0', 'The driver must have a car with a plate.');
+
+        Carbon::setTestNow();
+    }
+
+    public function test_create_driver_trip_uses_existing_car_plate_when_car_id_is_omitted(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $this->seedRouteCacheForMinimalCreatePoints();
+        Http::fake();
+
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ]);
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'ABC123',
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/trips', $this->minimalCreatePayload());
+
+        $response->assertOk();
+        $this->assertDatabaseHas('trips', [
+            'id' => (int) $response->json('data.id'),
+            'user_id' => $user->id,
+            'car_id' => $car->id,
+        ]);
 
         Carbon::setTestNow();
     }
@@ -247,7 +337,17 @@ class TripControllerIntegrationTest extends TestCase
         $this->seedRouteCacheForMinimalCreatePoints();
         Http::fake();
 
-        $user = User::factory()->create(['identity_validated' => true]);
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ]);
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'OK123',
+        ]);
 
         $response = $this->actingAs($user, 'api')
             ->postJson('/api/trips', $this->minimalCreatePayload());

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -118,6 +118,7 @@ class ManualIdentityValidationTest extends TestCase
             'reviewed_by',
             'reviewed_at',
             'review_note',
+            'private_admin_note',
             'manual_validation_started_at',
         ], (new ManualIdentityValidation)->getFillable());
     }

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -67,6 +67,24 @@ class TripsManagerTest extends TestCase
         ], $overrides);
     }
 
+    private function completeUser(array $overrides = []): User
+    {
+        return User::factory()->create(array_merge([
+            'description' => 'Completed test profile',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ], $overrides));
+    }
+
+    private function carWithPlateFor(User $user, array $overrides = []): Car
+    {
+        return Car::factory()->create(array_merge([
+            'user_id' => $user->id,
+            'patente' => 'ABC123',
+        ], $overrides));
+    }
+
     public function test_validator_create_requires_core_fields(): void
     {
         Carbon::setTestNow('2028-01-01 12:00:00');
@@ -164,7 +182,8 @@ class TripsManagerTest extends TestCase
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
         config(['carpoolear.module_validated_drivers' => true]);
-        $user = User::factory()->create(['driver_is_verified' => false]);
+        $user = $this->completeUser(['driver_is_verified' => false]);
+        $this->carWithPlateFor($user);
         $manager = $this->manager();
 
         $result = $manager->create($user, $this->minimalCreatePayload([
@@ -183,7 +202,8 @@ class TripsManagerTest extends TestCase
             'carpoolear.trip_creation_limits.max_trips' => 0,
             'carpoolear.trip_creation_limits.time_window_hours' => 24,
         ]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
         Trip::factory()->create([
             'user_id' => $user->id,
             'trip_date' => Carbon::now()->addDays(1),
@@ -203,7 +223,8 @@ class TripsManagerTest extends TestCase
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
         config(['carpoolear.banned_words_trip_description' => ['whatsapp']]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
         $manager = $this->manager();
 
         $result = $manager->create($user, $this->minimalCreatePayload([
@@ -220,7 +241,8 @@ class TripsManagerTest extends TestCase
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
         config(['carpoolear.banned_phones' => ['1234567890']]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
         $manager = $this->manager();
 
         $result = $manager->create($user, $this->minimalCreatePayload([
@@ -430,7 +452,8 @@ class TripsManagerTest extends TestCase
     public function test_create_aborts_when_get_trip_info_returns_routing_service_unavailable(): void
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
 
         $repo = Mockery::mock(TripRepository::class);
         $repo->shouldReceive('getRecentTrips')->once()->with($user->id, 24)->andReturn(collect([]));
@@ -481,7 +504,8 @@ class TripsManagerTest extends TestCase
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
         config(['carpoolear.module_validated_drivers' => true]);
-        $user = User::factory()->create(['driver_is_verified' => false]);
+        $user = $this->completeUser(['driver_is_verified' => false]);
+        $this->carWithPlateFor($user);
         $manager = $this->manager();
 
         $payload = $this->minimalCreatePayload(['is_passenger' => '0']);
@@ -499,7 +523,8 @@ class TripsManagerTest extends TestCase
             'carpoolear.trip_creation_limits.max_trips' => 2,
             'carpoolear.trip_creation_limits.time_window_hours' => 24,
         ]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
 
         $repo = Mockery::mock(TripRepository::class);
         $repo->shouldReceive('getRecentTrips')->once()->with($user->id, 24)->andReturn(collect([1, 2]));
@@ -531,7 +556,8 @@ class TripsManagerTest extends TestCase
             'carpoolear.trip_creation_limits.max_trips' => 2,
             'carpoolear.trip_creation_limits.time_window_hours' => 24,
         ]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
 
         $repo = Mockery::mock(TripRepository::class);
         $repo->shouldReceive('getRecentTrips')->once()->with($user->id, 24)->andReturn(collect([1, 2, 3]));
@@ -554,7 +580,8 @@ class TripsManagerTest extends TestCase
             'carpoolear.trip_creation_limits.max_trips' => 1,
             'carpoolear.trip_creation_limits.time_window_hours' => 24,
         ]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
 
         $repo = Mockery::mock(TripRepository::class);
         $repo->shouldReceive('getRecentTrips')->andReturn(collect([1, 2]));
@@ -591,7 +618,8 @@ class TripsManagerTest extends TestCase
 
         Carbon::setTestNow('2028-02-01 10:00:00');
         config(['carpoolear.banned_words_trip_description' => ['WhatsApp']]);
-        $user = User::factory()->create(['banned' => 0]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
         $manager = $this->manager();
 
         $result = $manager->create($user, $this->minimalCreatePayload([
@@ -623,8 +651,8 @@ class TripsManagerTest extends TestCase
 
         Carbon::setTestNow('2028-02-01 10:00:00');
         Event::fake([CreateEvent::class]);
-        $user = User::factory()->create();
-        $car = Car::factory()->create(['user_id' => $user->id]);
+        $user = $this->completeUser();
+        $car = $this->carWithPlateFor($user);
         $manager = $this->manager();
 
         $parent = $manager->create($user, $this->minimalCreatePayload([

--- a/tests/Unit/TripsTest.php
+++ b/tests/Unit/TripsTest.php
@@ -43,7 +43,12 @@ class TripsTest extends TestCase
             Event::fake();
             Carbon::setTestNow('2026-01-01 12:00:00');
 
-            $user = User::factory()->create();
+            $user = User::factory()->create([
+                'description' => 'Completed test profile',
+                'image' => 'profile.jpg',
+                'nro_doc' => '30111222',
+                'mobile_phone' => '+5493415551234',
+            ]);
             $car = \STS\Models\Car::factory()->create(['user_id' => $user->id]);
             $tripManager = \App::make(\STS\Services\Logic\TripsManager::class);
 


### PR DESCRIPTION
### Backend
- Enforce complete profile fields before trip creation.
- Require driver trips to use a car with a non-empty plate, including direct API requests.
- Auto-assign the user’s saved plated car when `car_id` is omitted.
- Updated backend tests and fixtures for the new trip creation requirements.
