### PR TITLE
Seats warning

### DIFF
--- a/app/Helpers/OldCordovaAppHelper.php
+++ b/app/Helpers/OldCordovaAppHelper.php
@@ -83,6 +83,7 @@ class OldCordovaAppHelper
             'allow_kids' => false,
             'allow_animals' => false,
             'allow_smoking' => false,
+            'rear_max_two_passengers' => false,
             'payment_id' => null,
             'needs_sellado' => false,
             'request' => '',

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -95,6 +95,7 @@ class Trip extends Model
             'allow_smoking',
             'allow_kids',
             'allow_animals',
+            'rear_max_two_passengers',
             'state',
             'payment_id',
             'needs_sellado',

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -46,6 +46,7 @@ class TripTransformer extends TransformerAbstract
             'allow_kids' => $trip->allow_kids,
             'allow_animals' => $trip->allow_animals,
             'allow_smoking' => $trip->allow_smoking,
+            'rear_max_two_passengers' => $trip->rear_max_two_passengers,
             'payment_id' => $trip->payment_id,
             'needs_sellado' => $trip->needs_sellado,
         ];

--- a/database/factories/TripFactory.php
+++ b/database/factories/TripFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use STS\Models\Trip;
 use STS\Models\User;
 
 /**
@@ -22,18 +21,19 @@ class TripFactory extends Factory
     public function definition(): array
     {
         return [
-            'is_passenger'       => 0,
-            'from_town'          => fake()->streetAddress(),
-            'to_town'            => fake()->streetAddress(),
-            'trip_date'          => Carbon::now()->addHour(),
-            'total_seats'        => 5,
+            'is_passenger' => 0,
+            'from_town' => fake()->streetAddress(),
+            'to_town' => fake()->streetAddress(),
+            'trip_date' => Carbon::now()->addHour(),
+            'total_seats' => 5,
             'friendship_type_id' => 2,
-            'estimated_time'     => '05:00',
-            'distance'           => 365,
-            'co2'                => 50,
-            'description'        => 'hola mundo',
-            'mail_send'          => false,
-            'user_id'            => User::factory(),
+            'estimated_time' => '05:00',
+            'distance' => 365,
+            'co2' => 50,
+            'description' => 'hola mundo',
+            'mail_send' => false,
+            'rear_max_two_passengers' => false,
+            'user_id' => User::factory(),
         ];
     }
 }

--- a/database/migrations/2026_05_27_120000_add_rear_max_two_passengers_to_trips_table.php
+++ b/database/migrations/2026_05_27_120000_add_rear_max_two_passengers_to_trips_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->boolean('rear_max_two_passengers')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn('rear_max_two_passengers');
+        });
+    }
+};

--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -363,6 +363,65 @@ class TripControllerIntegrationTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_create_persists_rear_max_two_passengers_and_returns_it_in_payload(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $this->seedRouteCacheForMinimalCreatePoints();
+        Http::fake();
+
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ]);
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'OK123',
+        ]);
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/trips', array_merge($this->minimalCreatePayload(), [
+                'rear_max_two_passengers' => 1,
+            ]));
+
+        $response->assertOk()
+            ->assertJsonPath('data.rear_max_two_passengers', 1);
+
+        $tripId = (int) $response->json('data.id');
+        $this->assertDatabaseHas('trips', [
+            'id' => $tripId,
+            'rear_max_two_passengers' => 1,
+        ]);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_update_persists_rear_max_two_passengers_and_returns_it_in_payload(): void
+    {
+        Carbon::setTestNow('2028-04-01 12:00:00');
+        $owner = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $owner->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::parse('2028-05-15 10:00:00'),
+            'rear_max_two_passengers' => false,
+        ]);
+
+        $this->actingAs($owner, 'api')
+            ->putJson("/api/trips/{$trip->id}", ['rear_max_two_passengers' => 1])
+            ->assertOk()
+            ->assertJsonPath('data.rear_max_two_passengers', 1);
+
+        $this->assertDatabaseHas('trips', [
+            'id' => $trip->id,
+            'rear_max_two_passengers' => 1,
+        ]);
+
+        Carbon::setTestNow();
+    }
+
     public function test_update_returns_trip_payload_when_owner_updates_description(): void
     {
         Carbon::setTestNow('2028-04-01 12:00:00');

--- a/tests/Unit/Helpers/OldCordovaAppHelperTest.php
+++ b/tests/Unit/Helpers/OldCordovaAppHelperTest.php
@@ -113,6 +113,7 @@ class OldCordovaAppHelperTest extends TestCase
         $this->assertFalse($data['allow_kids']);
         $this->assertFalse($data['allow_animals']);
         $this->assertFalse($data['allow_smoking']);
+        $this->assertFalse($data['rear_max_two_passengers']);
         $this->assertFalse($data['needs_sellado']);
 
         $user = $data['user'];
@@ -141,7 +142,7 @@ class OldCordovaAppHelperTest extends TestCase
             'description', 'total_seats', 'friendship_type_id', 'distance', 'estimated_time',
             'seat_price_cents', 'recommended_trip_price_cents', 'total_price', 'state', 'is_passenger',
             'passenger_count', 'seats_available', 'points', 'ratings', 'updated_at', 'allow_kids',
-            'allow_animals', 'allow_smoking', 'payment_id', 'needs_sellado', 'request', 'passenger',
+            'allow_animals', 'allow_smoking', 'rear_max_two_passengers', 'payment_id', 'needs_sellado', 'request', 'passenger',
             'user', 'passengerPending_count',
         ];
         foreach ($expectedTopLevel as $key) {

--- a/tests/Unit/Models/TripTest.php
+++ b/tests/Unit/Models/TripTest.php
@@ -62,6 +62,7 @@ class TripTest extends TestCase
             'allow_smoking',
             'allow_kids',
             'allow_animals',
+            'rear_max_two_passengers',
             'state',
             'payment_id',
             'needs_sellado',

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -97,7 +97,7 @@ class TripTransformerTest extends TestCase
 
         $payload = (new TripTransformer(null))->transform($trip->fresh());
 
-        $this->assertTrue($payload['rear_max_two_passengers']);
+        $this->assertSame(1, $payload['rear_max_two_passengers']);
     }
 
     public function test_transform_marks_sellado_pending_when_needed_and_not_ready(): void

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -71,6 +71,7 @@ class TripTransformerTest extends TestCase
             'allow_kids',
             'allow_animals',
             'allow_smoking',
+            'rear_max_two_passengers',
             'payment_id',
             'needs_sellado',
             'sellado_pending',
@@ -88,6 +89,15 @@ class TripTransformerTest extends TestCase
         $this->assertNull($payload['sellado_pending_label']);
         $this->assertSame('', $payload['request']);
         $this->assertSame([], $payload['passenger']);
+    }
+
+    public function test_transform_includes_rear_max_two_passengers(): void
+    {
+        $trip = $this->makeTrip(['rear_max_two_passengers' => true]);
+
+        $payload = (new TripTransformer(null))->transform($trip->fresh());
+
+        $this->assertTrue($payload['rear_max_two_passengers']);
     }
 
     public function test_transform_marks_sellado_pending_when_needed_and_not_ready(): void


### PR DESCRIPTION
- Adds `rear_max_two_passengers` boolean column on `trips` (default `false`).
- Field is mass-assignable on **create/update** and returned in trip API payloads via `TripTransformer`.
- Factory, legacy Cordova helper, and tests updated for parity.
- Integration tests cover create/update persistence and API response.
