### PR TITLE
Leave user notification fix

### DIFF
--- a/app/Notifications/CancelPassengerNotification.php
+++ b/app/Notifications/CancelPassengerNotification.php
@@ -2,21 +2,21 @@
 
 namespace STS\Notifications;
 
-use  STS\Services\Notifications\BaseNotification;
-use  STS\Services\Notifications\Channels\MailChannel;
-use  STS\Services\Notifications\Channels\PushChannel;
-use  STS\Services\Notifications\Channels\DatabaseChannel;
-use  STS\Services\Notifications\Channels\FacebookChannel;
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\FacebookChannel;
+use STS\Services\Notifications\Channels\MailChannel;
+use STS\Services\Notifications\Channels\PushChannel;
 
 class CancelPassengerNotification extends BaseNotification
 {
     protected $via = [
-        DatabaseChannel::class, 
-        MailChannel::class, 
-        PushChannel::class, 
+        DatabaseChannel::class,
+        MailChannel::class,
+        PushChannel::class,
         // FacebookChannel::class
     ];
-    
+
     public function toEmail($user)
     {
         $trip = $this->getAttribute('trip');
@@ -32,7 +32,7 @@ class CancelPassengerNotification extends BaseNotification
             'email_view' => 'cancel_passenger',
             'url' => config('app.url').'/app/trips/'.($trip ? $trip->id : ''),
             'name_app' => config('carpoolear.name_app'),
-            'domain' => config('app.url')
+            'domain' => config('app.url'),
         ];
     }
 
@@ -41,6 +41,7 @@ class CancelPassengerNotification extends BaseNotification
         $from = $this->getAttribute('from');
         $isDriver = $this->getAttribute('is_driver');
         $senderName = $from ? $from->name : __('notifications.someone');
+
         return $isDriver
             ? __('notifications.cancel_passenger.driver_removed', ['name' => $senderName])
             : __('notifications.cancel_passenger.passenger_left', ['name' => $senderName]);
@@ -49,8 +50,10 @@ class CancelPassengerNotification extends BaseNotification
     public function getExtras()
     {
         $trip = $this->getAttribute('trip');
+        $isDriver = $this->getAttribute('is_driver');
+
         return [
-            'type' => 'trip',
+            'type' => $isDriver ? 'trip' : 'my-trips',
             'trip_id' => $trip ? $trip->id : null,
         ];
     }
@@ -67,7 +70,7 @@ class CancelPassengerNotification extends BaseNotification
 
         return [
             'message' => $message,
-            'url' => '/trips/'.($trip ? $trip->id : ''),
+            'url' => $isDriver ? '/trips/'.($trip ? $trip->id : '') : '/my-trips',
             'extras' => [
                 'id' => $trip ? $trip->id : null,
             ],

--- a/app/Notifications/CancelPassengerNotification.php
+++ b/app/Notifications/CancelPassengerNotification.php
@@ -20,15 +20,9 @@ class CancelPassengerNotification extends BaseNotification
     public function toEmail($user)
     {
         $trip = $this->getAttribute('trip');
-        $from = $this->getAttribute('from');
-        $isDriver = $this->getAttribute('is_driver');
-        $senderName = $from ? $from->name : __('notifications.someone');
-        $title = $isDriver
-            ? __('notifications.cancel_passenger.driver_removed', ['name' => $senderName])
-            : __('notifications.cancel_passenger.passenger_left', ['name' => $senderName]);
 
         return [
-            'title' => $title,
+            'title' => $this->message(),
             'email_view' => 'cancel_passenger',
             'url' => config('app.url').'/app/trips/'.($trip ? $trip->id : ''),
             'name_app' => config('carpoolear.name_app'),
@@ -38,13 +32,7 @@ class CancelPassengerNotification extends BaseNotification
 
     public function toString()
     {
-        $from = $this->getAttribute('from');
-        $isDriver = $this->getAttribute('is_driver');
-        $senderName = $from ? $from->name : __('notifications.someone');
-
-        return $isDriver
-            ? __('notifications.cancel_passenger.driver_removed', ['name' => $senderName])
-            : __('notifications.cancel_passenger.passenger_left', ['name' => $senderName]);
+        return $this->message();
     }
 
     public function getExtras()
@@ -61,20 +49,25 @@ class CancelPassengerNotification extends BaseNotification
     public function toPush($user, $device)
     {
         $trip = $this->getAttribute('trip');
-        $from = $this->getAttribute('from');
         $isDriver = $this->getAttribute('is_driver');
-        $senderName = $from ? $from->name : __('notifications.someone');
-        $message = $isDriver
-            ? __('notifications.cancel_passenger.driver_removed', ['name' => $senderName])
-            : __('notifications.cancel_passenger.passenger_left', ['name' => $senderName]);
 
         return [
-            'message' => $message,
+            'message' => $this->message(),
             'url' => $isDriver ? '/trips/'.($trip ? $trip->id : '') : '/my-trips',
             'extras' => [
                 'id' => $trip ? $trip->id : null,
             ],
             'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
         ];
+    }
+
+    private function message(): string
+    {
+        $from = $this->getAttribute('from');
+        $senderName = $from ? $from->name : __('notifications.someone');
+
+        return $this->getAttribute('is_driver')
+            ? __('notifications.cancel_passenger.driver_removed', ['name' => $senderName])
+            : __('notifications.cancel_passenger.passenger_left', ['name' => $senderName]);
     }
 }

--- a/tests/Unit/Notifications/CancelPassengerNotificationTest.php
+++ b/tests/Unit/Notifications/CancelPassengerNotificationTest.php
@@ -96,9 +96,9 @@ class CancelPassengerNotificationTest extends TestCase
 
         $this->assertSame($expected, $email['title']);
         $this->assertSame('https://app.test/app/trips/', $email['url']);
-        $this->assertSame('trip', $extras['type']);
+        $this->assertSame('my-trips', $extras['type']);
         $this->assertNull($extras['trip_id']);
-        $this->assertSame('/trips/', $push['url']);
+        $this->assertSame('/my-trips', $push['url']);
         $this->assertNull($push['extras']['id']);
         $this->assertSame('https://carpoolear.com.ar/app/static/img/carpoolear_logo.png', $push['image']);
     }

--- a/tests/Unit/Notifications/CancelPassengerNotificationTest.php
+++ b/tests/Unit/Notifications/CancelPassengerNotificationTest.php
@@ -65,6 +65,23 @@ class CancelPassengerNotificationTest extends TestCase
         $this->assertSame($expected, $notification->toPush(null, null)['message']);
     }
 
+    public function test_passenger_left_push_points_driver_to_my_trips(): void
+    {
+        $from = User::factory()->create(['name' => 'Passenger B']);
+        $trip = Trip::factory()->create();
+        $notification = new CancelPassengerNotification;
+        $notification->setAttribute('from', $from);
+        $notification->setAttribute('trip', $trip);
+        $notification->setAttribute('is_driver', false);
+
+        $push = $notification->toPush(null, null);
+        $extras = $notification->getExtras();
+
+        $this->assertSame('/my-trips', $push['url']);
+        $this->assertSame('my-trips', $extras['type']);
+        $this->assertSame($trip->id, $extras['trip_id']);
+    }
+
     public function test_fallbacks_apply_when_sender_and_trip_are_missing(): void
     {
         config(['app.url' => 'https://app.test']);

--- a/tests/Unit/Services/Logic/PassengersManagerTest.php
+++ b/tests/Unit/Services/Logic/PassengersManagerTest.php
@@ -15,7 +15,9 @@ use STS\Events\Passenger\Request as RequestEvent;
 use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\User;
+use STS\Notifications\CancelPassengerNotification;
 use STS\Services\Logic\PassengersManager;
+use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
 
 class PassengersManagerTest extends TestCase
@@ -287,6 +289,32 @@ class PassengersManagerTest extends TestCase
         $this->manager()->cancelRequest($trip->id, (string) $passenger->id, $passenger, []);
 
         Event::assertDispatched(CancelEvent::class);
+        $this->assertSame(Passenger::STATE_CANCELED, (int) Passenger::where('trip_id', $trip->id)->where('user_id', $passenger->id)->value('request_state'));
+    }
+
+    public function test_cancel_request_passenger_self_cancel_notifies_driver(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $passenger = User::factory()->create();
+        Passenger::factory()->aceptado()->create(['trip_id' => $trip->id, 'user_id' => $passenger->id]);
+
+        $this->mock(NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(3)
+            ->withArgs(function ($notification, $users, $channel) use ($trip, $passenger, $driver) {
+                return $notification instanceof CancelPassengerNotification
+                    && $notification->getAttribute('trip')->is($trip)
+                    && $notification->getAttribute('from')->is($passenger)
+                    && $notification->getAttribute('is_driver') === false
+                    && $notification->getAttribute('canceledState') === Passenger::CANCELED_PASSENGER
+                    && $users instanceof User
+                    && $users->is($driver)
+                    && is_string($channel);
+            });
+
+        $this->manager()->cancelRequest($trip->id, $passenger->id, $passenger, []);
+
         $this->assertSame(Passenger::STATE_CANCELED, (int) Passenger::where('trip_id', $trip->id)->where('user_id', $passenger->id)->value('request_state'));
     }
 


### PR DESCRIPTION
### Backend
- Added coverage for passenger self-cancel flow to ensure the driver is notified when a passenger leaves a trip.
- Updated passenger-left push notification payloads to route drivers to `/my-trips`.
- Kept cancel passenger notifications using database, mail, and push channels.

Closes https://github.com/STS-Rosario/carpoolear_backend/issues/163
