### PR TITLE
Profile trip tweaks

### DIFF
--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -350,7 +350,7 @@ class TripRepository
             }); */
             $trips->join('trip_passengers', 'trips.id', '=', 'trip_passengers.trip_id');
             $trips->whereNull('trips.deleted_at');
-            $trips->where('trip_passengers.user_id', $user->id);
+            $trips->where('trip_passengers.user_id', $userId);
             $trips->where('trip_passengers.request_state', Passenger::STATE_ACCEPTED);
         }
 
@@ -376,7 +376,7 @@ class TripRepository
             }); */
             $trips->join('trip_passengers', 'trips.id', '=', 'trip_passengers.trip_id');
             $trips->whereNull('trips.deleted_at');
-            $trips->where('trip_passengers.user_id', $user->id);
+            $trips->where('trip_passengers.user_id', $userId);
             $trips->where('trip_passengers.request_state', Passenger::STATE_ACCEPTED);
         }
 

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -344,14 +344,7 @@ class TripRepository
         if ($asDriver) {
             $trips->where('user_id', $userId);
         } else {
-            /* $trips->whereHas('passengerAccepted', function ($q) use ($user) {
-                $q->where('request_state', Passenger::STATE_ACCEPTED);
-                $q->where('user_id', $user->id);
-            }); */
-            $trips->join('trip_passengers', 'trips.id', '=', 'trip_passengers.trip_id');
-            $trips->whereNull('trips.deleted_at');
-            $trips->where('trip_passengers.user_id', $userId);
-            $trips->where('trip_passengers.request_state', Passenger::STATE_ACCEPTED);
+            $this->applyAcceptedPassengerFilter($trips, $userId);
         }
 
         $trips->select('trips.*');
@@ -370,14 +363,7 @@ class TripRepository
         if ($asDriver) {
             $trips->where('user_id', $userId);
         } else {
-            /* $trips->whereHas('passengerAccepted', function ($q) use ($user) {
-                $q->where('request_state', Passenger::STATE_ACCEPTED);
-                $q->where('user_id', $user->id);
-            }); */
-            $trips->join('trip_passengers', 'trips.id', '=', 'trip_passengers.trip_id');
-            $trips->whereNull('trips.deleted_at');
-            $trips->where('trip_passengers.user_id', $userId);
-            $trips->where('trip_passengers.request_state', Passenger::STATE_ACCEPTED);
+            $this->applyAcceptedPassengerFilter($trips, $userId);
         }
 
         $trips->select('trips.*');
@@ -577,6 +563,14 @@ class TripRepository
             }
             $q->whereRaw('sin_lat * '.$sin_lat.' + cos_lat * '.$cos_lat.' *  (cos_lng * '.$cos_lng.' + sin_lng * '.$sin_lng.') > '.$dist);
         });
+    }
+
+    private function applyAcceptedPassengerFilter($query, $userId): void
+    {
+        $query->join('trip_passengers', 'trips.id', '=', 'trip_passengers.trip_id');
+        $query->whereNull('trips.deleted_at');
+        $query->where('trip_passengers.user_id', $userId);
+        $query->where('trip_passengers.request_state', Passenger::STATE_ACCEPTED);
     }
 
     private function filterActiveTrips($query)

--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -594,6 +594,41 @@ class TripControllerIntegrationTest extends TestCase
             ->assertJsonFragment(['id' => $past->id]);
     }
 
+    public function test_admin_old_trips_as_passenger_returns_requested_user_not_admin(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $profileUser = User::factory()->create();
+        $driver = User::factory()->create();
+
+        $profilePastTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDay(),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $profilePastTrip->id,
+            'user_id' => $profileUser->id,
+        ]);
+
+        $adminPastTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDays(2),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $adminPastTrip->id,
+            'user_id' => $admin->id,
+        ]);
+
+        $response = $this->actingAs($admin, 'api')
+            ->getJson('/api/users/my-old-trips?user_id='.$profileUser->id.'&as_driver=false')
+            ->assertOk();
+
+        $ids = collect($response->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($profilePastTrip->id));
+        $this->assertFalse($ids->contains($adminPastTrip->id));
+    }
+
     public function test_price_endpoint_returns_numeric_estimate_for_distance(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -1272,6 +1272,72 @@ class TripRepositoryTest extends TestCase
         $this->assertFalse($rows->pluck('id')->contains($past->id));
     }
 
+    public function test_get_old_trips_passenger_filters_by_target_user_id_not_authenticated_user(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $profileUser = User::factory()->create();
+        $driver = User::factory()->create();
+
+        $profilePastTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDay(),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $profilePastTrip->id,
+            'user_id' => $profileUser->id,
+        ]);
+
+        $adminPastTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDays(2),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $adminPastTrip->id,
+            'user_id' => $admin->id,
+        ]);
+
+        $rows = $this->repo()->getOldTrips($admin, $profileUser->id, false);
+
+        $ids = $rows->pluck('id');
+        $this->assertTrue($ids->contains($profilePastTrip->id));
+        $this->assertFalse($ids->contains($adminPastTrip->id));
+    }
+
+    public function test_get_trips_passenger_filters_by_target_user_id_not_authenticated_user(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $profileUser = User::factory()->create();
+        $driver = User::factory()->create();
+
+        $profileUpcomingTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDay(),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $profileUpcomingTrip->id,
+            'user_id' => $profileUser->id,
+        ]);
+
+        $adminUpcomingTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(2),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $adminUpcomingTrip->id,
+            'user_id' => $admin->id,
+        ]);
+
+        $rows = $this->repo()->getTrips($admin, $profileUser->id, false);
+
+        $ids = $rows->pluck('id');
+        $this->assertTrue($ids->contains($profileUpcomingTrip->id));
+        $this->assertFalse($ids->contains($adminUpcomingTrip->id));
+    }
+
     public function test_search_filters_by_user_id_and_paginates(): void
     {
         $owner = User::factory()->create();


### PR DESCRIPTION
### Summary
Fixes admin profile views showing the **wrong user’s passenger trips** when listing trips another user joined.
### Changes
- **`TripRepository`**: passenger branches in `getTrips` and `getOldTrips` now filter by **`$userId`** (profile/target user), not the authenticated user’s id.
- Extracted shared **`applyAcceptedPassengerFilter()`** for the passenger join logic.
- Regression tests:
  - `TripRepositoryTest` — target user vs admin passenger trips
  - `TripControllerIntegrationTest` — `GET /api/users/my-old-trips?user_id={id}&as_driver=false` as admin
 

