### PR TITLE
Support changes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,18 +11,18 @@ fi
 
 mapfile -t files < <(git diff --cached --name-only --diff-filter=ACM | grep -E '\.php$' || true)
 
-if [[ ${#files[@]} -eq 0 ]]; then
-  exit 0
+if [[ ${#files[@]} -gt 0 ]]; then
+  existing=()
+  for f in "${files[@]}"; do
+    [[ -f "$f" ]] && existing+=("$f")
+  done
+
+  if [[ ${#existing[@]} -gt 0 ]]; then
+    echo "pre-commit: pint..."
+    vendor/bin/pint "${existing[@]}"
+    git add "${existing[@]}"
+  fi
 fi
 
-existing=()
-for f in "${files[@]}"; do
-  [[ -f "$f" ]] && existing+=("$f")
-done
-
-if [[ ${#existing[@]} -eq 0 ]]; then
-  exit 0
-fi
-
-vendor/bin/pint "${existing[@]}"
-git add "${existing[@]}"
+echo "pre-commit: php artisan test..."
+php artisan test

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ storage/firebase*.json
 storage/logs/*
 tests/coverage/*
 cert
+storage/framework/phpunit-mysql-testing.lock

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -172,10 +172,15 @@ class SupportTicketController extends Controller
         return response()->json(['data' => $ticket]);
     }
 
+    public function markNeedsReview(int $id, Request $request): JsonResponse
+    {
+        return $this->applyActionStatus($id, $request, 'Necesita revisión');
+    }
+
     public function updateStatus(int $id, Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'status' => 'required|in:Open,Esperando respuesta,En revision,Resuelto,Cerrado',
+            'status' => 'required|in:Open,Esperando respuesta,En revision,Necesita revisión,Resuelto,Cerrado',
         ]);
         $admin = auth()->user();
         $ticket = SupportTicket::findOrFail($id);

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -44,6 +44,7 @@ class SupportTicketController extends Controller
             'contact' => 'normal',
             'feedback' => 'low',
             'account_verification' => 'high',
+            'account_recovery' => 'high',
         ];
     }
 
@@ -70,7 +71,7 @@ class SupportTicketController extends Controller
     {
         $validated = $request->validate([
             'user_id' => 'required|integer|exists:users,id',
-            'type' => 'required|in:bug_report,contact,feedback,report,account_verification',
+            'type' => 'required|in:bug_report,contact,feedback,report,account_verification,account_recovery',
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
         ]);

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -36,18 +36,6 @@ class SupportTicketController extends Controller
         return ['user:id,name'];
     }
 
-    private static function typeDefaultPriorities(): array
-    {
-        return [
-            'report' => 'high',
-            'bug_report' => 'normal',
-            'contact' => 'normal',
-            'feedback' => 'low',
-            'account_verification' => 'high',
-            'account_recovery' => 'high',
-        ];
-    }
-
     public function __construct(private readonly SupportTicketService $supportTicketService) {}
 
     public function index(): JsonResponse
@@ -71,7 +59,7 @@ class SupportTicketController extends Controller
     {
         $validated = $request->validate([
             'user_id' => 'required|integer|exists:users,id',
-            'type' => 'required|in:bug_report,contact,feedback,report,account_verification,account_recovery',
+            'type' => SupportTicket::typeValidationRule(),
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
         ]);
@@ -83,7 +71,7 @@ class SupportTicketController extends Controller
                 'type' => $validated['type'],
                 'subject' => $validated['subject'],
                 'status' => self::ADMIN_CREATED_TICKET_STATUS,
-                'priority' => self::typeDefaultPriorities()[$validated['type']] ?? 'normal',
+                'priority' => SupportTicket::TYPE_DEFAULT_PRIORITIES[$validated['type']] ?? 'normal',
                 'unread_for_user' => 1,
                 'unread_for_admin' => 0,
                 'created_by' => $admin->id,

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -5,14 +5,18 @@ namespace STS\Http\Controllers\Api\Admin;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use STS\Http\Controllers\Concerns\StreamsSupportTicketAttachments;
 use STS\Http\Controllers\Controller;
 use STS\Models\SupportTicket;
 use STS\Models\SupportTicketReply;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SupportTicketController extends Controller
 {
+    use StreamsSupportTicketAttachments;
+
     private const ADMIN_CREATED_TICKET_STATUS = 'Esperando respuesta';
 
     /**
@@ -107,7 +111,7 @@ class SupportTicketController extends Controller
         $validated = $request->validate([
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
-            'attachments.*' => 'file|mimes:jpg,jpeg,png,webp|max:10240',
+            'attachments.*' => 'file|max:10240',
         ]);
 
         $admin = auth()->user();
@@ -130,7 +134,7 @@ class SupportTicketController extends Controller
             ]);
 
             foreach (($validated['attachments'] ?? []) as $file) {
-                $this->supportTicketService->storeReplyAttachments([$file], $admin->id, $reply->id);
+                $this->supportTicketService->storeReplyAttachments([$file], $ticket->id, $admin->id, $reply->id);
             }
 
             $this->supportTicketService->applyAdminReplyTransition($ticket, $admin->id);
@@ -219,6 +223,21 @@ class SupportTicketController extends Controller
         $ticket->save();
 
         return response()->json(['data' => $ticket]);
+    }
+
+    public function attachmentImage(int $ticketId, int $attachmentId): StreamedResponse|JsonResponse
+    {
+        SupportTicket::query()->findOrFail($ticketId);
+
+        return $this->streamSupportTicketAttachment($this->supportTicketService, $ticketId, $attachmentId);
+    }
+
+    public function purgeAttachments(int $id): JsonResponse
+    {
+        SupportTicket::query()->findOrFail($id);
+        $this->supportTicketService->purgeTicketAttachments($id);
+
+        return response()->json(['message' => 'Attachments purged']);
     }
 
     private function applyActionStatus(int $id, Request $request, string $status): JsonResponse

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -174,13 +174,13 @@ class SupportTicketController extends Controller
 
     public function markNeedsReview(int $id, Request $request): JsonResponse
     {
-        return $this->applyActionStatus($id, $request, 'Necesita revisión');
+        return $this->applyActionStatus($id, $request, SupportTicket::STATUS_NEEDS_REVIEW);
     }
 
     public function updateStatus(int $id, Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'status' => 'required|in:Open,Esperando respuesta,En revision,Necesita revisión,Resuelto,Cerrado',
+            'status' => SupportTicket::statusValidationRule(),
         ]);
         $admin = auth()->user();
         $ticket = SupportTicket::findOrFail($id);

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -11,6 +11,7 @@ use STS\Models\SupportTicket;
 use STS\Models\SupportTicketReply;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
+use STS\Support\ImageAttachmentRules;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SupportTicketController extends Controller
@@ -111,11 +112,15 @@ class SupportTicketController extends Controller
         $validated = $request->validate([
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
-            'attachments.*' => 'file|max:10240',
+            'attachments.*' => ImageAttachmentRules::FILE,
         ]);
 
         $admin = auth()->user();
         $ticket = SupportTicket::findOrFail($id);
+
+        if (! $this->supportTicketService->ticketAcceptsReplies($ticket)) {
+            return response()->json(['error' => 'Ticket is closed for replies'], 422);
+        }
 
         if ($this->supportTicketService->ticketAlreadyHasReplyWithMessageMarkdown(
             $ticket->id,
@@ -174,6 +179,20 @@ class SupportTicketController extends Controller
         $ticket->save();
 
         return response()->json(['data' => $ticket]);
+    }
+
+    public function unresolve(int $id): JsonResponse
+    {
+        $admin = auth()->user();
+        $ticket = SupportTicket::findOrFail($id);
+
+        if ($ticket->status !== 'Resuelto') {
+            return response()->json(['error' => 'Ticket is not resolved'], 422);
+        }
+
+        $this->supportTicketService->unresolveTicket($ticket, $admin->id);
+
+        return response()->json(['data' => $ticket->fresh()]);
     }
 
     public function markNeedsReview(int $id, Request $request): JsonResponse

--- a/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
@@ -11,6 +11,7 @@ use STS\Models\ManualIdentityValidation;
 use STS\Services\HeicToJpegConverter;
 use STS\Services\ImageUploadValidator;
 use STS\Services\MercadoPagoService;
+use STS\Support\ImageAttachmentRules;
 
 class ManualIdentityValidationController extends Controller
 {
@@ -222,17 +223,24 @@ class ManualIdentityValidationController extends Controller
             throw new ExceptionWithErrors('Payment is required before submitting images.', [], 422);
         }
 
+        $request->validate([
+            'front_image' => ImageAttachmentRules::requiredImage(),
+            'back_image' => ImageAttachmentRules::requiredImage(),
+            'selfie_image' => ImageAttachmentRules::requiredImage(),
+        ]);
+
         $front = $request->file('front_image');
         $back = $request->file('back_image');
         $selfie = $request->file('selfie_image');
 
-        if (! $front || ! $back || ! $selfie) {
-            throw new ExceptionWithErrors('All three images are required: front_image, back_image, selfie_image.', []);
-        }
-
         $validator = app(ImageUploadValidator::class);
         foreach (['front_image' => $front, 'back_image' => $back, 'selfie_image' => $selfie] as $field => $file) {
-            $result = $validator->validate($file, $field);
+            $result = $validator->validate(
+                $file,
+                $field,
+                ImageAttachmentRules::ALLOWED_MIMES,
+                ImageAttachmentRules::ALLOWED_EXTENSIONS,
+            );
             if (! ($result['valid'] ?? true)) {
                 throw new ExceptionWithErrors('Invalid image upload.', $result['errors'] ?? []);
             }

--- a/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
@@ -4,6 +4,7 @@ namespace STS\Http\Controllers\Api\v1;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
@@ -223,15 +224,28 @@ class ManualIdentityValidationController extends Controller
             throw new ExceptionWithErrors('Payment is required before submitting images.', [], 422);
         }
 
-        $request->validate([
-            'front_image' => ImageAttachmentRules::requiredImage(),
-            'back_image' => ImageAttachmentRules::requiredImage(),
-            'selfie_image' => ImageAttachmentRules::requiredImage(),
-        ]);
-
         $front = $request->file('front_image');
         $back = $request->file('back_image');
         $selfie = $request->file('selfie_image');
+
+        if (! $front || ! $back || ! $selfie) {
+            throw new ExceptionWithErrors(
+                'All three images are required: front_image, back_image, selfie_image.',
+                []
+            );
+        }
+
+        $laravelValidator = Validator::make(
+            ['front_image' => $front, 'back_image' => $back, 'selfie_image' => $selfie],
+            [
+                'front_image' => ImageAttachmentRules::FILE,
+                'back_image' => ImageAttachmentRules::FILE,
+                'selfie_image' => ImageAttachmentRules::FILE,
+            ],
+        );
+        if ($laravelValidator->fails()) {
+            throw new ExceptionWithErrors('Invalid image upload.', $laravelValidator->errors()->toArray());
+        }
 
         $validator = app(ImageUploadValidator::class);
         foreach (['front_image' => $front, 'back_image' => $back, 'selfie_image' => $selfie] as $field => $file) {

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -5,15 +5,19 @@ namespace STS\Http\Controllers\Api\v1;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use STS\Http\Controllers\Concerns\StreamsSupportTicketAttachments;
 use STS\Http\Controllers\Controller;
 use STS\Models\SupportTicket;
 use STS\Models\SupportTicketReply;
 use STS\Models\User;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SupportTicketController extends Controller
 {
+    use StreamsSupportTicketAttachments;
+
     public function __construct(private readonly SupportTicketService $supportTicketService)
     {
         $this->middleware('logged');
@@ -47,7 +51,7 @@ class SupportTicketController extends Controller
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
-            'attachments.*' => 'file|mimes:jpg,jpeg,png,webp|max:10240',
+            'attachments.*' => 'file|max:10240',
         ]);
 
         $user = auth()->user();
@@ -83,7 +87,7 @@ class SupportTicketController extends Controller
             ]);
 
             foreach (($validated['attachments'] ?? []) as $file) {
-                $this->supportTicketService->storeReplyAttachments([$file], $user->id, $reply->id);
+                $this->supportTicketService->storeReplyAttachments([$file], $ticket->id, $user->id, $reply->id);
             }
 
             $addedOpeningAutoReply = $this->supportTicketService->appendOpeningAutoReply($ticket);
@@ -119,7 +123,7 @@ class SupportTicketController extends Controller
         $validated = $request->validate([
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
-            'attachments.*' => 'file|mimes:jpg,jpeg,png,webp|max:10240',
+            'attachments.*' => 'file|max:10240',
         ]);
 
         $user = auth()->user();
@@ -147,7 +151,7 @@ class SupportTicketController extends Controller
                 'created_by' => $user->id,
             ]);
             foreach (($validated['attachments'] ?? []) as $file) {
-                $this->supportTicketService->storeReplyAttachments([$file], $user->id, $reply->id);
+                $this->supportTicketService->storeReplyAttachments([$file], $ticket->id, $user->id, $reply->id);
             }
 
             $this->supportTicketService->applyUserReplyTransition($ticket, $user->id);
@@ -187,6 +191,17 @@ class SupportTicketController extends Controller
         });
 
         return response()->json(['data' => $ticket->fresh()]);
+    }
+
+    public function attachmentImage(int $ticketId, int $attachmentId): StreamedResponse|JsonResponse
+    {
+        $user = auth()->user();
+        $ticket = SupportTicket::where('user_id', $user->id)->find($ticketId);
+        if (! $ticket) {
+            return response()->json(['error' => 'Ticket not found'], 404);
+        }
+
+        return $this->streamSupportTicketAttachment($this->supportTicketService, $ticketId, $attachmentId);
     }
 
     private function notifyTicketOwnerOfAdminReply(SupportTicket $ticket, User $owner): void

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -11,7 +11,6 @@ use STS\Models\SupportTicketReply;
 use STS\Models\User;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
-use STS\Support\SupportTicketOpeningAutoReply;
 
 class SupportTicketController extends Controller
 {
@@ -62,7 +61,7 @@ class SupportTicketController extends Controller
             return response()->json(['data' => $existingDuplicate->fresh()]);
         }
 
-        $ticket = DB::transaction(function () use ($validated, $user) {
+        [$ticket, $addedOpeningAutoReply] = DB::transaction(function () use ($validated, $user) {
             $ticket = SupportTicket::create([
                 'user_id' => $user->id,
                 'type' => $validated['type'],
@@ -87,15 +86,12 @@ class SupportTicketController extends Controller
                 $this->supportTicketService->storeReplyAttachments([$file], $user->id, $reply->id);
             }
 
-            $this->supportTicketService->appendOpeningAutoReply($ticket);
+            $addedOpeningAutoReply = $this->supportTicketService->appendOpeningAutoReply($ticket);
 
-            return $ticket->fresh();
+            return [$ticket->fresh(), $addedOpeningAutoReply];
         });
 
-        if ($this->supportTicketService->ticketAlreadyHasReplyWithMessageMarkdown(
-            $ticket->id,
-            SupportTicketOpeningAutoReply::MARKDOWN,
-        )) {
+        if ($addedOpeningAutoReply) {
             $this->notifyTicketOwnerOfAdminReply($ticket, $user);
         }
 

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -12,6 +12,7 @@ use STS\Models\SupportTicketReply;
 use STS\Models\User;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
+use STS\Support\ImageAttachmentRules;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SupportTicketController extends Controller
@@ -51,7 +52,7 @@ class SupportTicketController extends Controller
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
-            'attachments.*' => 'file|max:10240',
+            'attachments.*' => ImageAttachmentRules::FILE,
         ]);
 
         $user = auth()->user();
@@ -123,7 +124,7 @@ class SupportTicketController extends Controller
         $validated = $request->validate([
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
-            'attachments.*' => 'file|max:10240',
+            'attachments.*' => ImageAttachmentRules::FILE,
         ]);
 
         $user = auth()->user();

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -12,18 +12,6 @@ use STS\Services\SupportTicketService;
 
 class SupportTicketController extends Controller
 {
-    private static function typeDefaultPriorities(): array
-    {
-        return [
-            'report' => 'high',
-            'bug_report' => 'normal',
-            'contact' => 'normal',
-            'feedback' => 'low',
-            'account_verification' => 'high',
-            'account_recovery' => 'high',
-        ];
-    }
-
     public function __construct(private readonly SupportTicketService $supportTicketService)
     {
         $this->middleware('logged');
@@ -53,7 +41,7 @@ class SupportTicketController extends Controller
     public function create(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'type' => 'required|in:bug_report,contact,feedback,report,account_verification,account_recovery',
+            'type' => SupportTicket::typeValidationRule(),
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',
@@ -77,7 +65,7 @@ class SupportTicketController extends Controller
                 'type' => $validated['type'],
                 'subject' => $validated['subject'],
                 'status' => 'Open',
-                'priority' => self::typeDefaultPriorities()[$validated['type']] ?? 'normal',
+                'priority' => SupportTicket::TYPE_DEFAULT_PRIORITIES[$validated['type']] ?? 'normal',
                 'unread_for_user' => 0,
                 'unread_for_admin' => 1,
                 'created_by' => $user->id,

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -8,7 +8,10 @@ use Illuminate\Support\Facades\DB;
 use STS\Http\Controllers\Controller;
 use STS\Models\SupportTicket;
 use STS\Models\SupportTicketReply;
+use STS\Models\User;
+use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
+use STS\Support\SupportTicketOpeningAutoReply;
 
 class SupportTicketController extends Controller
 {
@@ -84,8 +87,17 @@ class SupportTicketController extends Controller
                 $this->supportTicketService->storeReplyAttachments([$file], $user->id, $reply->id);
             }
 
+            $this->supportTicketService->appendOpeningAutoReply($ticket);
+
             return $ticket->fresh();
         });
+
+        if ($this->supportTicketService->ticketAlreadyHasReplyWithMessageMarkdown(
+            $ticket->id,
+            SupportTicketOpeningAutoReply::MARKDOWN,
+        )) {
+            $this->notifyTicketOwnerOfAdminReply($ticket, $user);
+        }
 
         return response()->json(['data' => $ticket]);
     }
@@ -179,5 +191,27 @@ class SupportTicketController extends Controller
         });
 
         return response()->json(['data' => $ticket->fresh()]);
+    }
+
+    private function notifyTicketOwnerOfAdminReply(SupportTicket $ticket, User $owner): void
+    {
+        $actorUserId = $this->supportTicketService->resolveAutoReplyActorUserId();
+        if ($actorUserId === null) {
+            return;
+        }
+
+        $actor = User::query()->find($actorUserId);
+        if ($actor === null) {
+            return;
+        }
+
+        $notification = new SupportTicketReplyNotification;
+        $notification->setAttribute('ticket', $ticket->fresh());
+        $notification->setAttribute('from', $actor);
+        try {
+            $notification->notify($owner);
+        } catch (\Throwable $e) {
+            report($e);
+        }
     }
 }

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -20,6 +20,7 @@ class SupportTicketController extends Controller
             'contact' => 'normal',
             'feedback' => 'low',
             'account_verification' => 'high',
+            'account_recovery' => 'high',
         ];
     }
 
@@ -52,7 +53,7 @@ class SupportTicketController extends Controller
     public function create(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'type' => 'required|in:bug_report,contact,feedback,report,account_verification',
+            'type' => 'required|in:bug_report,contact,feedback,report,account_verification,account_recovery',
             'subject' => 'required|string|min:3|max:160',
             'message_markdown' => 'required|string|min:1',
             'attachments' => 'nullable|array|max:3',

--- a/app/Http/Controllers/Concerns/StreamsSupportTicketAttachments.php
+++ b/app/Http/Controllers/Concerns/StreamsSupportTicketAttachments.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace STS\Http\Controllers\Concerns;
+
+use Illuminate\Http\JsonResponse;
+use STS\Models\SupportTicketAttachment;
+use STS\Services\SupportTicketService;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+trait StreamsSupportTicketAttachments
+{
+    private function streamSupportTicketAttachment(
+        SupportTicketService $supportTicketService,
+        int $ticketId,
+        int $attachmentId,
+    ): StreamedResponse|JsonResponse {
+        $attachment = $supportTicketService->findTicketAttachment($ticketId, $attachmentId);
+        if ($attachment === null) {
+            return response()->json(['error' => 'Attachment not found'], 404);
+        }
+
+        return $this->streamSupportTicketAttachmentModel($supportTicketService, $attachment);
+    }
+
+    private function streamSupportTicketAttachmentModel(
+        SupportTicketService $supportTicketService,
+        SupportTicketAttachment $attachment,
+    ): StreamedResponse|JsonResponse {
+        $disk = $supportTicketService->diskForAttachmentPath($attachment->path);
+        if ($disk === null) {
+            return response()->json(['error' => 'Attachment not found'], 404);
+        }
+
+        $mime = $attachment->mime ?: $disk->mimeType($attachment->path) ?: 'application/octet-stream';
+
+        return response()->stream(function () use ($disk, $attachment) {
+            $stream = $disk->readStream($attachment->path);
+            if ($stream) {
+                fpassthru($stream);
+                fclose($stream);
+            }
+        }, 200, [
+            'Content-Type' => $mime,
+            'Content-Disposition' => 'inline; filename="'.addslashes($attachment->original_name).'"',
+        ]);
+    }
+}

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -29,9 +29,26 @@ class SupportTicket extends Model
         'account_recovery' => 'high',
     ];
 
+    public const STATUS_NEEDS_REVIEW = 'Necesita revisión';
+
+    /** @var list<string> */
+    public const STATUSES = [
+        'Open',
+        'Esperando respuesta',
+        'En revision',
+        self::STATUS_NEEDS_REVIEW,
+        'Resuelto',
+        'Cerrado',
+    ];
+
     public static function typeValidationRule(): string
     {
         return 'required|in:'.implode(',', self::TYPES);
+    }
+
+    public static function statusValidationRule(): string
+    {
+        return 'required|in:'.implode(',', self::STATUSES);
     }
 
     protected $fillable = [

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -9,6 +9,31 @@ class SupportTicket extends Model
 {
     use HasFactory;
 
+    /** @var list<string> */
+    public const TYPES = [
+        'bug_report',
+        'contact',
+        'feedback',
+        'report',
+        'account_verification',
+        'account_recovery',
+    ];
+
+    /** @var array<string, string> */
+    public const TYPE_DEFAULT_PRIORITIES = [
+        'report' => 'high',
+        'bug_report' => 'normal',
+        'contact' => 'normal',
+        'feedback' => 'low',
+        'account_verification' => 'high',
+        'account_recovery' => 'high',
+    ];
+
+    public static function typeValidationRule(): string
+    {
+        return 'required|in:'.implode(',', self::TYPES);
+    }
+
     protected $fillable = [
         'user_id',
         'type',

--- a/app/Services/ImageUploadValidator.php
+++ b/app/Services/ImageUploadValidator.php
@@ -9,12 +9,18 @@ class ImageUploadValidator
     /**
      * Validate an uploaded image file (MIME, extension, size).
      *
+     * @param  list<string>|null  $allowedMimes
+     * @param  list<string>|null  $allowedExtensions
      * @return array{valid: bool, errors?: array<string, array<string>>}
      */
-    public function validate(UploadedFile $file, ?string $field = 'image'): array
-    {
-        $allowedMimes = config('carpoolear.image_upload_allowed_mimes', []);
-        $allowedExtensions = config('carpoolear.image_upload_allowed_extensions', []);
+    public function validate(
+        UploadedFile $file,
+        ?string $field = 'image',
+        ?array $allowedMimes = null,
+        ?array $allowedExtensions = null,
+    ): array {
+        $allowedMimes = $allowedMimes ?? config('carpoolear.image_upload_allowed_mimes', []);
+        $allowedExtensions = $allowedExtensions ?? config('carpoolear.image_upload_allowed_extensions', []);
         $maxBytesRaw = config('carpoolear.image_upload_max_bytes');
         $maxBytes = (int) ($maxBytesRaw ?? 10 * 1024 * 1024);
 

--- a/app/Services/SupportTicketAttachmentStorage.php
+++ b/app/Services/SupportTicketAttachmentStorage.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace STS\Services;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use STS\Models\SupportTicketAttachment;
+use STS\Models\SupportTicketReply;
+
+class SupportTicketAttachmentStorage
+{
+    public const PATH_PREFIX = 'support_tickets';
+
+    public function __construct(
+        private readonly ImageUploadValidator $imageUploadValidator,
+        private readonly HeicToJpegConverter $heicToJpegConverter,
+    ) {}
+
+    public function storeForReply(UploadedFile $file, int $ticketId, int $replyId, int $userId): SupportTicketAttachment
+    {
+        $result = $this->imageUploadValidator->validate($file, 'attachments');
+        if (! ($result['valid'] ?? false)) {
+            throw ValidationException::withMessages($result['errors'] ?? [
+                'attachments' => ['Invalid image upload.'],
+            ]);
+        }
+
+        $basePath = self::PATH_PREFIX.'/'.$ticketId.'/'.$replyId;
+        $path = $this->storeImageFile($file, $basePath);
+
+        return SupportTicketAttachment::create([
+            'reply_id' => $replyId,
+            'ticket_id' => null,
+            'user_id' => $userId,
+            'path' => $path,
+            'original_name' => $file->getClientOriginalName(),
+            'mime' => $this->mimeForPath($path, $file),
+            'size_bytes' => (int) Storage::disk('local')->size($path),
+        ]);
+    }
+
+    public function findForTicket(int $ticketId, int $attachmentId): ?SupportTicketAttachment
+    {
+        $attachment = SupportTicketAttachment::query()->find($attachmentId);
+        if ($attachment === null) {
+            return null;
+        }
+
+        if ($attachment->reply_id !== null) {
+            $ownsReply = SupportTicketReply::query()
+                ->whereKey($attachment->reply_id)
+                ->where('ticket_id', $ticketId)
+                ->exists();
+
+            return $ownsReply ? $attachment : null;
+        }
+
+        return (int) $attachment->ticket_id === $ticketId ? $attachment : null;
+    }
+
+    public function purgeForTicket(int $ticketId): int
+    {
+        $replyIds = SupportTicketReply::query()
+            ->where('ticket_id', $ticketId)
+            ->pluck('id');
+
+        $attachments = SupportTicketAttachment::query()
+            ->where(function ($query) use ($ticketId, $replyIds) {
+                $query->where('ticket_id', $ticketId);
+                if ($replyIds->isNotEmpty()) {
+                    $query->orWhereIn('reply_id', $replyIds);
+                }
+            })
+            ->get();
+
+        foreach ($attachments as $attachment) {
+            $this->deleteStoredFile($attachment->path);
+            $attachment->delete();
+        }
+
+        return $attachments->count();
+    }
+
+    public function diskForPath(string $path): ?Filesystem
+    {
+        if (Storage::disk('local')->exists($path)) {
+            return Storage::disk('local');
+        }
+
+        if (Storage::disk('public')->exists($path)) {
+            return Storage::disk('public');
+        }
+
+        return null;
+    }
+
+    private function storeImageFile(UploadedFile $file, string $basePath): string
+    {
+        $jpegContent = $this->heicToJpegConverter->convert($file);
+        if ($jpegContent !== null) {
+            $path = $basePath.'/'.Str::random(40).'.jpg';
+            Storage::disk('local')->put($path, $jpegContent);
+
+            return $path;
+        }
+
+        return $file->store($basePath, 'local');
+    }
+
+    private function deleteStoredFile(string $path): void
+    {
+        $disk = $this->diskForPath($path);
+        if ($disk !== null) {
+            $disk->delete($path);
+        }
+    }
+
+    private function mimeForPath(string $path, UploadedFile $file): string
+    {
+        return Storage::disk('local')->mimeType($path)
+            ?: $file->getMimeType()
+            ?: 'application/octet-stream';
+    }
+}

--- a/app/Services/SupportTicketAttachmentStorage.php
+++ b/app/Services/SupportTicketAttachmentStorage.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
+use STS\Support\ImageAttachmentRules;
 
 class SupportTicketAttachmentStorage
 {
@@ -21,7 +22,12 @@ class SupportTicketAttachmentStorage
 
     public function storeForReply(UploadedFile $file, int $ticketId, int $replyId, int $userId): SupportTicketAttachment
     {
-        $result = $this->imageUploadValidator->validate($file, 'attachments');
+        $result = $this->imageUploadValidator->validate(
+            $file,
+            'attachments',
+            ImageAttachmentRules::ALLOWED_MIMES,
+            ImageAttachmentRules::ALLOWED_EXTENSIONS,
+        );
         if (! ($result['valid'] ?? false)) {
             throw ValidationException::withMessages($result['errors'] ?? [
                 'attachments' => ['Invalid image upload.'],

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Str;
 use STS\Models\SupportTicket;
 use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
+use STS\Models\User;
+use STS\Support\SupportTicketOpeningAutoReply;
 
 class SupportTicketService
 {
@@ -27,6 +29,41 @@ class SupportTicketService
      * {@see applyAdminReplyTransition}
      */
     private const ADMIN_REPLY_SETS_WAITING_FOR_USER = ['Open', 'Esperando respuesta', 'En revision'];
+
+    public function appendOpeningAutoReply(SupportTicket $ticket): void
+    {
+        $actorUserId = $this->resolveAutoReplyActorUserId();
+        if ($actorUserId === null) {
+            return;
+        }
+
+        if ($this->ticketAlreadyHasReplyWithMessageMarkdown($ticket->id, SupportTicketOpeningAutoReply::MARKDOWN)) {
+            return;
+        }
+
+        SupportTicketReply::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $actorUserId,
+            'is_admin' => true,
+            'message_markdown' => SupportTicketOpeningAutoReply::MARKDOWN,
+            'created_by' => null,
+        ]);
+
+        $this->applyAdminReplyTransition($ticket, $actorUserId);
+        $ticket->save();
+    }
+
+    public function resolveAutoReplyActorUserId(): ?int
+    {
+        $configured = config('carpoolear.support_ticket_auto_reply_user_id');
+        if ($configured) {
+            return (int) $configured;
+        }
+
+        $adminId = User::query()->where('is_admin', 1)->orderBy('id')->value('id');
+
+        return $adminId ? (int) $adminId : null;
+    }
 
     public function storeReplyAttachments(array $files, int $userId, int $replyId): void
     {

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -30,15 +30,15 @@ class SupportTicketService
      */
     private const ADMIN_REPLY_SETS_WAITING_FOR_USER = ['Open', 'Esperando respuesta', 'En revision'];
 
-    public function appendOpeningAutoReply(SupportTicket $ticket): void
+    public function appendOpeningAutoReply(SupportTicket $ticket): bool
     {
         $actorUserId = $this->resolveAutoReplyActorUserId();
         if ($actorUserId === null) {
-            return;
+            return false;
         }
 
         if ($this->ticketAlreadyHasReplyWithMessageMarkdown($ticket->id, SupportTicketOpeningAutoReply::MARKDOWN)) {
-            return;
+            return false;
         }
 
         SupportTicketReply::create([
@@ -51,6 +51,8 @@ class SupportTicketService
 
         $this->applyAdminReplyTransition($ticket, $actorUserId);
         $ticket->save();
+
+        return true;
     }
 
     public function resolveAutoReplyActorUserId(): ?int

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -120,4 +120,32 @@ class SupportTicketService
         $ticket->last_reply_at = now();
         $ticket->updated_by = $actorUserId;
     }
+
+    /**
+     * Status to restore when undoing "Resuelto", based on who sent the latest reply.
+     */
+    public function statusAfterUndoResolve(SupportTicket $ticket): string
+    {
+        $lastReply = $ticket->replies()
+            ->orderByDesc('id')
+            ->first();
+
+        if ($lastReply === null) {
+            return 'En revision';
+        }
+
+        return $lastReply->is_admin ? 'Esperando respuesta' : 'En revision';
+    }
+
+    public function unresolveTicket(SupportTicket $ticket, int $adminUserId): void
+    {
+        $ticket->status = $this->statusAfterUndoResolve($ticket);
+        $ticket->updated_by = $adminUserId;
+        $ticket->save();
+    }
+
+    public function ticketAcceptsReplies(SupportTicket $ticket): bool
+    {
+        return ! in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true);
+    }
 }

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -3,8 +3,6 @@
 namespace STS\Services;
 
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use STS\Models\SupportTicket;
 use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
@@ -13,6 +11,10 @@ use STS\Support\SupportTicketOpeningAutoReply;
 
 class SupportTicketService
 {
+    public function __construct(
+        private readonly SupportTicketAttachmentStorage $attachmentStorage,
+    ) {}
+
     /** Statuses where neither party may add replies via normal flows. */
     private const TERMINAL_USER_REPLY_STATUSES = ['Resuelto', 'Cerrado'];
 
@@ -59,7 +61,9 @@ class SupportTicketService
     {
         $configured = config('carpoolear.support_ticket_auto_reply_user_id');
         if ($configured) {
-            return (int) $configured;
+            $id = User::query()->whereKey((int) $configured)->value('id');
+
+            return $id ? (int) $id : null;
         }
 
         $adminId = User::query()->where('is_admin', true)->orderBy('id')->value('id');
@@ -67,27 +71,30 @@ class SupportTicketService
         return $adminId ? (int) $adminId : null;
     }
 
-    public function storeReplyAttachments(array $files, int $userId, int $replyId): void
+    public function storeReplyAttachments(array $files, int $ticketId, int $userId, int $replyId): void
     {
         foreach ($files as $file) {
             if (! ($file instanceof UploadedFile)) {
                 continue;
             }
 
-            $folder = 'support/'.date('Y').'/'.date('m');
-            $filename = Str::ulid().'_'.Str::random(20).'.'.$file->getClientOriginalExtension();
-            $path = Storage::disk('public')->putFileAs($folder, $file, $filename);
-
-            SupportTicketAttachment::create([
-                'reply_id' => $replyId,
-                'ticket_id' => null,
-                'user_id' => $userId,
-                'path' => $path,
-                'original_name' => $file->getClientOriginalName(),
-                'mime' => $file->getMimeType() ?? 'application/octet-stream',
-                'size_bytes' => (int) $file->getSize(),
-            ]);
+            $this->attachmentStorage->storeForReply($file, $ticketId, $replyId, $userId);
         }
+    }
+
+    public function purgeTicketAttachments(int $ticketId): int
+    {
+        return $this->attachmentStorage->purgeForTicket($ticketId);
+    }
+
+    public function findTicketAttachment(int $ticketId, int $attachmentId): ?SupportTicketAttachment
+    {
+        return $this->attachmentStorage->findForTicket($ticketId, $attachmentId);
+    }
+
+    public function diskForAttachmentPath(string $path): ?\Illuminate\Contracts\Filesystem\Filesystem
+    {
+        return $this->attachmentStorage->diskForPath($path);
     }
 
     /** Marks unread for admins and moves active tickets to pending team review. */

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -62,7 +62,7 @@ class SupportTicketService
             return (int) $configured;
         }
 
-        $adminId = User::query()->where('is_admin', 1)->orderBy('id')->value('id');
+        $adminId = User::query()->where('is_admin', true)->orderBy('id')->value('id');
 
         return $adminId ? (int) $adminId : null;
     }

--- a/app/Support/ImageAttachmentRules.php
+++ b/app/Support/ImageAttachmentRules.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace STS\Support;
+
+final class ImageAttachmentRules
+{
+    /** @var string Laravel validation rule for a single uploaded image attachment */
+    public const FILE = 'file|mimes:jpg,jpeg,png,webp|max:10240';
+
+    /** @var list<string> */
+    public const ALLOWED_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+
+    /** @var list<string> */
+    public const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
+
+    public static function requiredImage(): string
+    {
+        return 'required|'.self::FILE;
+    }
+}

--- a/app/Support/SupportTicketOpeningAutoReply.php
+++ b/app/Support/SupportTicketOpeningAutoReply.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace STS\Support;
+
+final class SupportTicketOpeningAutoReply
+{
+    public const MARKDOWN = <<<'MARKDOWN'
+¡Hola!
+
+Somos un equipo 100% voluntario, cada persona tiene su trabajo y llevamos adelante este proyecto cuando no estamos en esos horarios laborales. Respondemos dentro de las 48hs hábiles desde la consulta.
+Agradecemos que sepan entenderlo y valorarlo.
+
+Mientras nos esperas, podés ir leyendo el sitio [http://www.carpoolear.com.ar](http://www.carpoolear.com.ar) que tiene mucha info de ayuda y quizás te responda la consulta, en particular lo que son las [preguntas frecuentes](https://carpoolear.com.ar/plataforma-preguntas-frecuentes).
+
+Tené en cuenta que siempre estamos buscando personas que se sumen para colaborar en programación, sea por freelance o voluntariado, para poder resolver errores y mejorar la plataforma. A lo mejor conozcas a gente que programe, comentales acerca de Carpoolear por favor.
+
+Muchas gracias. ¡Abrazo!
+
+Equipo Carpoolear
+
+[Proyecto de gestión colectiva, sin fines de lucro y [código libre](https://github.com/sts-rosario) de la asociación civil [STS Rosario](https://stsrosario.org.ar/) en marcha desde el 2013. Vos también podés [sumarte](https://carpoolear.com.ar/colabora-como-colaborar) ó [DONAR](https://carpoolear.com.ar/donar) para que siga adelante :D]
+MARKDOWN;
+}

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,10 @@
     },
     "scripts": {
         "test": "php artisan test",
+        "check": [
+            "@php vendor/bin/pint --test app tests routes database config bootstrap",
+            "@test"
+        ],
         "test:coverage": "php -d memory_limit=512M artisan test --coverage",
         "test:coverage:ci": "php -d memory_limit=512M artisan test --coverage --min=50",
         "test:mutate": "bash scripts/pest-mutate.sh",

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -92,7 +92,7 @@ return [
     ],
 
     'trip_creation_limits' => [
-        'max_trips' => 4,        // Maximum number of trips allowed
+        'max_trips' => 100,        // Maximum number of trips allowed
         'time_window_hours' => 24,     // Time window in hours
     ],
 
@@ -112,6 +112,9 @@ return [
     'support_ticket_rate_limit_create_per_hour' => (int) env('SUPPORT_TICKET_RATE_LIMIT_CREATE_PER_HOUR', 5),
     'support_ticket_rate_limit_reply_per_hour' => (int) env('SUPPORT_TICKET_RATE_LIMIT_REPLY_PER_HOUR', 20),
     'support_ticket_rate_limit_admin_reply_per_hour' => (int) env('SUPPORT_TICKET_RATE_LIMIT_ADMIN_REPLY_PER_HOUR', 120),
+    'support_ticket_auto_reply_user_id' => env('SUPPORT_TICKET_AUTO_REPLY_USER_ID')
+        ? (int) env('SUPPORT_TICKET_AUTO_REPLY_USER_ID')
+        : null,
 
     // OSRM (trip-info + public map proxy). Primary = demo or self-hosted base URL without trailing slash.
     'osrm_router_base_url' => rtrim(env('OSRM_ROUTER_BASE_URL', 'https://router.project-osrm.org'), '/'),

--- a/routes/api.php
+++ b/routes/api.php
@@ -106,6 +106,7 @@ Route::middleware(['api'])->group(function () {
         Route::get('/tickets', [SupportTicketController::class, 'index']);
         Route::post('/tickets', [SupportTicketController::class, 'create'])->middleware('throttle:support-ticket-create');
         Route::get('/tickets/{id}', [SupportTicketController::class, 'show']);
+        Route::get('/tickets/{ticketId}/attachments/{attachmentId}/image', [SupportTicketController::class, 'attachmentImage']);
         Route::post('/tickets/{id}/replies', [SupportTicketController::class, 'reply'])->middleware('throttle:support-ticket-reply');
         Route::post('/tickets/{id}/close', [SupportTicketController::class, 'close']);
     });
@@ -268,6 +269,8 @@ Route::middleware(['api'])->group(function () {
         Route::post('support/tickets/{id}/close', [AdminSupportTicketController::class, 'close']);
         Route::post('support/tickets/{id}/reopen', [AdminSupportTicketController::class, 'reopen']);
         Route::post('support/tickets/{id}/needs-review', [AdminSupportTicketController::class, 'markNeedsReview']);
+        Route::get('support/tickets/{ticketId}/attachments/{attachmentId}/image', [AdminSupportTicketController::class, 'attachmentImage']);
+        Route::post('support/tickets/{id}/purge-attachments', [AdminSupportTicketController::class, 'purgeAttachments']);
 
         Route::post('support/reply-templates/{reply_template}/duplicate', [AdminSupportReplyTemplateController::class, 'duplicate']);
         Route::apiResource('support/reply-templates', AdminSupportReplyTemplateController::class)->except(['create', 'edit']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -267,6 +267,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('support/tickets/{id}/resolve', [AdminSupportTicketController::class, 'resolve']);
         Route::post('support/tickets/{id}/close', [AdminSupportTicketController::class, 'close']);
         Route::post('support/tickets/{id}/reopen', [AdminSupportTicketController::class, 'reopen']);
+        Route::post('support/tickets/{id}/needs-review', [AdminSupportTicketController::class, 'markNeedsReview']);
 
         Route::post('support/reply-templates/{reply_template}/duplicate', [AdminSupportReplyTemplateController::class, 'duplicate']);
         Route::apiResource('support/reply-templates', AdminSupportReplyTemplateController::class)->except(['create', 'edit']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -268,6 +268,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('support/tickets/{id}/resolve', [AdminSupportTicketController::class, 'resolve']);
         Route::post('support/tickets/{id}/close', [AdminSupportTicketController::class, 'close']);
         Route::post('support/tickets/{id}/reopen', [AdminSupportTicketController::class, 'reopen']);
+        Route::post('support/tickets/{id}/unresolve', [AdminSupportTicketController::class, 'unresolve']);
         Route::post('support/tickets/{id}/needs-review', [AdminSupportTicketController::class, 'markNeedsReview']);
         Route::get('support/tickets/{ticketId}/attachments/{attachmentId}/image', [AdminSupportTicketController::class, 'attachmentImage']);
         Route::post('support/tickets/{id}/purge-attachments', [AdminSupportTicketController::class, 'purgeAttachments']);

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -376,6 +376,30 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertNull($ticket->fresh()->internal_note_markdown);
     }
 
+    public function test_admin_created_ticket_does_not_include_opening_auto_reply(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/support/tickets', [
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Admin opened ticket',
+            'message_markdown' => 'Staff message only',
+        ])->assertOk();
+
+        $ticketId = (int) $response->json('data.id');
+        $replies = SupportTicketReply::query()->where('ticket_id', $ticketId)->orderBy('id')->get();
+
+        $this->assertCount(1, $replies);
+        $this->assertTrue((bool) $replies[0]->is_admin);
+        $this->assertSame('Staff message only', $replies[0]->message_markdown);
+        $this->assertStringNotContainsString('¡Hola!', $replies[0]->message_markdown);
+    }
+
     public function test_admin_can_create_account_verification_ticket_for_user_with_high_priority(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -340,6 +340,92 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertSame($admin->id, (int) $fresh->updated_by);
     }
 
+    public function test_unresolve_restores_esperando_respuesta_when_last_reply_is_admin(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Resuelto']);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User message',
+            'created_by' => $owner->id,
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin reply',
+            'created_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/unresolve')
+            ->assertOk()
+            ->assertJsonPath('data.status', 'Esperando respuesta');
+    }
+
+    public function test_unresolve_restores_en_revision_when_last_reply_is_user(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Resuelto']);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin reply',
+            'created_by' => $admin->id,
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User follow-up',
+            'created_by' => $owner->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/unresolve')
+            ->assertOk()
+            ->assertJsonPath('data.status', 'En revision');
+    }
+
+    public function test_unresolve_returns_422_when_ticket_is_not_resolved(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Open']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/unresolve')
+            ->assertStatus(422)
+            ->assertExactJson(['error' => 'Ticket is not resolved']);
+    }
+
+    public function test_admin_reply_returns_422_when_ticket_is_resolved(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Resuelto']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/replies', [
+            'message_markdown' => 'Trying after resolve',
+        ])
+            ->assertStatus(422)
+            ->assertExactJson(['error' => 'Ticket is closed for replies']);
+    }
+
     public function test_update_status_non_cerrado_does_not_set_closed_metadata(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -567,6 +567,96 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertSame($before, SupportTicketReply::where('ticket_id', $ticket->id)->count());
     }
 
+    public function test_reply_with_image_stores_file_on_local_support_tickets_disk(): void
+    {
+        Storage::fake('local');
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->post('api/admin/support/tickets/'.$ticket->id.'/replies', [
+            'message_markdown' => 'See screenshot',
+            'attachments' => [UploadedFile::fake()->image('screen.png')],
+        ])->assertOk();
+
+        $attachment = SupportTicketAttachment::query()->where('ticket_id', $ticket->id)
+            ->orWhereIn('reply_id', SupportTicketReply::where('ticket_id', $ticket->id)->pluck('id'))
+            ->first();
+        $this->assertNotNull($attachment);
+        $this->assertStringStartsWith('support_tickets/'.$ticket->id.'/', $attachment->path);
+        Storage::disk('local')->assertExists($attachment->path);
+    }
+
+    public function test_admin_can_stream_ticket_attachment_image(): void
+    {
+        Storage::fake('local');
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner);
+        $path = 'support_tickets/'.$ticket->id.'/1/shot.png';
+        Storage::disk('local')->put($path, 'png-bytes');
+        $reply = SupportTicketReply::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'Hi',
+        ]);
+        $attachment = SupportTicketAttachment::create([
+            'ticket_id' => null,
+            'reply_id' => $reply->id,
+            'user_id' => $owner->id,
+            'path' => $path,
+            'original_name' => 'shot.png',
+            'mime' => 'image/png',
+            'size_bytes' => 9,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->get('api/admin/support/tickets/'.$ticket->id.'/attachments/'.$attachment->id.'/image')
+            ->assertOk()
+            ->assertHeader('content-type', 'image/png');
+    }
+
+    public function test_purge_attachments_deletes_all_ticket_files_and_records(): void
+    {
+        Storage::fake('local');
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner);
+        $path = 'support_tickets/'.$ticket->id.'/1/a.png';
+        Storage::disk('local')->put($path, 'x');
+        $reply = SupportTicketReply::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'Hi',
+        ]);
+        SupportTicketAttachment::create([
+            'ticket_id' => null,
+            'reply_id' => $reply->id,
+            'user_id' => $owner->id,
+            'path' => $path,
+            'original_name' => 'a.png',
+            'mime' => 'image/png',
+            'size_bytes' => 1,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/purge-attachments')
+            ->assertOk()
+            ->assertJsonPath('message', 'Attachments purged');
+
+        $this->assertFalse(Storage::disk('local')->exists($path));
+        $this->assertSame(0, SupportTicketAttachment::query()->where('reply_id', $reply->id)->count());
+    }
+
     public function test_update_priority_persists_and_returns_ticket_payload(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -163,7 +163,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
 
     public function test_reply_without_message_is_unprocessable(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
 
         $admin = $this->adminUser();
         $owner = User::factory()->create();
@@ -178,7 +178,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
 
     public function test_reply_with_image_persists_attachment_for_reply(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
 
         $admin = $this->adminUser();
         $owner = User::factory()->create();
@@ -582,8 +582,8 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
             'attachments' => [UploadedFile::fake()->image('screen.png')],
         ])->assertOk();
 
-        $attachment = SupportTicketAttachment::query()->where('ticket_id', $ticket->id)
-            ->orWhereIn('reply_id', SupportTicketReply::where('ticket_id', $ticket->id)->pluck('id'))
+        $attachment = SupportTicketAttachment::query()
+            ->whereIn('reply_id', SupportTicketReply::where('ticket_id', $ticket->id)->pluck('id'))
             ->first();
         $this->assertNotNull($attachment);
         $this->assertStringStartsWith('support_tickets/'.$ticket->id.'/', $attachment->path);
@@ -761,7 +761,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
 
     public function test_reply_rejects_more_than_three_attachments(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
 
         $admin = $this->adminUser();
         $owner = User::factory()->create();
@@ -787,7 +787,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
 
     public function test_reply_rejects_attachment_with_disallowed_mime(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
 
         $admin = $this->adminUser();
         $owner = User::factory()->create();

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -502,6 +502,47 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         ])->assertUnprocessable();
     }
 
+    public function test_mark_needs_review_sets_status_and_creates_optional_admin_reply(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Open']);
+        $before = SupportTicketReply::where('ticket_id', $ticket->id)->count();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/support/tickets/'.$ticket->id.'/needs-review', [
+            'message_markdown' => 'Seguimiento interno pendiente.',
+        ])->assertOk();
+
+        $this->assertSame('Necesita revisión', $response->json('data.status'));
+        $this->assertSame($before + 1, SupportTicketReply::where('ticket_id', $ticket->id)->count());
+        $this->assertDatabaseHas('support_ticket_replies', [
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Seguimiento interno pendiente.',
+        ]);
+    }
+
+    public function test_mark_needs_review_without_message_only_updates_status(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Esperando respuesta']);
+        $before = SupportTicketReply::where('ticket_id', $ticket->id)->count();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/needs-review', [])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'Necesita revisión');
+
+        $this->assertSame($before, SupportTicketReply::where('ticket_id', $ticket->id)->count());
+    }
+
     public function test_update_priority_persists_and_returns_ticket_payload(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/ManualIdentityValidationApiTest.php
+++ b/tests/Feature/Http/ManualIdentityValidationApiTest.php
@@ -1358,12 +1358,11 @@ class ManualIdentityValidationApiTest extends TestCase
         $this->assertNull($validationRequest->front_image_path);
     }
 
-    public function test_submit_with_heic_stores_as_jpeg(): void
+    public function test_submit_rejects_heic_images(): void
     {
         if (! \STS\Services\HeicToJpegConverter::isAvailable()) {
-            $this->markTestSkipped('HEIC to JPEG conversion is not available (Imagick with HEIC support required)');
+            $this->markTestSkipped('HEIC fixture is not available (Imagick with HEIC support required)');
         }
-        config(['carpoolear.image_upload_convert_heic_to_jpeg' => true]);
         $user = User::factory()->create();
         $validationRequest = $this->createPaidValidationRequest($user);
 
@@ -1378,10 +1377,9 @@ class ManualIdentityValidationApiTest extends TestCase
             'selfie_image' => $selfie,
         ]);
 
-        $response->assertStatus(201);
+        $response->assertStatus(422);
         $validationRequest->refresh();
-        $this->assertNotNull($validationRequest->front_image_path);
-        $this->assertStringEndsWith('.jpg', $validationRequest->front_image_path);
+        $this->assertNull($validationRequest->front_image_path);
 
         @unlink($front->getRealPath());
     }

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -109,6 +109,7 @@ class SupportTicketApiTest extends TestCase
 
         $user = $this->createUser();
         $admin = $this->createUser(true);
+        config()->set('carpoolear.support_ticket_auto_reply_user_id', $admin->id);
 
         $this->actingAs($user, 'api');
         $createResponse = $this->post('api/support/tickets', [
@@ -124,10 +125,10 @@ class SupportTicketApiTest extends TestCase
         $createResponse->assertStatus(200);
         $ticketId = (int) data_get($createResponse->json(), 'data.id');
         $this->assertGreaterThan(0, $ticketId);
-        $this->assertSame('Open', data_get($createResponse->json(), 'data.status'));
+        $this->assertSame('Esperando respuesta', data_get($createResponse->json(), 'data.status'));
         $this->assertSame('normal', data_get($createResponse->json(), 'data.priority'));
-        $this->assertSame(0, data_get($createResponse->json(), 'data.unread_for_user'));
-        $this->assertSame(1, data_get($createResponse->json(), 'data.unread_for_admin'));
+        $this->assertSame(1, data_get($createResponse->json(), 'data.unread_for_user'));
+        $this->assertSame(0, data_get($createResponse->json(), 'data.unread_for_admin'));
 
         $this->actingAs($admin, 'api');
         $this->withoutMiddleware(\STS\Http\Middleware\UserAdmin::class);
@@ -136,7 +137,7 @@ class SupportTicketApiTest extends TestCase
         ]);
         $adminReply->assertStatus(200);
         $adminReply->assertJsonPath('data.status', 'Esperando respuesta');
-        $adminReply->assertJsonPath('data.unread_for_user', 1);
+        $adminReply->assertJsonPath('data.unread_for_user', 2);
         $adminReply->assertJsonPath('data.unread_for_admin', 0);
     }
 

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -617,6 +617,57 @@ class SupportTicketApiTest extends TestCase
         $ticket->assertJsonPath('data.priority', 'high');
     }
 
+    public function test_user_created_ticket_includes_opening_auto_reply_after_user_message(): void
+    {
+        $user = $this->createUser();
+        $admin = $this->createUser(true);
+        config()->set('carpoolear.support_ticket_auto_reply_user_id', $admin->id);
+
+        $this->actingAs($user, 'api');
+        $ticketId = (int) data_get($this->post('api/support/tickets', [
+            'type' => 'contact',
+            'subject' => 'Need help with account',
+            'message_markdown' => 'My opening question',
+        ])->json(), 'data.id');
+
+        $replies = SupportTicketReply::query()
+            ->where('ticket_id', $ticketId)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $replies);
+        $this->assertFalse((bool) $replies[0]->is_admin);
+        $this->assertSame('My opening question', $replies[0]->message_markdown);
+        $this->assertTrue((bool) $replies[1]->is_admin);
+        $this->assertStringContainsString('¡Hola!', $replies[1]->message_markdown);
+        $this->assertSame($admin->id, (int) $replies[1]->user_id);
+
+        $ticket = SupportTicket::query()->findOrFail($ticketId);
+        $this->assertSame('Esperando respuesta', $ticket->status);
+        $this->assertSame(1, (int) $ticket->unread_for_user);
+        $this->assertSame(0, (int) $ticket->unread_for_admin);
+    }
+
+    public function test_duplicate_user_ticket_create_does_not_append_second_opening_auto_reply(): void
+    {
+        $user = $this->createUser();
+        $admin = $this->createUser(true);
+        config()->set('carpoolear.support_ticket_auto_reply_user_id', $admin->id);
+
+        $payload = [
+            'type' => 'contact',
+            'subject' => 'Duplicate auto reply check',
+            'message_markdown' => 'Same opening body',
+        ];
+
+        $this->actingAs($user, 'api');
+        $firstId = (int) data_get($this->postJson('api/support/tickets', $payload)->json(), 'data.id');
+        $this->assertSame(2, SupportTicketReply::query()->where('ticket_id', $firstId)->count());
+
+        $this->postJson('api/support/tickets', $payload)->assertOk();
+        $this->assertSame(2, SupportTicketReply::query()->where('ticket_id', $firstId)->count());
+    }
+
     public function test_account_recovery_type_is_allowed_and_forced_to_high_priority(): void
     {
         $user = $this->createUser();

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -22,6 +22,8 @@ class SupportTicketApiTest extends TestCase
     {
         parent::setUp();
 
+        config()->set('carpoolear.support_ticket_auto_reply_user_id', null);
+
         if (! Schema::hasTable('support_tickets')) {
             Schema::create('support_tickets', function (Blueprint $table) {
                 $table->increments('id');
@@ -105,7 +107,7 @@ class SupportTicketApiTest extends TestCase
 
     public function test_user_creates_ticket_with_attachments_and_admin_reply_updates_unread_counters(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
 
         $user = $this->createUser();
         $admin = $this->createUser(true);
@@ -475,7 +477,7 @@ class SupportTicketApiTest extends TestCase
 
     public function test_reply_persists_user_attachment_and_advances_ticket_status(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
 
         $user = $this->createUser();
         $this->actingAs($user, 'api');
@@ -486,7 +488,7 @@ class SupportTicketApiTest extends TestCase
             'message_markdown' => 'Initial',
         ])->json(), 'data.id');
 
-        $beforeFiles = count(Storage::disk('public')->allFiles());
+        $beforeFiles = count(Storage::disk('local')->allFiles());
 
         $this->post('api/support/tickets/'.$ticketId.'/replies', [
             'message_markdown' => 'Here is a screenshot',
@@ -495,7 +497,7 @@ class SupportTicketApiTest extends TestCase
             ],
         ])->assertStatus(200);
 
-        $this->assertGreaterThan($beforeFiles, count(Storage::disk('public')->allFiles()));
+        $this->assertGreaterThan($beforeFiles, count(Storage::disk('local')->allFiles()));
 
         $this->assertDatabaseHas('support_ticket_replies', [
             'ticket_id' => $ticketId,
@@ -532,7 +534,7 @@ class SupportTicketApiTest extends TestCase
 
     public function test_close_persists_status_and_optional_closing_message(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
         $user = $this->createUser();
         $this->actingAs($user, 'api');
 
@@ -733,14 +735,21 @@ class SupportTicketApiTest extends TestCase
 
     private function createUser(bool $isAdmin = false): User
     {
-        return User::query()->create([
+        $user = User::query()->create([
             'name' => 'Support Tester '.uniqid(),
             'email' => uniqid('support_', true).'@example.com',
             'password' => Hash::make('123456'),
             'active' => 1,
-            'is_admin' => $isAdmin ? 1 : 0,
             'terms_and_conditions' => 1,
             'emails_notifications' => 1,
         ]);
+
+        if ($isAdmin) {
+            $user->forceFill(['is_admin' => true])->saveQuietly();
+
+            return $user->fresh();
+        }
+
+        return $user;
     }
 }

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -618,6 +618,51 @@ class SupportTicketApiTest extends TestCase
         $ticket->assertJsonPath('data.priority', 'high');
     }
 
+    public function test_user_can_stream_own_ticket_attachment_image(): void
+    {
+        Storage::fake('local');
+        $user = $this->createUser();
+        $this->actingAs($user, 'api');
+
+        $ticketId = (int) data_get($this->post('api/support/tickets', [
+            'type' => 'contact',
+            'subject' => 'With image',
+            'message_markdown' => 'See attach',
+            'attachments' => [UploadedFile::fake()->image('proof.jpg')],
+        ])->json(), 'data.id');
+
+        $attachment = SupportTicketAttachment::query()
+            ->whereIn('reply_id', SupportTicketReply::where('ticket_id', $ticketId)->pluck('id'))
+            ->firstOrFail();
+        $this->assertStringStartsWith('support_tickets/'.$ticketId.'/', $attachment->path);
+        Storage::disk('local')->assertExists($attachment->path);
+
+        $this->get('api/support/tickets/'.$ticketId.'/attachments/'.$attachment->id.'/image')
+            ->assertOk();
+    }
+
+    public function test_user_cannot_stream_another_users_ticket_attachment(): void
+    {
+        Storage::fake('local');
+        $owner = $this->createUser();
+        $stranger = $this->createUser();
+
+        $this->actingAs($owner, 'api');
+        $ticketId = (int) data_get($this->post('api/support/tickets', [
+            'type' => 'contact',
+            'subject' => 'Private',
+            'message_markdown' => 'Mine',
+            'attachments' => [UploadedFile::fake()->image('mine.jpg')],
+        ])->json(), 'data.id');
+        $attachmentId = (int) SupportTicketAttachment::query()
+            ->whereIn('reply_id', SupportTicketReply::where('ticket_id', $ticketId)->pluck('id'))
+            ->value('id');
+
+        $this->actingAs($stranger, 'api');
+        $this->getJson('api/support/tickets/'.$ticketId.'/attachments/'.$attachmentId.'/image')
+            ->assertNotFound();
+    }
+
     public function test_user_created_ticket_includes_opening_auto_reply_after_user_message(): void
     {
         $user = $this->createUser();

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -617,6 +617,23 @@ class SupportTicketApiTest extends TestCase
         $ticket->assertJsonPath('data.priority', 'high');
     }
 
+    public function test_account_recovery_type_is_allowed_and_forced_to_high_priority(): void
+    {
+        $user = $this->createUser();
+        $this->actingAs($user, 'api');
+
+        $ticket = $this->post('api/support/tickets', [
+            'type' => 'account_recovery',
+            'subject' => 'Recuperacion de cuenta',
+            'message_markdown' => 'Tengo una cuenta duplicada y necesito recuperar el acceso.',
+            'priority' => 'low',
+        ]);
+
+        $ticket->assertStatus(200);
+        $ticket->assertJsonPath('data.type', 'account_recovery');
+        $ticket->assertJsonPath('data.priority', 'high');
+    }
+
     private function createUser(bool $isAdmin = false): User
     {
         return User::query()->create([

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -11,6 +11,11 @@ use Tests\TestCase;
 
 class SupportTicketTest extends TestCase
 {
+    public function test_type_default_priorities_assigns_high_to_account_recovery(): void
+    {
+        $this->assertSame('high', SupportTicket::TYPE_DEFAULT_PRIORITIES['account_recovery']);
+    }
+
     public function test_fillable_contains_expected_mass_assignable_attributes(): void
     {
         $this->assertSame([

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -16,6 +16,11 @@ class SupportTicketTest extends TestCase
         $this->assertSame('high', SupportTicket::TYPE_DEFAULT_PRIORITIES['account_recovery']);
     }
 
+    public function test_statuses_include_needs_review(): void
+    {
+        $this->assertContains(SupportTicket::STATUS_NEEDS_REVIEW, SupportTicket::STATUSES);
+    }
+
     public function test_fillable_contains_expected_mass_assignable_attributes(): void
     {
         $this->assertSame([

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -38,7 +38,8 @@ class SupportTicketServiceTest extends TestCase
         ]);
 
         $service = new SupportTicketService;
-        $service->appendOpeningAutoReply($ticket->fresh());
+        $this->assertTrue($service->appendOpeningAutoReply($ticket->fresh()));
+        $this->assertFalse($service->appendOpeningAutoReply($ticket->fresh()));
 
         $replies = SupportTicketReply::query()->where('ticket_id', $ticket->id)->orderBy('id')->get();
         $this->assertCount(2, $replies);

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -14,6 +14,11 @@ use Tests\TestCase;
 
 class SupportTicketServiceTest extends TestCase
 {
+    private function service(): SupportTicketService
+    {
+        return $this->app->make(SupportTicketService::class);
+    }
+
     public function test_append_opening_auto_reply_creates_admin_reply_after_user_message(): void
     {
         $owner = User::factory()->create();
@@ -37,7 +42,7 @@ class SupportTicketServiceTest extends TestCase
             'created_by' => $owner->id,
         ]);
 
-        $service = new SupportTicketService;
+        $service = $this->service();
         $this->assertTrue($service->appendOpeningAutoReply($ticket->fresh()));
         $this->assertFalse($service->appendOpeningAutoReply($ticket->fresh()));
 
@@ -67,15 +72,15 @@ class SupportTicketServiceTest extends TestCase
             'created_by' => $user->id,
         ]);
 
-        $service = new SupportTicketService;
+        $service = $this->service();
 
         $this->assertTrue($service->ticketAlreadyHasReplyWithMessageMarkdown($ticket->id, 'Already posted'));
         $this->assertFalse($service->ticketAlreadyHasReplyWithMessageMarkdown($ticket->id, 'New content'));
     }
 
-    public function test_store_reply_attachments_continues_after_invalid_item_and_processes_next_file(): void
+    public function test_store_reply_attachments_skips_non_files_and_stores_valid_images(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
         $user = User::factory()->create();
         $ticket = SupportTicket::query()->create([
             'user_id' => $user->id,
@@ -91,11 +96,11 @@ class SupportTicketServiceTest extends TestCase
             'message_markdown' => 'details',
         ]);
 
-        $validFile = UploadedFile::fake()->create('proof.pdf', 15, 'application/pdf');
+        $validFile = UploadedFile::fake()->image('proof.png');
 
-        $service = new SupportTicketService;
-        $service->storeReplyAttachments(
+        $this->service()->storeReplyAttachments(
             ['not-a-file', $validFile],
+            $ticket->id,
             $user->id,
             $reply->id
         );
@@ -105,17 +110,15 @@ class SupportTicketServiceTest extends TestCase
 
     public function test_store_reply_attachments_with_empty_array_creates_no_records(): void
     {
-        Storage::fake('public');
-        $service = new SupportTicketService;
-
-        $service->storeReplyAttachments([], 1, 1);
+        Storage::fake('local');
+        $this->service()->storeReplyAttachments([], 1, 1, 1);
 
         $this->assertSame(0, SupportTicketAttachment::query()->count());
     }
 
     public function test_store_reply_attachments_persists_only_uploaded_files(): void
     {
-        Storage::fake('public');
+        Storage::fake('local');
         $user = User::factory()->create();
         $ticket = SupportTicket::query()->create([
             'user_id' => $user->id,
@@ -133,9 +136,9 @@ class SupportTicketServiceTest extends TestCase
 
         $validFile = UploadedFile::fake()->create('evidence.png', 20, 'image/png');
 
-        $service = new SupportTicketService;
-        $service->storeReplyAttachments(
+        $this->service()->storeReplyAttachments(
             [$validFile, 'not-a-file'],
+            $ticket->id,
             $user->id,
             $reply->id
         );
@@ -147,66 +150,9 @@ class SupportTicketServiceTest extends TestCase
         $this->assertSame($user->id, (int) $attachment->user_id);
         $this->assertNull($attachment->ticket_id);
         $this->assertSame('evidence.png', $attachment->original_name);
-        $this->assertMatchesRegularExpression(
-            '#^support/\d{4}/\d{2}/[A-Z0-9]{26}_[A-Za-z0-9]{20}\.png$#',
-            $attachment->path
-        );
+        $this->assertStringStartsWith('support_tickets/'.$ticket->id.'/'.$reply->id.'/', $attachment->path);
         $this->assertSame('image/png', $attachment->mime);
-        $this->assertIsInt($attachment->fresh()->size_bytes);
-        $this->assertSame(20480, $attachment->fresh()->size_bytes);
-        $this->assertArrayHasKey('ticket_id', $attachment->fresh()->getAttributes());
-        $this->assertNull($attachment->fresh()->ticket_id);
-        Storage::disk('public')->assertExists($attachment->path);
-    }
-
-    public function test_store_reply_attachments_uses_fallback_mime_and_integer_size_when_mime_is_missing(): void
-    {
-        Storage::fake('public');
-        $user = User::factory()->create();
-        $ticket = SupportTicket::query()->create([
-            'user_id' => $user->id,
-            'type' => 'bug',
-            'subject' => 'App issue',
-            'status' => 'Open',
-            'priority' => 'normal',
-        ]);
-        $reply = SupportTicketReply::query()->create([
-            'ticket_id' => $ticket->id,
-            'user_id' => $user->id,
-            'is_admin' => false,
-            'message_markdown' => 'details',
-        ]);
-
-        $tempPath = tempnam(sys_get_temp_dir(), 'st-attachment-');
-        file_put_contents($tempPath, 'manual attachment payload');
-        $file = new class($tempPath) extends UploadedFile
-        {
-            public function __construct(string $path)
-            {
-                parent::__construct($path, 'evidence.bin', null, null, true);
-            }
-
-            public function getMimeType(): ?string
-            {
-                return null;
-            }
-
-            public function getSize(): int|false
-            {
-                return 3210;
-            }
-        };
-
-        $service = new SupportTicketService;
-        $service->storeReplyAttachments([$file], $user->id, $reply->id);
-        @unlink($tempPath);
-
-        $attachment = SupportTicketAttachment::query()->where('reply_id', $reply->id)->first();
-        $this->assertNotNull($attachment);
-        $this->assertSame('application/octet-stream', $attachment->mime);
-        $this->assertSame(3210, (int) $attachment->size_bytes);
-        $this->assertSame('evidence.bin', $attachment->original_name);
-        Storage::disk('public')->assertExists($attachment->path);
+        Storage::disk('local')->assertExists($attachment->path);
     }
 
     public function test_apply_admin_reply_transition_updates_status_and_counters(): void
@@ -217,8 +163,7 @@ class SupportTicketServiceTest extends TestCase
             'unread_for_admin' => 3,
         ]);
 
-        $service = new SupportTicketService;
-        $service->applyAdminReplyTransition($ticket, 99);
+        $this->service()->applyAdminReplyTransition($ticket, 99);
 
         $this->assertSame('Esperando respuesta', $ticket->status);
         $this->assertSame(1, $ticket->unread_for_user);
@@ -235,7 +180,7 @@ class SupportTicketServiceTest extends TestCase
             'unread_for_admin' => 4,
         ]);
 
-        $service = new SupportTicketService;
+        $service = $this->service();
         $service->applyAdminReplyTransition($ticket, 22);
 
         $this->assertSame('Esperando respuesta', $ticket->status);
@@ -253,7 +198,7 @@ class SupportTicketServiceTest extends TestCase
             'unread_for_admin' => 2,
         ]);
 
-        $service = new SupportTicketService;
+        $service = $this->service();
         $service->applyAdminReplyTransition($ticket, 44);
 
         $this->assertSame('Necesita revisión', $ticket->status);
@@ -269,7 +214,7 @@ class SupportTicketServiceTest extends TestCase
             'unread_for_admin' => 2,
         ]);
 
-        $service = new SupportTicketService;
+        $service = $this->service();
         $service->applyAdminReplyTransition($ticket, 55);
 
         $this->assertSame('Resuelto', $ticket->status);
@@ -287,8 +232,7 @@ class SupportTicketServiceTest extends TestCase
             'unread_for_admin' => 1,
         ]);
 
-        $service = new SupportTicketService;
-        $service->applyUserReplyTransition($ticket, 77);
+        $this->service()->applyUserReplyTransition($ticket, 77);
 
         $this->assertSame('En revision', $ticket->status);
         $this->assertSame(2, $ticket->unread_for_admin);
@@ -305,7 +249,7 @@ class SupportTicketServiceTest extends TestCase
             'unread_for_admin' => 0,
         ]);
 
-        $service = new SupportTicketService;
+        $service = $this->service();
         $service->applyUserReplyTransition($ticket, 101);
 
         $this->assertSame('En revision', $ticket->status);

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -209,6 +209,22 @@ class SupportTicketServiceTest extends TestCase
         $this->assertNotNull($ticket->last_reply_at);
     }
 
+    public function test_apply_admin_reply_transition_keeps_necesita_revision_status(): void
+    {
+        $ticket = new SupportTicket([
+            'status' => 'Necesita revisión',
+            'unread_for_user' => 1,
+            'unread_for_admin' => 2,
+        ]);
+
+        $service = new SupportTicketService;
+        $service->applyAdminReplyTransition($ticket, 44);
+
+        $this->assertSame('Necesita revisión', $ticket->status);
+        $this->assertSame(2, $ticket->unread_for_user);
+        $this->assertSame(0, $ticket->unread_for_admin);
+    }
+
     public function test_apply_admin_reply_transition_keeps_non_transitionable_status(): void
     {
         $ticket = new SupportTicket([

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -9,10 +9,45 @@ use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
 use STS\Models\User;
 use STS\Services\SupportTicketService;
+use STS\Support\SupportTicketOpeningAutoReply;
 use Tests\TestCase;
 
 class SupportTicketServiceTest extends TestCase
 {
+    public function test_append_opening_auto_reply_creates_admin_reply_after_user_message(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => 1]);
+        config()->set('carpoolear.support_ticket_auto_reply_user_id', $admin->id);
+
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'unread_for_admin' => 1,
+            'unread_for_user' => 0,
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User question',
+            'created_by' => $owner->id,
+        ]);
+
+        $service = new SupportTicketService;
+        $service->appendOpeningAutoReply($ticket->fresh());
+
+        $replies = SupportTicketReply::query()->where('ticket_id', $ticket->id)->orderBy('id')->get();
+        $this->assertCount(2, $replies);
+        $this->assertTrue((bool) $replies[1]->is_admin);
+        $this->assertSame(SupportTicketOpeningAutoReply::MARKDOWN, $replies[1]->message_markdown);
+        $this->assertSame($admin->id, (int) $replies[1]->user_id);
+        $this->assertSame('Esperando respuesta', $ticket->fresh()->status);
+    }
+
     public function test_ticket_already_has_reply_with_message_markdown_detects_existing_body(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -258,4 +258,97 @@ class SupportTicketServiceTest extends TestCase
         $this->assertSame(101, (int) $ticket->updated_by);
         $this->assertNotNull($ticket->last_reply_at);
     }
+
+    public function test_status_after_undo_resolve_when_last_reply_is_admin(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => 1]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Resuelto',
+            'priority' => 'normal',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin',
+        ]);
+
+        $this->assertSame(
+            'Esperando respuesta',
+            $this->service()->statusAfterUndoResolve($ticket->fresh())
+        );
+    }
+
+    public function test_status_after_undo_resolve_when_last_reply_is_user(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => 1]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Resuelto',
+            'priority' => 'normal',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User follow-up',
+        ]);
+
+        $this->assertSame(
+            'En revision',
+            $this->service()->statusAfterUndoResolve($ticket->fresh())
+        );
+    }
+
+    public function test_unresolve_ticket_restores_status_from_last_reply(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => 1]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Resuelto',
+            'priority' => 'normal',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Done',
+        ]);
+
+        $this->service()->unresolveTicket($ticket, $admin->id);
+
+        $this->assertSame('Esperando respuesta', $ticket->fresh()->status);
+        $this->assertSame($admin->id, (int) $ticket->fresh()->updated_by);
+    }
+
+    public function test_ticket_accepts_replies_is_false_for_resolved_and_closed(): void
+    {
+        $service = $this->service();
+
+        $this->assertFalse($service->ticketAcceptsReplies(new SupportTicket(['status' => 'Resuelto'])));
+        $this->assertFalse($service->ticketAcceptsReplies(new SupportTicket(['status' => 'Cerrado'])));
+        $this->assertTrue($service->ticketAcceptsReplies(new SupportTicket(['status' => 'Open'])));
+    }
 }

--- a/tests/Unit/Support/SupportTicketOpeningAutoReplyTest.php
+++ b/tests/Unit/Support/SupportTicketOpeningAutoReplyTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use STS\Support\SupportTicketOpeningAutoReply;
+use Tests\TestCase;
+
+class SupportTicketOpeningAutoReplyTest extends TestCase
+{
+    public function test_markdown_contains_expected_greeting_and_team_signoff(): void
+    {
+        $markdown = SupportTicketOpeningAutoReply::MARKDOWN;
+
+        $this->assertStringContainsString('¡Hola!', $markdown);
+        $this->assertStringContainsString('Equipo Carpoolear', $markdown);
+        $this->assertStringContainsString('preguntas frecuentes', $markdown);
+    }
+}


### PR DESCRIPTION
### Ticket type & workflow
- **`account_recovery`** support ticket type with **high** default priority.
- **`Necesita revisión`** status and admin endpoint `POST /api/admin/support/tickets/{id}/needs-review`.
- Types, statuses, and default priorities centralized on `SupportTicket` model.
### Opening auto-reply
- Automatic admin-style opening reply when a **user** creates a ticket (not on admin create or duplicates).
- Optional `SUPPORT_TICKET_AUTO_REPLY_USER_ID` in config; falls back to first admin user.
- Idempotent: does not append a second auto-reply on duplicate creates.
### Private attachments (manual-validation pattern)
- Images stored on **`local`** disk under `support_tickets/{ticketId}/{replyId}/` (HEIC → JPEG via existing validators).
- Authenticated stream endpoints:
  - User: `GET /api/support/tickets/{ticketId}/attachments/{attachmentId}/image`
  - Admin: `GET /api/admin/support/tickets/{ticketId}/attachments/{attachmentId}/image`
- Legacy **`public`** paths still readable via disk fallback.
- Admin **`POST /api/admin/support/tickets/{id}/purge-attachments`** deletes all attachment files and DB rows for the ticket.
### Resolve / unresolve
- **`POST /api/admin/support/tickets/{id}/unresolve`** — only when status is `Resuelto`; restores:
  - **`Esperando respuesta`** if the last reply is from admin
  - **`En revision`** if the last reply is from the user
- Admin and user replies blocked on **`Resuelto`** / **`Cerrado`** (422).
