### PR TITLE
Admin user tweaks

### DIFF
--- a/app/Http/Controllers/Api/Admin/RatingController.php
+++ b/app/Http/Controllers/Api/Admin/RatingController.php
@@ -11,7 +11,6 @@ use STS\Models\User;
 use STS\Repository\RatingRepository;
 use STS\Services\AdminActionLogger;
 use STS\Transformers\AdminRatingTransformer;
-use STS\Transformers\RatingTransformer;
 
 class RatingController extends Controller
 {
@@ -87,6 +86,9 @@ class RatingController extends Controller
             ]
         );
 
-        return $this->item($model->fresh(), new RatingTransformer(auth()->user()));
+        return $this->item(
+            $model->fresh(['from', 'to', 'trip']),
+            new AdminRatingTransformer(auth()->user())
+        );
     }
 }

--- a/app/Http/Controllers/Api/Admin/RatingController.php
+++ b/app/Http/Controllers/Api/Admin/RatingController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\AdminActionLog;
+use STS\Models\Rating;
+use STS\Transformers\RatingTransformer;
+
+class RatingController extends Controller
+{
+    public function update(Request $request, int $rating): JsonResponse
+    {
+        if (! auth()->user()?->is_admin) {
+            return response()->json('Unauthorized.', 401);
+        }
+
+        $model = Rating::query()->find($rating);
+        if (! $model) {
+            return response()->json(['message' => 'Rating not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'rating' => 'sometimes|integer|in:0,1',
+            'comment' => 'nullable|string',
+            'reply_comment' => 'nullable|string',
+        ]);
+
+        if ($validated === []) {
+            return response()->json(['message' => 'No fields to update.'], 422);
+        }
+
+        $before = [
+            'rating' => (int) $model->rating,
+            'comment' => $model->comment,
+            'reply_comment' => $model->reply_comment,
+        ];
+
+        $model->fill($validated);
+        $model->save();
+
+        $after = [
+            'rating' => (int) $model->rating,
+            'comment' => $model->comment,
+            'reply_comment' => $model->reply_comment,
+        ];
+
+        AdminActionLog::create([
+            'admin_user_id' => auth()->id(),
+            'action' => AdminActionLog::ACTION_RATING_UPDATE,
+            'target_user_id' => $model->user_id_to,
+            'details' => [
+                'entity_id' => $model->id,
+                'entity_type' => 'rating',
+                'before' => $before,
+                'after' => $after,
+            ],
+        ]);
+
+        return $this->item($model->fresh(), new RatingTransformer(auth()->user()));
+    }
+}

--- a/app/Http/Controllers/Api/Admin/RatingController.php
+++ b/app/Http/Controllers/Api/Admin/RatingController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
 use STS\Models\AdminActionLog;
 use STS\Models\Rating;
+use STS\Services\AdminActionLogger;
 use STS\Transformers\RatingTransformer;
 
 class RatingController extends Controller
@@ -47,17 +48,17 @@ class RatingController extends Controller
             'reply_comment' => $model->reply_comment,
         ];
 
-        AdminActionLog::create([
-            'admin_user_id' => auth()->id(),
-            'action' => AdminActionLog::ACTION_RATING_UPDATE,
-            'target_user_id' => $model->user_id_to,
-            'details' => [
+        AdminActionLogger::log(
+            auth()->user(),
+            AdminActionLog::ACTION_RATING_UPDATE,
+            $model->user_id_to,
+            [
                 'entity_id' => $model->id,
                 'entity_type' => 'rating',
                 'before' => $before,
                 'after' => $after,
-            ],
-        ]);
+            ]
+        );
 
         return $this->item($model->fresh(), new RatingTransformer(auth()->user()));
     }

--- a/app/Http/Controllers/Api/Admin/RatingController.php
+++ b/app/Http/Controllers/Api/Admin/RatingController.php
@@ -7,11 +7,38 @@ use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
 use STS\Models\AdminActionLog;
 use STS\Models\Rating;
+use STS\Models\User;
+use STS\Repository\RatingRepository;
 use STS\Services\AdminActionLogger;
+use STS\Transformers\AdminRatingTransformer;
 use STS\Transformers\RatingTransformer;
 
 class RatingController extends Controller
 {
+    public function __construct(protected RatingRepository $ratingRepository) {}
+
+    public function index(User $user): JsonResponse
+    {
+        if (! auth()->user()?->is_admin) {
+            return response()->json('Unauthorized.', 401);
+        }
+
+        $transformer = new AdminRatingTransformer(auth()->user());
+        $received = $this->ratingRepository->getReceivedRatingsForUser($user->id)
+            ->map(fn (Rating $rating) => $transformer->transform($rating))
+            ->values();
+        $given = $this->ratingRepository->getGivenRatingsByUser($user->id)
+            ->map(fn (Rating $rating) => $transformer->transform($rating))
+            ->values();
+
+        return response()->json([
+            'data' => [
+                'received' => $received,
+                'given' => $given,
+            ],
+        ]);
+    }
+
     public function update(Request $request, int $rating): JsonResponse
     {
         if (! auth()->user()?->is_admin) {

--- a/app/Http/Controllers/Api/Admin/ReferencesController.php
+++ b/app/Http/Controllers/Api/Admin/ReferencesController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\AdminActionLog;
+use STS\Models\References;
+use STS\Services\AdminActionLogger;
+use STS\Transformers\ReferenceTransformer;
+
+class ReferencesController extends Controller
+{
+    public function update(Request $request, int $reference): JsonResponse
+    {
+        if (! auth()->user()?->is_admin) {
+            return response()->json('Unauthorized.', 401);
+        }
+
+        $model = References::query()->find($reference);
+        if (! $model) {
+            return response()->json(['message' => 'Reference not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'comment' => 'required|string',
+        ]);
+
+        $before = [
+            'comment' => $model->comment,
+        ];
+
+        $model->comment = $validated['comment'];
+        $model->save();
+
+        $after = [
+            'comment' => $model->comment,
+        ];
+
+        AdminActionLogger::log(
+            auth()->user(),
+            AdminActionLog::ACTION_REFERENCE_UPDATE,
+            $model->user_id_to,
+            [
+                'entity_id' => $model->id,
+                'entity_type' => 'reference',
+                'before' => $before,
+                'after' => $after,
+            ]
+        );
+
+        return $this->item($model->fresh(), new ReferenceTransformer);
+    }
+}

--- a/app/Http/Controllers/Api/v1/TripController.php
+++ b/app/Http/Controllers/Api/v1/TripController.php
@@ -3,19 +3,20 @@
 namespace STS\Http\Controllers\Api\v1;
 
 use Illuminate\Http\Request;
-use STS\Http\Controllers\Controller;
-use STS\Http\ExceptionWithErrors;
-use STS\Services\Logic\TripsManager;
-use STS\Transformers\TripTransformer;
 use STS\Helpers\IdentityValidationHelper;
 use STS\Helpers\OldCordovaAppHelper;
+use STS\Http\Controllers\Controller;
+use STS\Http\ExceptionWithErrors;
 use STS\Repository\TripSearchRepository;
+use STS\Services\Logic\TripsManager;
+use STS\Transformers\TripTransformer;
 
 class TripController extends Controller
 {
     protected $user;
 
     protected $tripsLogic;
+
     protected $tripSearchRepository;
 
     public function __construct(Request $r, TripsManager $tripsLogic, TripSearchRepository $tripSearchRepository)
@@ -42,7 +43,7 @@ class TripController extends Controller
         }
 
         return $this->item($trip, new TripTransformer($this->user));
-        //return response()->json(['data' => $trip]);
+        // return response()->json(['data' => $trip]);
     }
 
     public function update($id, Request $request)
@@ -58,7 +59,7 @@ class TripController extends Controller
         }
 
         return $this->item($trip, new TripTransformer($this->user));
-        //return response()->json(['data' => $trip]);
+        // return response()->json(['data' => $trip]);
     }
 
     public function changeTripSeats($id, Request $request)
@@ -99,7 +100,7 @@ class TripController extends Controller
         }
 
         return $this->item($trip, new TripTransformer($this->user));
-        //return response()->json(['data' => $trip]);
+        // return response()->json(['data' => $trip]);
     }
 
     public function search(Request $request)
@@ -125,17 +126,17 @@ class TripController extends Controller
 
         $data = $request->all();
 
-        if (!isset($data['page_size'])) {
+        if (! isset($data['page_size'])) {
             $data['page_size'] = 20;
         }
 
         $this->user = auth('api')->user();
         $trips = $this->tripsLogic->search($this->user, $data);
-        
+
         // Track the search for advertising purposes
         $this->trackSearch($data, $trips);
-        
-        /// return $trips;
+
+        // / return $trips;
         return $this->paginator($trips, new TripTransformer($this->user));
     }
 
@@ -146,7 +147,7 @@ class TripController extends Controller
             $destinationId = isset($data['destination_id']) ? $data['destination_id'] : null;
             $searchDate = isset($data['date']) ? $data['date'] : null;
             $isPassenger = isset($data['is_passenger']) ? parse_boolean($data['is_passenger']) : false;
-            
+
             // Track searches with either origin, destination, or both
             if ($originId || $destinationId) {
                 $clientPlatform = 0; // Default to web for now
@@ -154,7 +155,7 @@ class TripController extends Controller
             }
         } catch (\Exception $e) {
             // Log error but don't break the search functionality
-            \Log::error('Error tracking trip search: ' . $e->getMessage());
+            \Log::error('Error tracking trip search: '.$e->getMessage());
         }
     }
 
@@ -167,37 +168,39 @@ class TripController extends Controller
         } else {
             $asDriver = true;
         }
-        if ($request->has('user_id')  && $this->user->is_admin) {
-            $trips = $this->tripsLogic->getTrips($this->user,$request->get('user_id'), $asDriver);
-        } else {
-            $trips = $this->tripsLogic->getTrips($this->user,$this->user->id, $asDriver);
-        }
+        $targetUserId = $this->resolveTargetUserId($request);
+        $trips = $this->tripsLogic->getTrips($this->user, $targetUserId, $asDriver);
 
         return $this->collection($trips, new TripTransformer($this->user));
-        //return response()->json(['data' => $trips]);
+        // return response()->json(['data' => $trips]);
     }
 
     public function getOldTrips(Request $request)
     {
         $this->user = auth()->user();
 
-        
         if ($request->has('as_driver')) {
             $asDriver = parse_boolean($request->get('as_driver'));
         } else {
             $asDriver = true;
         }
-        
-        if ($request->has('user_id')) {
-            $trips = $this->tripsLogic->getOldTrips($this->user,$request->get('user_id'), $asDriver);
-        } else {
-            $trips = $this->tripsLogic->getOldTrips($this->user,$this->user->id, $asDriver);
-        }
+
+        $targetUserId = $this->resolveTargetUserId($request);
+        $trips = $this->tripsLogic->getOldTrips($this->user, $targetUserId, $asDriver);
 
         return $this->collection($trips, new TripTransformer($this->user));
     }
 
-    public function price(Request $request) 
+    private function resolveTargetUserId(Request $request): int
+    {
+        if ($request->has('user_id') && $this->user->is_admin) {
+            return (int) $request->get('user_id');
+        }
+
+        return $this->user->id;
+    }
+
+    public function price(Request $request)
     {
         $data = $request->all();
 
@@ -205,14 +208,14 @@ class TripController extends Controller
         $to = isset($data['to']) ? $data['to'] : null;
         $distance = isset($data['distance']) ? $data['distance'] : null;
 
-        
-        return $this->tripsLogic->price($from, $to, $distance);       
+        return $this->tripsLogic->price($from, $to, $distance);
     }
 
     public function getTripInfo(Request $request)
     {
         $data = $request->all();
         $points = isset($data['points']) ? $data['points'] : null;
+
         return $this->tripsLogic->getTripInfo($points);
     }
 
@@ -223,12 +226,12 @@ class TripController extends Controller
         $infoSelladoViaje = $this->tripsLogic->selladoViaje($this->user);
 
         return response()->json([
-            'success' => true, 
-            'data' => $infoSelladoViaje
+            'success' => true,
+            'data' => $infoSelladoViaje,
         ]);
     }
 
-    public function changeVisibility($id, Request $request) 
+    public function changeVisibility($id, Request $request)
     {
         $this->user = auth()->user();
         $trip = $this->tripsLogic->changeVisibility($this->user, $id);

--- a/app/Models/AdminActionLog.php
+++ b/app/Models/AdminActionLog.php
@@ -7,8 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class AdminActionLog extends Model
 {
     const ACTION_USER_DELETE = 'user_delete';
+
     const ACTION_USER_ANONYMIZE = 'user_anonymize';
+
     const ACTION_USER_BAN_AND_ANONYMIZE = 'user_ban_and_anonymize';
+
+    const ACTION_RATING_UPDATE = 'rating_update';
+
+    const ACTION_REFERENCE_UPDATE = 'reference_update';
 
     protected $table = 'admin_action_logs';
 

--- a/app/Repository/RatingRepository.php
+++ b/app/Repository/RatingRepository.php
@@ -17,6 +17,24 @@ class RatingRepository
         return $rate->first();
     }
 
+    public function getReceivedRatingsForUser(int $userId)
+    {
+        return RatingModel::query()
+            ->where('user_id_to', $userId)
+            ->with(['from', 'to', 'trip'])
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    public function getGivenRatingsByUser(int $userId)
+    {
+        return RatingModel::query()
+            ->where('user_id_from', $userId)
+            ->with(['from', 'to', 'trip'])
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
     public function getRatings($user, $data = [])
     {
         // $inQuery = "id IN (SELECT id FROM availables_ratings WHERE user_id_to = '" . $user->id . "' )";

--- a/app/Services/AdminActionLogger.php
+++ b/app/Services/AdminActionLogger.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\AdminActionLog;
+use STS\Models\User;
+
+class AdminActionLogger
+{
+    public static function log(User $admin, string $action, int $targetUserId, array $details): AdminActionLog
+    {
+        return AdminActionLog::create([
+            'admin_user_id' => $admin->id,
+            'action' => $action,
+            'target_user_id' => $targetUserId,
+            'details' => $details,
+        ]);
+    }
+}

--- a/app/Transformers/AdminRatingTransformer.php
+++ b/app/Transformers/AdminRatingTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace STS\Transformers;
+
+use League\Fractal\TransformerAbstract;
+use STS\Models\Rating;
+
+class AdminRatingTransformer extends TransformerAbstract
+{
+    protected $user;
+
+    public function __construct($user = null)
+    {
+        $this->user = $user;
+    }
+
+    public function transform(Rating $rate): array
+    {
+        $tripTrans = new TripTransformer($this->user);
+        $userTrans = new TripUserTransformer($this->user);
+
+        return [
+            'id' => $rate->id,
+            'from' => $rate->from ? $userTrans->transform($rate->from) : null,
+            'to' => $rate->to ? $userTrans->transform($rate->to) : null,
+            'trip' => $rate->trip ? $tripTrans->transform($rate->trip) : null,
+            'comment' => $rate->comment,
+            'user_to_state' => $rate->user_to_state,
+            'user_to_type' => $rate->user_to_type,
+            'rate_at' => $rate->rate_at ? $rate->rate_at->toDateTimeString() : null,
+            'reply_comment' => $rate->reply_comment,
+            'reply_comment_created_at' => $rate->reply_comment_created_at
+                ? $rate->reply_comment_created_at->toDateTimeString()
+                : null,
+            'rating' => $rate->rating,
+        ];
+    }
+}

--- a/app/Transformers/ReferenceTransformer.php
+++ b/app/Transformers/ReferenceTransformer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace STS\Transformers;
+
+use League\Fractal\TransformerAbstract;
+use STS\Models\References;
+
+class ReferenceTransformer extends TransformerAbstract
+{
+    public function transform(References $reference): array
+    {
+        return [
+            'id' => $reference->id,
+            'user_id_from' => $reference->user_id_from,
+            'user_id_to' => $reference->user_id_to,
+            'comment' => $reference->comment,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
 use STS\Http\Controllers\Api\Admin\MercadoPagoRejectedValidationController as AdminMercadoPagoRejectedValidationController;
 use STS\Http\Controllers\Api\Admin\RatingController as AdminRatingController;
+use STS\Http\Controllers\Api\Admin\ReferencesController as AdminReferencesController;
 use STS\Http\Controllers\Api\Admin\SupportReplyTemplateController as AdminSupportReplyTemplateController;
 use STS\Http\Controllers\Api\Admin\SupportTicketController as AdminSupportTicketController;
 use STS\Http\Controllers\Api\Admin\UserController as AdminUserController;
@@ -217,6 +218,7 @@ Route::middleware(['api'])->group(function () {
         // Car management routes
         Route::apiResource('cars', AdminCarController::class);
         Route::patch('ratings/{rating}', [AdminRatingController::class, 'update']);
+        Route::patch('references/{reference}', [AdminReferencesController::class, 'update']);
         Route::get('users', [AdminUserController::class, 'index']);
         Route::get('user-migrations', [AdminUserMigrationController::class, 'index']);
         Route::post('user-migrations', [AdminUserMigrationController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -217,6 +217,7 @@ Route::middleware(['api'])->group(function () {
         Route::apiResource('campaigns.rewards', CampaignRewardController::class);
         // Car management routes
         Route::apiResource('cars', AdminCarController::class);
+        Route::get('users/{user}/ratings', [AdminRatingController::class, 'index']);
         Route::patch('ratings/{rating}', [AdminRatingController::class, 'update']);
         Route::patch('references/{reference}', [AdminReferencesController::class, 'update']);
         Route::get('users', [AdminUserController::class, 'index']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
 use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
 use STS\Http\Controllers\Api\Admin\MercadoPagoRejectedValidationController as AdminMercadoPagoRejectedValidationController;
+use STS\Http\Controllers\Api\Admin\RatingController as AdminRatingController;
 use STS\Http\Controllers\Api\Admin\SupportReplyTemplateController as AdminSupportReplyTemplateController;
 use STS\Http\Controllers\Api\Admin\SupportTicketController as AdminSupportTicketController;
 use STS\Http\Controllers\Api\Admin\UserController as AdminUserController;
@@ -215,6 +216,7 @@ Route::middleware(['api'])->group(function () {
         Route::apiResource('campaigns.rewards', CampaignRewardController::class);
         // Car management routes
         Route::apiResource('cars', AdminCarController::class);
+        Route::patch('ratings/{rating}', [AdminRatingController::class, 'update']);
         Route::get('users', [AdminUserController::class, 'index']);
         Route::get('user-migrations', [AdminUserMigrationController::class, 'index']);
         Route::post('user-migrations', [AdminUserMigrationController::class, 'store']);

--- a/tests/Feature/Http/AdminRatingControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminRatingControllerIntegrationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Carbon\Carbon;
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\AdminActionLog;
+use STS\Models\Passenger;
+use STS\Models\Rating;
+use STS\Models\Trip;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminRatingControllerIntegrationTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    private function persistRating(array $attributes): Rating
+    {
+        $rating = new Rating;
+        foreach ($attributes as $key => $value) {
+            $rating->{$key} = $value;
+        }
+        if (! array_key_exists('available', $attributes)) {
+            $rating->available = 0;
+        }
+        $rating->save();
+
+        return $rating->fresh();
+    }
+
+    public function test_update_requires_admin(): void
+    {
+        $user = User::factory()->create();
+        $rated = User::factory()->create();
+        $voter = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $voter->id]);
+        $rating = $this->persistRating([
+            'trip_id' => $trip->id,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $rated->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'Original',
+            'reply_comment' => '',
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::now(),
+            'available' => 1,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->patchJson('api/admin/ratings/'.$rating->id, [
+            'rating' => Rating::STATE_NEGATIVO,
+            'comment' => 'Updated',
+        ])->assertUnauthorized();
+    }
+
+    public function test_admin_update_persists_fields_and_logs_action(): void
+    {
+        $admin = $this->admin();
+        $rated = User::factory()->create();
+        $voter = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $voter->id]);
+        $rating = $this->persistRating([
+            'trip_id' => $trip->id,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $rated->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'Original comment',
+            'reply_comment' => 'Original reply',
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::now(),
+            'available' => 1,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/ratings/'.$rating->id, [
+            'rating' => Rating::STATE_NEGATIVO,
+            'comment' => 'Updated comment',
+            'reply_comment' => 'Updated reply',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.rating', Rating::STATE_NEGATIVO)
+            ->assertJsonPath('data.comment', 'Updated comment')
+            ->assertJsonPath('data.reply_comment', 'Updated reply');
+
+        $this->assertDatabaseHas('rating', [
+            'id' => $rating->id,
+            'rating' => Rating::STATE_NEGATIVO,
+            'comment' => 'Updated comment',
+            'reply_comment' => 'Updated reply',
+        ]);
+
+        $log = AdminActionLog::query()
+            ->where('admin_user_id', $admin->id)
+            ->where('action', AdminActionLog::ACTION_RATING_UPDATE)
+            ->where('target_user_id', $rated->id)
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('rating', $log->details['entity_type']);
+        $this->assertSame($rating->id, $log->details['entity_id']);
+        $this->assertSame(Rating::STATE_POSITIVO, $log->details['before']['rating']);
+        $this->assertSame('Original comment', $log->details['before']['comment']);
+        $this->assertSame(Rating::STATE_NEGATIVO, $log->details['after']['rating']);
+        $this->assertSame('Updated comment', $log->details['after']['comment']);
+    }
+
+    public function test_update_returns_unprocessable_for_invalid_rating_value(): void
+    {
+        $admin = $this->admin();
+        $rated = User::factory()->create();
+        $voter = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $voter->id]);
+        $rating = $this->persistRating([
+            'trip_id' => $trip->id,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $rated->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'Original',
+            'reply_comment' => '',
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::now(),
+            'available' => 1,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/ratings/'.$rating->id, [
+            'rating' => 99,
+        ])->assertUnprocessable();
+    }
+
+    public function test_update_returns_not_found_for_missing_rating(): void
+    {
+        $admin = $this->admin();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/ratings/999999999', [
+            'comment' => 'Nope',
+        ])->assertNotFound();
+    }
+}

--- a/tests/Feature/Http/AdminRatingControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminRatingControllerIntegrationTest.php
@@ -161,4 +161,107 @@ class AdminRatingControllerIntegrationTest extends TestCase
             'comment' => 'Nope',
         ])->assertNotFound();
     }
+
+    public function test_index_requires_admin(): void
+    {
+        $user = User::factory()->create();
+        $target = User::factory()->create();
+
+        $this->actingAs($user, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/users/'.$target->id.'/ratings')
+            ->assertUnauthorized();
+    }
+
+    public function test_index_returns_received_and_given_ratings_with_links(): void
+    {
+        $admin = $this->admin();
+        $profileUser = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $tripReceived = Trip::factory()->create([
+            'user_id' => $otherUser->id,
+            'from_town' => 'Rosario',
+            'to_town' => 'Buenos Aires',
+        ]);
+        $tripGiven = Trip::factory()->create([
+            'user_id' => $profileUser->id,
+            'from_town' => 'Córdoba',
+            'to_town' => 'Mendoza',
+        ]);
+
+        $received = $this->persistRating([
+            'trip_id' => $tripReceived->id,
+            'user_id_from' => $otherUser->id,
+            'user_id_to' => $profileUser->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'Great passenger',
+            'reply_comment' => '',
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::now(),
+            'available' => 1,
+        ]);
+
+        $given = $this->persistRating([
+            'trip_id' => $tripGiven->id,
+            'user_id_from' => $profileUser->id,
+            'user_id_to' => $otherUser->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_NEGATIVO,
+            'comment' => 'Late arrival',
+            'reply_comment' => '',
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::now(),
+            'available' => 1,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/users/'.$profileUser->id.'/ratings')
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'received' => [['id', 'rating', 'comment', 'from', 'to', 'trip']],
+                    'given' => [['id', 'rating', 'comment', 'from', 'to', 'trip']],
+                ],
+            ]);
+
+        $response->assertJsonPath('data.received.0.id', $received->id)
+            ->assertJsonPath('data.received.0.rating', Rating::STATE_POSITIVO)
+            ->assertJsonPath('data.received.0.comment', 'Great passenger')
+            ->assertJsonPath('data.received.0.from.id', $otherUser->id)
+            ->assertJsonPath('data.received.0.to.id', $profileUser->id)
+            ->assertJsonPath('data.received.0.trip.id', $tripReceived->id)
+            ->assertJsonPath('data.received.0.trip.from_town', 'Rosario')
+            ->assertJsonPath('data.received.0.trip.to_town', 'Buenos Aires');
+
+        $response->assertJsonPath('data.given.0.id', $given->id)
+            ->assertJsonPath('data.given.0.rating', Rating::STATE_NEGATIVO)
+            ->assertJsonPath('data.given.0.comment', 'Late arrival')
+            ->assertJsonPath('data.given.0.from.id', $profileUser->id)
+            ->assertJsonPath('data.given.0.to.id', $otherUser->id)
+            ->assertJsonPath('data.given.0.trip.id', $tripGiven->id)
+            ->assertJsonPath('data.given.0.trip.from_town', 'Córdoba')
+            ->assertJsonPath('data.given.0.trip.to_town', 'Mendoza');
+    }
+
+    public function test_index_returns_empty_arrays_when_user_has_no_ratings(): void
+    {
+        $admin = $this->admin();
+        $target = User::factory()->create();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/users/'.$target->id.'/ratings')
+            ->assertOk()
+            ->assertJsonPath('data.received', [])
+            ->assertJsonPath('data.given', []);
+    }
 }

--- a/tests/Feature/Http/AdminRatingControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminRatingControllerIntegrationTest.php
@@ -57,6 +57,7 @@ class AdminRatingControllerIntegrationTest extends TestCase
         ]);
 
         $this->actingAs($user, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
 
         $this->patchJson('api/admin/ratings/'.$rating->id, [
             'rating' => Rating::STATE_NEGATIVO,

--- a/tests/Feature/Http/AdminReferencesControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminReferencesControllerIntegrationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\AdminActionLog;
+use STS\Models\References;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminReferencesControllerIntegrationTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_update_requires_admin(): void
+    {
+        $user = User::factory()->create();
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $reference = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Original',
+        ]);
+
+        $this->actingAs($user, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/references/'.$reference->id, [
+            'comment' => 'Updated',
+        ])->assertUnauthorized();
+    }
+
+    public function test_admin_update_persists_comment_and_logs_action(): void
+    {
+        $admin = $this->admin();
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $reference = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Original reference',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/references/'.$reference->id, [
+            'comment' => 'Updated reference',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.comment', 'Updated reference')
+            ->assertJsonPath('data.id', $reference->id);
+
+        $this->assertDatabaseHas('users_references', [
+            'id' => $reference->id,
+            'comment' => 'Updated reference',
+        ]);
+
+        $log = AdminActionLog::query()
+            ->where('admin_user_id', $admin->id)
+            ->where('action', AdminActionLog::ACTION_REFERENCE_UPDATE)
+            ->where('target_user_id', $to->id)
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('reference', $log->details['entity_type']);
+        $this->assertSame($reference->id, $log->details['entity_id']);
+        $this->assertSame('Original reference', $log->details['before']['comment']);
+        $this->assertSame('Updated reference', $log->details['after']['comment']);
+    }
+
+    public function test_update_returns_unprocessable_when_comment_missing(): void
+    {
+        $admin = $this->admin();
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $reference = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Original',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/references/'.$reference->id, [])
+            ->assertUnprocessable();
+    }
+
+    public function test_update_returns_not_found_for_missing_reference(): void
+    {
+        $admin = $this->admin();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->patchJson('api/admin/references/999999999', [
+            'comment' => 'Nope',
+        ])->assertNotFound();
+    }
+}

--- a/tests/Feature/Http/TripApiTest.php
+++ b/tests/Feature/Http/TripApiTest.php
@@ -394,20 +394,35 @@ class TripApiTest extends TestCase
             ->assertOk();
     }
 
-    public function test_get_old_trips_forwards_explicit_user_id_when_present(): void
+    public function test_get_old_trips_ignores_user_id_for_non_admin(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['is_admin' => false]);
         $other = User::factory()->create();
         $this->actingAs($user, 'api');
 
         $this->tripsLogic->shouldReceive('getOldTrips')
             ->once()
-            ->with($user, $other->id, true)
+            ->with($user, $user->id, true)
             ->andReturn(collect([]));
 
         $this->getJson('api/users/my-old-trips?user_id='.$other->id)
             ->assertOk()
             ->assertJsonStructure(['data']);
+    }
+
+    public function test_get_old_trips_admin_may_pass_explicit_user_id_target(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $member = User::factory()->create();
+        $this->actingAs($admin, 'api');
+
+        $this->tripsLogic->shouldReceive('getOldTrips')
+            ->once()
+            ->with($admin, $member->id, true)
+            ->andReturn(collect([]));
+
+        $this->getJson('api/users/my-old-trips?user_id='.$member->id)
+            ->assertOk();
     }
 
     public function test_get_old_trips_defaults_as_driver_true_when_omitted(): void

--- a/tests/Unit/Models/AdminActionLogTest.php
+++ b/tests/Unit/Models/AdminActionLogTest.php
@@ -64,6 +64,8 @@ class AdminActionLogTest extends TestCase
         $this->assertSame('user_delete', AdminActionLog::ACTION_USER_DELETE);
         $this->assertSame('user_anonymize', AdminActionLog::ACTION_USER_ANONYMIZE);
         $this->assertSame('user_ban_and_anonymize', AdminActionLog::ACTION_USER_BAN_AND_ANONYMIZE);
+        $this->assertSame('rating_update', AdminActionLog::ACTION_RATING_UPDATE);
+        $this->assertSame('reference_update', AdminActionLog::ACTION_REFERENCE_UPDATE);
     }
 
     public function test_table_name_is_admin_action_logs(): void

--- a/tests/Unit/Repository/RatingRepositoryTest.php
+++ b/tests/Unit/Repository/RatingRepositoryTest.php
@@ -416,4 +416,34 @@ class RatingRepositoryTest extends TestCase
         $this->assertTrue($ratingA->is($repo->getRating($passenger->id, $driver->id, $tripA->id)));
         $this->assertTrue($ratingB->is($repo->getRating($passenger->id, $driver->id, $tripB->id)));
     }
+
+    public function test_get_received_ratings_for_user_filters_by_user_id_to(): void
+    {
+        $profile = User::factory()->create();
+        $rater = User::factory()->create();
+        $other = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $rater->id]);
+        $received = $this->seedRating($rater, $profile, $trip);
+        $this->seedRating($profile, $other, $trip);
+
+        $rows = (new RatingRepository)->getReceivedRatingsForUser($profile->id);
+
+        $this->assertCount(1, $rows);
+        $this->assertTrue($received->is($rows->first()));
+    }
+
+    public function test_get_given_ratings_by_user_filters_by_user_id_from(): void
+    {
+        $profile = User::factory()->create();
+        $rated = User::factory()->create();
+        $other = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $profile->id]);
+        $given = $this->seedRating($profile, $rated, $trip);
+        $this->seedRating($other, $profile, $trip);
+
+        $rows = (new RatingRepository)->getGivenRatingsByUser($profile->id);
+
+        $this->assertCount(1, $rows);
+        $this->assertTrue($given->is($rows->first()));
+    }
 }


### PR DESCRIPTION
## Summary
Admin tooling to inspect and moderate a user’s trips, ratings, and references from dedicated pages under `/admin/users/:userId`, with audit logging for admin edits.
## Backend (`carpoolear_backend`)
### Admin APIs
- `GET /api/admin/users/{user}/ratings` — returns **received** (`user_id_to`) and **given** (`user_id_from`) ratings with full `from`, `to`, and trip data (`AdminRatingTransformer`).
- `PATCH /api/admin/ratings/{id}` — update `rating`, `comment`, `reply_comment`.
- `PATCH /api/admin/references/{id}` — update `comment`.
### Audit
- New `AdminActionLog` actions: `rating_update`, `reference_update`.
- `AdminActionLogger` records `before` / `after` payloads on each edit.
### Security
- `getOldTrips` now matches `getTrips`: only admins may pass another user’s `user_id`.
### Tests
- Integration tests for admin rating/reference PATCH and ratings index.
- Unit tests for `RatingRepository` received/given helpers.
- `TripApiTest` coverage for old-trips admin guard.
