### PR TITLE
Facebook profile URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,7 @@ MODULE_UNASWERED_MESSAGE_LIMIT=false # If enabled, implements a limit on unanswe
 MODULE_CONVERSATION_AVERAGE_DELAY=false # If enabled, the app shows the driver's message response speed and response rate on trip detail (TripDriver)
 MODULE_TRIP_SEATS_PAYMENT=false # If enabled, allows users to make payments for specific seats on a trip, implementing a payment system for trip reservations
 MODULE_VALIDATED_DRIVERS=false # If enabled, users must go through a verification process before they can create trips as drivers, adding a layer of safety and trust to the platform
+MODULE_FACEBOOK_PROFILE_URL_ENABLED=false # If enabled, profile forms expose an optional Facebook profile URL field
 MODULE_COORDINATE_BY_MESSAGE=true # Enables the ability to coordinate trip details through messages. When enabled, users can exchange specific trip coordination information through the messaging system.
 MODULE_TRIP_CREATION_PAYMENT_ENABLED=false # If enabled, the trip creator will be asked to pay a fee
 MODULE_TRIP_CREATION_PAYMENT_AMOUNT_CENTS=1500 # Amount in cents that the trip creator will have to pay if enabled

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,6 +23,3 @@ if [[ ${#files[@]} -gt 0 ]]; then
     git add "${existing[@]}"
   fi
 fi
-
-echo "pre-commit: php artisan test..."
-php artisan test

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,6 +69,7 @@ class User extends Authenticatable implements JWTSubject
             'account_type',
             'account_bank',
             'data_visibility',
+            'facebook_profile_url',
             'identity_validated',
             'identity_validated_at',
             'identity_validation_type',

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -46,6 +46,8 @@ class UsersManager extends BaseManager
 
     public function validator(array $data, $id = null, $is_social = false, $is_driver = false, $is_admin = false)
     {
+        $facebookModuleEnabled = (bool) config('carpoolear.module_facebook_profile_url_enabled', false);
+
         if ($id) {
             $rules = [
                 'name' => 'max:255',
@@ -75,6 +77,9 @@ class UsersManager extends BaseManager
                 ];
             }
         }
+        if ($facebookModuleEnabled) {
+            $rules['facebook_profile_url'] = 'nullable|url|max:255';
+        }
         if (config('carpoolear.module_validated_drivers', false) && $is_driver) {
             $rules['driver_data_docs'] = 'required|array|min:1';
         }
@@ -99,6 +104,9 @@ class UsersManager extends BaseManager
      */
     public function create(array $data, $validate = true, $is_social = false, $is_driver = false)
     {
+        if (! config('carpoolear.module_facebook_profile_url_enabled', false)) {
+            unset($data['facebook_profile_url']);
+        }
         \Log::info('Create USER: '.$data['name']);
         $v = $this->validator($data, null, $is_social, $is_driver);
         if ($v->fails() && $validate) {
@@ -219,6 +227,9 @@ class UsersManager extends BaseManager
 
     public function update($user, array $data, $is_driver = false, $is_admin = false)
     {
+        if (! config('carpoolear.module_facebook_profile_url_enabled', false)) {
+            unset($data['facebook_profile_url']);
+        }
         $requestData = $data;
         $data = $this->userEditablePropertiesService->filterForUser($data, $is_admin);
 

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -32,6 +32,11 @@ class UsersManager extends BaseManager
 
     protected $userEditablePropertiesService;
 
+    private function isFacebookProfileUrlModuleEnabled(): bool
+    {
+        return (bool) config('carpoolear.module_facebook_profile_url_enabled', false);
+    }
+
     public function __construct(
         UserRepository $userRep,
         TripRepository $tripRepository,
@@ -46,7 +51,7 @@ class UsersManager extends BaseManager
 
     public function validator(array $data, $id = null, $is_social = false, $is_driver = false, $is_admin = false)
     {
-        $facebookModuleEnabled = (bool) config('carpoolear.module_facebook_profile_url_enabled', false);
+        $facebookModuleEnabled = $this->isFacebookProfileUrlModuleEnabled();
 
         if ($id) {
             $rules = [
@@ -104,7 +109,7 @@ class UsersManager extends BaseManager
      */
     public function create(array $data, $validate = true, $is_social = false, $is_driver = false)
     {
-        if (! config('carpoolear.module_facebook_profile_url_enabled', false)) {
+        if (! $this->isFacebookProfileUrlModuleEnabled()) {
             unset($data['facebook_profile_url']);
         }
         \Log::info('Create USER: '.$data['name']);
@@ -227,7 +232,7 @@ class UsersManager extends BaseManager
 
     public function update($user, array $data, $is_driver = false, $is_admin = false)
     {
-        if (! config('carpoolear.module_facebook_profile_url_enabled', false)) {
+        if (! $this->isFacebookProfileUrlModuleEnabled()) {
             unset($data['facebook_profile_url']);
         }
         $requestData = $data;

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -20,6 +20,7 @@ use STS\Repository\UserRepository;
 use STS\Services\HeicToJpegConverter;
 use STS\Services\ImageUploadValidator;
 use STS\Services\UserEditablePropertiesService;
+use STS\Support\FacebookProfileUrl;
 use Validator;
 
 class UsersManager extends BaseManager
@@ -35,6 +36,27 @@ class UsersManager extends BaseManager
     private function isFacebookProfileUrlModuleEnabled(): bool
     {
         return (bool) config('carpoolear.module_facebook_profile_url_enabled', false);
+    }
+
+    private function prepareFacebookProfileUrl(array $data): array
+    {
+        if (! $this->isFacebookProfileUrlModuleEnabled() || ! array_key_exists('facebook_profile_url', $data)) {
+            return $data;
+        }
+
+        $raw = $data['facebook_profile_url'];
+        if ($raw === null || trim((string) $raw) === '') {
+            $data['facebook_profile_url'] = null;
+
+            return $data;
+        }
+
+        $normalized = FacebookProfileUrl::tryNormalize((string) $raw);
+        if ($normalized !== null) {
+            $data['facebook_profile_url'] = $normalized;
+        }
+
+        return $data;
     }
 
     public function __construct(
@@ -83,7 +105,18 @@ class UsersManager extends BaseManager
             }
         }
         if ($facebookModuleEnabled) {
-            $rules['facebook_profile_url'] = 'nullable|url|max:255';
+            $rules['facebook_profile_url'] = [
+                'nullable',
+                'max:255',
+                function ($attribute, $value, $fail) {
+                    if ($value === null || trim((string) $value) === '') {
+                        return;
+                    }
+                    if (FacebookProfileUrl::tryNormalize((string) $value) === null) {
+                        $fail('El enlace debe ser un perfil de Facebook válido (por ejemplo facebook.com/tu-perfil).');
+                    }
+                },
+            ];
         }
         if (config('carpoolear.module_validated_drivers', false) && $is_driver) {
             $rules['driver_data_docs'] = 'required|array|min:1';
@@ -111,6 +144,8 @@ class UsersManager extends BaseManager
     {
         if (! $this->isFacebookProfileUrlModuleEnabled()) {
             unset($data['facebook_profile_url']);
+        } else {
+            $data = $this->prepareFacebookProfileUrl($data);
         }
         \Log::info('Create USER: '.$data['name']);
         $v = $this->validator($data, null, $is_social, $is_driver);
@@ -234,6 +269,8 @@ class UsersManager extends BaseManager
     {
         if (! $this->isFacebookProfileUrlModuleEnabled()) {
             unset($data['facebook_profile_url']);
+        } else {
+            $data = $this->prepareFacebookProfileUrl($data);
         }
         $requestData = $data;
         $data = $this->userEditablePropertiesService->filterForUser($data, $is_admin);

--- a/app/Support/FacebookProfileUrl.php
+++ b/app/Support/FacebookProfileUrl.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace STS\Support;
+
+final class FacebookProfileUrl
+{
+    /** @var list<string> */
+    private const ALLOWED_HOSTS = [
+        'facebook.com',
+        'www.facebook.com',
+        'm.facebook.com',
+        'mbasic.facebook.com',
+    ];
+
+    /**
+     * @return string|null Canonical https://facebook.com/... URL, or null when empty/invalid
+     */
+    public static function tryNormalize(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        $withScheme = $trimmed;
+        if (! preg_match('#^https?://#i', $withScheme)) {
+            $withScheme = 'https://'.ltrim($withScheme, '/');
+        }
+
+        $parts = parse_url($withScheme);
+        if ($parts === false || empty($parts['host'])) {
+            return null;
+        }
+
+        $host = strtolower($parts['host']);
+        if (! self::isAllowedHost($host)) {
+            return null;
+        }
+
+        $path = $parts['path'] ?? '/';
+        if ($path === '') {
+            $path = '/';
+        }
+
+        $query = isset($parts['query']) && $parts['query'] !== '' ? '?'.$parts['query'] : '';
+        $fragment = isset($parts['fragment']) && $parts['fragment'] !== '' ? '#'.$parts['fragment'] : '';
+
+        return 'https://facebook.com'.$path.$query.$fragment;
+    }
+
+    public static function isAllowedHost(string $host): bool
+    {
+        return in_array(strtolower($host), self::ALLOWED_HOSTS, true);
+    }
+}

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -74,6 +74,7 @@ class ProfileTransformer extends TransformerAbstract
             'driver_data_docs' => $user->driver_data_docs ? json_decode($user->driver_data_docs) : null,
             'references' => $user->references,
             'data_visibility' => $user->data_visibility,
+            'facebook_profile_url' => $user->facebook_profile_url,
             'references_data' => $user->referencesReceived,
             // Identity validation: exposed to every user (all viewers of the profile)
             'identity_validated' => $user->identity_validated ? true : false,

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -26,6 +26,7 @@ return [
     'module_trip_seats_payment' => env('MODULE_TRIP_SEATS_PAYMENT', false),
     'module_unique_doc_phone' => env('MODULE_UNIQUE_DOC_PHONE', false),
     'module_validated_drivers' => env('MODULE_VALIDATED_DRIVERS', false),
+    'module_facebook_profile_url_enabled' => env('MODULE_FACEBOOK_PROFILE_URL_ENABLED', false),
     'module_trip_creation_payment_enabled' => env('MODULE_TRIP_CREATION_PAYMENT_ENABLED', false),
     'module_trip_creation_payment_amount_cents' => (int) env('MODULE_TRIP_CREATION_PAYMENT_AMOUNT_CENTS', 1500),
     'module_trip_creation_payment_trips_threshold' => (int) env('MODULE_TRIP_CREATION_PAYMENT_TRIPS_THRESHOLD', 2),
@@ -157,12 +158,14 @@ return [
             'on_boarding_view',
             'user_be_driver', 'driver_data_docs',
             'account_number', 'account_type', 'account_bank',
+            'facebook_profile_url',
         ],
 
         // Additional properties editable only by admin (name/email only at registration for users)
         'admin_allowed' => [
             'name', 'email', 'banned', 'active', 'driver_is_verified',
             'patente', 'car_description', 'private_note',
+            'facebook_profile_url',
             'identity_validated', 'identity_validated_at',
             'identity_validation_type', 'identity_validation_reject_reason',
             'validate_by_date',

--- a/database/migrations/2026_05_28_123600_add_facebook_profile_url_to_users_table.php
+++ b/database/migrations/2026_05_28_123600_add_facebook_profile_url_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('facebook_profile_url')->nullable()->after('data_visibility');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('facebook_profile_url');
+        });
+    }
+};

--- a/tests/Feature/Http/AuthControllerApiTest.php
+++ b/tests/Feature/Http/AuthControllerApiTest.php
@@ -86,6 +86,16 @@ class AuthControllerApiTest extends TestCase
         $this->assertSame(config('carpoolear.maintenance_admin_path'), $maintenance['admin_path']);
     }
 
+    public function test_get_config_exposes_facebook_profile_module_flag_defaulting_to_false(): void
+    {
+        config(['carpoolear.module_facebook_profile_url_enabled' => false]);
+
+        $response = $this->getJson('api/config');
+
+        $response->assertOk();
+        $response->assertJsonPath('module_facebook_profile_url_enabled', false);
+    }
+
     public function test_get_config_reflects_active_maintenance_payload(): void
     {
         app(MaintenanceStateService::class)->applyManualActive(

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -257,6 +257,44 @@ class UserControllerApiTest extends TestCase
         $this->assertSame($facebookUrl, $target->fresh()->facebook_profile_url);
     }
 
+    public function test_registration_normalizes_facebook_profile_url_without_scheme(): void
+    {
+        config(['carpoolear.module_facebook_profile_url_enabled' => true]);
+
+        $email = 'facebook-url-normalize-'.uniqid('', true).'@example.com';
+        $expected = 'https://facebook.com/registro-fixture';
+
+        $response = $this->postJson('api/users/', [
+            'name' => 'Facebook Url Normalize',
+            'email' => $email,
+            'password' => 'secret12',
+            'password_confirmation' => 'secret12',
+            'facebook_profile_url' => 'facebook.com/registro-fixture',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.facebook_profile_url', $expected);
+        $this->assertDatabaseHas('users', [
+            'email' => $email,
+            'facebook_profile_url' => $expected,
+        ]);
+    }
+
+    public function test_registration_rejects_non_facebook_profile_url(): void
+    {
+        config(['carpoolear.module_facebook_profile_url_enabled' => true]);
+
+        $email = 'facebook-url-invalid-'.uniqid('', true).'@example.com';
+
+        $this->postJson('api/users/', [
+            'name' => 'Facebook Url Invalid',
+            'email' => $email,
+            'password' => 'secret12',
+            'password_confirmation' => 'secret12',
+            'facebook_profile_url' => 'https://example.com/profile',
+        ])->assertStatus(422);
+    }
+
     public function test_update_bans_user_when_mobile_matches_configured_fragment(): void
     {
         config(['carpoolear.banned_phones' => ['0009']]);

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -192,6 +192,71 @@ class UserControllerApiTest extends TestCase
         $this->assertSame('Bio without declaring driver intent.', $user->fresh()->description);
     }
 
+    public function test_registration_persists_facebook_profile_url_when_module_enabled(): void
+    {
+        config(['carpoolear.module_facebook_profile_url_enabled' => true]);
+
+        $email = 'facebook-url-registration-'.uniqid('', true).'@example.com';
+        $facebookUrl = 'https://facebook.com/registro-fixture';
+
+        $response = $this->postJson('api/users/', [
+            'name' => 'Facebook Url Registration',
+            'email' => $email,
+            'password' => 'secret12',
+            'password_confirmation' => 'secret12',
+            'facebook_profile_url' => $facebookUrl,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.facebook_profile_url', $facebookUrl);
+        $this->assertDatabaseHas('users', [
+            'email' => $email,
+            'facebook_profile_url' => $facebookUrl,
+        ]);
+    }
+
+    public function test_update_persists_facebook_profile_url_when_module_enabled(): void
+    {
+        config(['carpoolear.module_facebook_profile_url_enabled' => true]);
+
+        $user = User::factory()->create([
+            'active' => true,
+            'banned' => false,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $facebookUrl = 'https://facebook.com/update-fixture';
+        $this->putJson('api/users/', [
+            'description' => 'Bio update with facebook profile URL.',
+            'facebook_profile_url' => $facebookUrl,
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.facebook_profile_url', $facebookUrl);
+
+        $this->assertSame($facebookUrl, $user->fresh()->facebook_profile_url);
+    }
+
+    public function test_admin_update_persists_facebook_profile_url_when_module_enabled(): void
+    {
+        config(['carpoolear.module_facebook_profile_url_enabled' => true]);
+
+        $admin = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false]);
+
+        $this->actingAs($admin, 'api');
+
+        $facebookUrl = 'https://facebook.com/admin-update-fixture';
+        $this->putJson('api/users/modify', [
+            'user' => ['id' => $target->id],
+            'facebook_profile_url' => $facebookUrl,
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.facebook_profile_url', $facebookUrl);
+
+        $this->assertSame($facebookUrl, $target->fresh()->facebook_profile_url);
+    }
+
     public function test_update_bans_user_when_mobile_matches_configured_fragment(): void
     {
         config(['carpoolear.banned_phones' => ['0009']]);

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -97,6 +97,7 @@ class UserTest extends TestCase
             'account_type',
             'account_bank',
             'data_visibility',
+            'facebook_profile_url',
             'identity_validated',
             'identity_validated_at',
             'identity_validation_type',

--- a/tests/Unit/Support/FacebookProfileUrlTest.php
+++ b/tests/Unit/Support/FacebookProfileUrlTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use STS\Support\FacebookProfileUrl;
+use Tests\TestCase;
+
+class FacebookProfileUrlTest extends TestCase
+{
+    public function test_try_normalize_returns_null_for_empty_values(): void
+    {
+        $this->assertNull(FacebookProfileUrl::tryNormalize(null));
+        $this->assertNull(FacebookProfileUrl::tryNormalize(''));
+        $this->assertNull(FacebookProfileUrl::tryNormalize('   '));
+    }
+
+    /**
+     * @dataProvider validFacebookProfileUrlsProvider
+     */
+    public function test_try_normalize_canonicalizes_facebook_profile_urls(
+        string $input,
+        string $expected
+    ): void {
+        $this->assertSame($expected, FacebookProfileUrl::tryNormalize($input));
+    }
+
+    public static function validFacebookProfileUrlsProvider(): array
+    {
+        return [
+            'without scheme' => ['facebook.com/test-user', 'https://facebook.com/test-user'],
+            'with www' => ['www.facebook.com/test-user', 'https://facebook.com/test-user'],
+            'with https www' => ['https://www.facebook.com/test-user', 'https://facebook.com/test-user'],
+            'already canonical' => ['https://facebook.com/test-user', 'https://facebook.com/test-user'],
+            'root host only' => ['facebook.com', 'https://facebook.com/'],
+            'mobile host' => ['m.facebook.com/test-user', 'https://facebook.com/test-user'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidFacebookProfileUrlsProvider
+     */
+    public function test_try_normalize_rejects_non_facebook_urls(string $input): void
+    {
+        $this->assertNull(FacebookProfileUrl::tryNormalize($input));
+    }
+
+    public static function invalidFacebookProfileUrlsProvider(): array
+    {
+        return [
+            'other domain' => ['https://example.com/profile'],
+            'lookalike domain' => ['https://facebook.com.evil.com/profile'],
+            'not a url' => ['not-a-url'],
+        ];
+    }
+}

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -47,6 +47,7 @@ class ProfileTransformerTest extends TestCase
             'driver_data_docs',
             'references',
             'data_visibility',
+            'facebook_profile_url',
             'references_data',
             'identity_validated',
             'identity_validated_at',


### PR DESCRIPTION
- **DB:** nullable `facebook_profile_url` column on `users`
- **Config:** `module_facebook_profile_url_enabled` in `config/carpoolear.php` and `.env.example`; field allowed in user/admin profile edit allowlists
- **API:** `facebook_profile_url` in fillable, `ProfileTransformer`, and `UsersManager` (stripped when module off)
- **Validation:** `FacebookProfileUrl` helper — accepts values like `facebook.com/tu-perfil`, stores `https://facebook.com/tu-perfil`, rejects non-Facebook domains
- **Tests:** feature tests for registration/update/admin update; unit tests for normalizer
- **Chore:** pre-commit runs Pint only (full test suite removed from hook)
**Enable locally:** `MODULE_FACEBOOK_PROFILE_URL_ENABLED=true` + `php artisan migrate`
