### PR TITLE
Multiple cars

### DIFF
--- a/app/Models/Car.php
+++ b/app/Models/Car.php
@@ -4,15 +4,18 @@ namespace STS\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Car extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected static function newFactory()
     {
         return \Database\Factories\CarFactory::new();
     }
+
     protected $table = 'cars';
 
     protected $fillable = ['patente', 'description', 'user_id'];

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -170,7 +170,7 @@ class Trip extends Model
 
     public function car()
     {
-        return $this->belongsTo('STS\Models\Car', 'car_id');
+        return $this->belongsTo('STS\Models\Car', 'car_id')->withTrashed();
     }
 
     public function passenger()

--- a/app/Repository/CarsRepository.php
+++ b/app/Repository/CarsRepository.php
@@ -36,9 +36,4 @@ class CarsRepository
     {
         return CarModel::where('user_id', $userId)->first();
     }
-
-    public function activeCarsForUser($userId)
-    {
-        return CarModel::where('user_id', $userId)->get();
-    }
 }

--- a/app/Repository/CarsRepository.php
+++ b/app/Repository/CarsRepository.php
@@ -2,8 +2,8 @@
 
 namespace STS\Repository;
 
-use STS\Models\User as UserModel;
 use STS\Models\Car as CarModel;
+use STS\Models\User as UserModel;
 
 class CarsRepository
 {
@@ -35,5 +35,10 @@ class CarsRepository
     public function getUserCar($userId)
     {
         return CarModel::where('user_id', $userId)->first();
+    }
+
+    public function activeCarsForUser($userId)
+    {
+        return CarModel::where('user_id', $userId)->get();
     }
 }

--- a/app/Services/Logic/CarsManager.php
+++ b/app/Services/Logic/CarsManager.php
@@ -2,10 +2,11 @@
 
 namespace STS\Services\Logic;
 
+use Illuminate\Validation\Rule;
+use STS\Models\Car as CarModel;
+use STS\Models\User as UserModel;
 use STS\Repository\CarsRepository;
 use Validator;
-use STS\Models\User as UserModel;
-use STS\Models\Car as CarModel;
 
 class CarsManager extends BaseManager
 {
@@ -19,18 +20,19 @@ class CarsManager extends BaseManager
     public function validator(array $data, $userId = null, $carId = null)
     {
         $rules = [
-            'patente'     => 'required|string|max:10',
+            'patente' => ['required', 'string', 'max:10'],
             'description' => 'required|string|max:255',
         ];
 
-        // Add unique validation for patente per user
         if ($userId) {
-            $rules['patente'] .= '|unique:cars,patente,NULL,id,user_id,' . $userId;
-        }
+            $uniquePatente = Rule::unique('cars', 'patente')
+                ->where(fn ($query) => $query->where('user_id', $userId)->whereNull('deleted_at'));
 
-        // If updating, ignore current car's patente
-        if ($carId) {
-            $rules['patente'] = 'required|string|max:10|unique:cars,patente,' . $carId . ',id,user_id,' . $userId;
+            if ($carId) {
+                $uniquePatente->ignore($carId);
+            }
+
+            $rules['patente'][] = $uniquePatente;
         }
 
         return Validator::make($data, $rules);
@@ -38,21 +40,13 @@ class CarsManager extends BaseManager
 
     public function create(UserModel $user, $data)
     {
-        // Check if user already has a car
-        $existingCar = $this->repo->getUserCar($user->id);
-        if ($existingCar) {
-            $this->setErrors(['error' => 'user_already_has_car', 'message' => 'User already has a car. Please update the existing one instead.']);
-
-            return;
-        }
-
         $v = $this->validator($data, $user->id);
         if ($v->fails()) {
             $this->setErrors($v->errors());
 
             return;
         } else {
-            $car = new CarModel();
+            $car = new CarModel;
             $car->description = $data['description'];
             $car->patente = $data['patente'];
             $car->user_id = $user->id;

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -194,9 +194,9 @@ class TripsManager extends BaseManager
             return;
         }
 
-        $car = $this->firstUserCarWithPlate($user);
-        if ($car) {
-            $data['car_id'] = $car->id;
+        $cars = $this->activeCarsWithPlate($user);
+        if ($cars->count() === 1) {
+            $data['car_id'] = $cars->first()->id;
         }
     }
 
@@ -224,16 +224,17 @@ class TripsManager extends BaseManager
             return $car && $this->hasValue($car->patente);
         }
 
-        return (bool) $this->firstUserCarWithPlate($user);
+        return $this->activeCarsWithPlate($user)->count() === 1;
     }
 
-    private function firstUserCarWithPlate($user)
+    private function activeCarsWithPlate($user)
     {
         return $user->cars()
             ->get()
-            ->first(function ($car) {
+            ->filter(function ($car) {
                 return $this->hasValue($car->patente);
-            });
+            })
+            ->values();
     }
 
     private function hasValue($value): bool

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -75,12 +75,12 @@ class TripTransformer extends TransformerAbstract
                     foreach ($trip->passengerAccepted as $passenger) {
                         $data['passenger'][] = $userTranforms->transform($passenger->user);
                     }
-                    $data['car'] = $trip->car;
+                    $data['car'] = $this->transformCar($trip->car);
                 } elseif ($trip->isPending($this->user)) {
                     $data['request'] = 'send';
                 }
 
-                $data['car'] = $trip->car;
+                $data['car'] = $this->transformCar($trip->car);
                 $data['request_count'] = count($trip->passenger);
                 $data['passengerAccepted_count'] = count($trip->passengerAccepted);
                 foreach ($trip->passenger as $prequest) {
@@ -98,5 +98,19 @@ class TripTransformer extends TransformerAbstract
         }
 
         return $data;
+    }
+
+    private function transformCar($car): ?array
+    {
+        if (! $car) {
+            return null;
+        }
+
+        $payload = $car->toArray();
+        if (method_exists($car, 'trashed') && $car->trashed()) {
+            $payload['deleted'] = true;
+        }
+
+        return $payload;
     }
 }

--- a/database/migrations/2026_05_28_000000_add_deleted_at_to_cars_table.php
+++ b/database/migrations/2026_05_28_000000_add_deleted_at_to_cars_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_05_28_000001_allow_multiple_cars_per_user.php
+++ b/database/migrations/2026_05_28_000001_allow_multiple_cars_per_user.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->index('user_id', 'cars_user_id_index');
+            $table->dropUnique('cars_user_id_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->unique('user_id', 'cars_user_id_unique');
+            $table->dropIndex('cars_user_id_index');
+        });
+    }
+};

--- a/tests/Feature/Http/AdminCarControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminCarControllerIntegrationTest.php
@@ -97,7 +97,7 @@ class AdminCarControllerIntegrationTest extends TestCase
         $this->assertSame('FFF666', $target->fresh()->patente);
     }
 
-    public function test_destroy_removes_car_record(): void
+    public function test_destroy_soft_deletes_car_record(): void
     {
         $this->authenticateAsAdmin();
 
@@ -106,7 +106,8 @@ class AdminCarControllerIntegrationTest extends TestCase
         $this->deleteJson("api/admin/cars/{$car->id}")
             ->assertNoContent();
 
-        $this->assertDatabaseMissing('cars', ['id' => $car->id]);
+        $this->assertNull(Car::query()->find($car->id));
+        $this->assertNotNull(Car::withTrashed()->find($car->id)?->deleted_at);
     }
 
     public function test_user_cars_and_store_for_user_cover_admin_user_scoped_flow(): void

--- a/tests/Feature/Http/CarApiTest.php
+++ b/tests/Feature/Http/CarApiTest.php
@@ -109,7 +109,7 @@ class CarApiTest extends TestCase
         ])->assertStatus(422);
     }
 
-    public function test_create_returns_unprocessable_when_user_already_has_a_car(): void
+    public function test_create_allows_second_car_for_same_user(): void
     {
         $user = User::factory()->create(['active' => true, 'banned' => false]);
         Car::factory()->create(['user_id' => $user->id, 'patente' => 'HAS1']);
@@ -118,7 +118,22 @@ class CarApiTest extends TestCase
 
         $this->postJson('api/cars', [
             'patente' => 'HAS2',
-            'description' => 'Second car attempt',
+            'description' => 'Second car',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.patente', 'HAS2');
+    }
+
+    public function test_create_returns_unprocessable_when_patente_duplicates_active_car(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        Car::factory()->create(['user_id' => $user->id, 'patente' => 'DUP1']);
+
+        $this->actingAs($user, 'api');
+
+        $this->postJson('api/cars', [
+            'patente' => 'DUP1',
+            'description' => 'Duplicate patente',
         ])->assertStatus(422);
     }
 }

--- a/tests/Feature/Http/CarApiTest.php
+++ b/tests/Feature/Http/CarApiTest.php
@@ -79,6 +79,7 @@ class CarApiTest extends TestCase
             ->assertExactJson(['data' => 'ok']);
 
         $this->assertNull(Car::find($carId));
+        $this->assertNotNull(Car::withTrashed()->find($carId)?->deleted_at);
     }
 
     public function test_show_returns_unprocessable_when_car_missing_or_not_owned(): void

--- a/tests/Unit/Console/Commands/CleanupDuplicateCarsTest.php
+++ b/tests/Unit/Console/Commands/CleanupDuplicateCarsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit\Console\Commands;
 
 use Carbon\Carbon;
-use Illuminate\Support\Facades\DB;
 use STS\Console\Commands\CleanupDuplicateCars;
 use STS\Models\Car;
 use STS\Models\User;
@@ -11,17 +10,8 @@ use Tests\TestCase;
 
 class CleanupDuplicateCarsTest extends TestCase
 {
-    private bool $droppedCarsUserUniqueIndex = false;
-
     protected function tearDown(): void
     {
-        if ($this->droppedCarsUserUniqueIndex) {
-            DB::statement(
-                'DELETE c1 FROM cars c1 JOIN cars c2 ON c1.user_id = c2.user_id AND c1.id < c2.id WHERE c1.user_id IS NOT NULL'
-            );
-            DB::statement('ALTER TABLE cars DROP INDEX cars_user_id_index, ADD UNIQUE INDEX cars_user_id_unique (user_id)');
-        }
-
         Carbon::setTestNow();
         parent::tearDown();
     }
@@ -64,8 +54,6 @@ class CleanupDuplicateCarsTest extends TestCase
 
     public function test_handle_keeps_newest_car_deletes_older_duplicates_and_relinks_trips(): void
     {
-        $this->dropCarsUserUniqueIndex();
-
         $user = User::factory()->create(['name' => 'Driver Duplicate']);
 
         $oldestCar = Car::factory()->create([
@@ -108,8 +96,10 @@ class CleanupDuplicateCarsTest extends TestCase
         $this->assertCount(1, $remainingCars);
         $this->assertSame($newestCar->id, $remainingCars->first()->id);
 
-        $this->assertDatabaseMissing('cars', ['id' => $oldestCar->id]);
-        $this->assertDatabaseMissing('cars', ['id' => $middleCar->id]);
+        $this->assertNull(Car::query()->find($oldestCar->id));
+        $this->assertNull(Car::query()->find($middleCar->id));
+        $this->assertNotNull(Car::withTrashed()->find($oldestCar->id)?->deleted_at);
+        $this->assertNotNull(Car::withTrashed()->find($middleCar->id)?->deleted_at);
 
         $this->assertSame($newestCar->id, $tripUsingOldest->fresh()->car_id);
         $this->assertSame($newestCar->id, $tripUsingMiddle->fresh()->car_id);
@@ -117,8 +107,6 @@ class CleanupDuplicateCarsTest extends TestCase
 
     public function test_handle_dry_run_with_duplicates_reports_actions_without_mutating_data(): void
     {
-        $this->dropCarsUserUniqueIndex();
-
         $user = User::factory()->create(['name' => 'Dry Run Driver']);
 
         $oldCar = Car::factory()->create([
@@ -150,11 +138,5 @@ class CleanupDuplicateCarsTest extends TestCase
         $this->assertDatabaseHas('cars', ['id' => $oldCar->id]);
         $this->assertDatabaseHas('cars', ['id' => $newCar->id]);
         $this->assertSame($oldCar->id, $trip->fresh()->car_id);
-    }
-
-    private function dropCarsUserUniqueIndex(): void
-    {
-        DB::statement('ALTER TABLE cars DROP INDEX cars_user_id_unique, ADD INDEX cars_user_id_index (user_id)');
-        $this->droppedCarsUserUniqueIndex = true;
     }
 }

--- a/tests/Unit/Models/CarTest.php
+++ b/tests/Unit/Models/CarTest.php
@@ -81,6 +81,17 @@ class CarTest extends TestCase
         $this->assertSame('Blue hatchback', $car->description);
     }
 
+    public function test_soft_deleted_car_is_excluded_from_default_queries(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->create(['user_id' => $user->id]);
+        $car->delete();
+
+        $this->assertNull(Car::query()->find($car->id));
+        $this->assertNotNull(Car::withTrashed()->find($car->id));
+        $this->assertNotNull($car->fresh()->deleted_at);
+    }
+
     public function test_table_name_is_cars(): void
     {
         $this->assertSame('cars', (new Car)->getTable());

--- a/tests/Unit/Repository/CarsRepositoryTest.php
+++ b/tests/Unit/Repository/CarsRepositoryTest.php
@@ -63,7 +63,7 @@ class CarsRepositoryTest extends TestCase
         $this->assertNull($this->repo()->show(999_999_999));
     }
 
-    public function test_delete_removes_car(): void
+    public function test_delete_soft_deletes_car(): void
     {
         $user = User::factory()->create();
         $car = Car::factory()->create([
@@ -75,6 +75,26 @@ class CarsRepositoryTest extends TestCase
         $this->assertTrue((bool) $this->repo()->delete($car));
 
         $this->assertNull(Car::query()->find($id));
+        $this->assertNotNull(Car::withTrashed()->find($id)?->deleted_at);
+    }
+
+    public function test_index_excludes_soft_deleted_cars(): void
+    {
+        $user = User::factory()->create();
+        $active = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'AC-'.substr(uniqid('', true), 0, 6),
+        ]);
+        $deleted = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'DL-'.substr(uniqid('', true), 0, 6),
+        ]);
+        $deleted->delete();
+
+        $cars = $this->repo()->index($user->fresh());
+
+        $this->assertCount(1, $cars);
+        $this->assertTrue($cars->first()->is($active));
     }
 
     public function test_index_returns_user_cars_relation(): void

--- a/tests/Unit/Services/Logic/CarsManagerTest.php
+++ b/tests/Unit/Services/Logic/CarsManagerTest.php
@@ -59,7 +59,7 @@ class CarsManagerTest extends TestCase
         $this->assertTrue($v->errors()->has('patente'));
     }
 
-    public function test_create_rejected_when_user_already_has_car(): void
+    public function test_create_allows_multiple_cars_for_same_user(): void
     {
         $user = User::factory()->create();
         Car::factory()->create([
@@ -69,13 +69,56 @@ class CarsManagerTest extends TestCase
         ]);
 
         $manager = $this->manager();
-        $result = $manager->create($user, $this->validCarData());
+        $data = $this->validCarData('SECOND');
+        $car = $manager->create($user, $data);
+
+        $this->assertInstanceOf(Car::class, $car);
+        $this->assertDatabaseHas('cars', [
+            'user_id' => $user->id,
+            'patente' => $data['patente'],
+        ]);
+        $this->assertSame(2, Car::query()->where('user_id', $user->id)->count());
+    }
+
+    public function test_create_rejects_duplicate_active_patente_for_same_user(): void
+    {
+        $user = User::factory()->create();
+        $patente = 'DU'.substr(uniqid('', true), 0, 6);
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => $patente,
+            'description' => 'First',
+        ]);
+
+        $manager = $this->manager();
+        $result = $manager->create($user, [
+            'patente' => $patente,
+            'description' => 'Duplicate attempt',
+        ]);
 
         $this->assertNull($result);
-        $errors = $manager->getErrors();
-        $this->assertIsArray($errors);
-        $this->assertSame('user_already_has_car', $errors['error']);
-        $this->assertSame('User already has a car. Please update the existing one instead.', $errors['message']);
+        $this->assertTrue($manager->getErrors()->has('patente'));
+    }
+
+    public function test_create_allows_patente_reused_after_previous_car_was_soft_deleted(): void
+    {
+        $user = User::factory()->create();
+        $patente = 'RE'.substr(uniqid('', true), 0, 6);
+        $old = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => $patente,
+            'description' => 'Old car',
+        ]);
+        $old->delete();
+
+        $manager = $this->manager();
+        $car = $manager->create($user, [
+            'patente' => $patente,
+            'description' => 'Replacement car',
+        ]);
+
+        $this->assertInstanceOf(Car::class, $car);
+        $this->assertSame($patente, $car->patente);
     }
 
     public function test_create_persists_car_when_valid(): void
@@ -231,7 +274,7 @@ class CarsManagerTest extends TestCase
         $this->assertSame($car->id, $found->id);
     }
 
-    public function test_delete_removes_car_for_owner(): void
+    public function test_delete_soft_deletes_car_for_owner(): void
     {
         $user = User::factory()->create();
         $car = Car::factory()->create([
@@ -244,6 +287,7 @@ class CarsManagerTest extends TestCase
         $manager = $this->manager();
         $this->assertTrue($manager->delete($user, $id));
         $this->assertNull(Car::query()->find($id));
+        $this->assertNotNull(Car::withTrashed()->find($id)?->deleted_at);
     }
 
     public function test_delete_returns_null_when_not_found(): void

--- a/tests/Unit/Services/Logic/CarsManagerTest.php
+++ b/tests/Unit/Services/Logic/CarsManagerTest.php
@@ -97,7 +97,8 @@ class CarsManagerTest extends TestCase
         ]);
 
         $this->assertNull($result);
-        $this->assertTrue($manager->getErrors()->has('patente'));
+        $errors = $manager->getErrors();
+        $this->assertTrue(is_object($errors) ? $errors->has('patente') : isset($errors['patente']));
     }
 
     public function test_create_allows_patente_reused_after_previous_car_was_soft_deleted(): void

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -631,6 +631,91 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_create_driver_trip_auto_assigns_car_when_user_has_single_active_car(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), 'route/v1/driving')) {
+                return Http::response([
+                    'code' => 'Ok',
+                    'routes' => [['distance' => 365_000, 'duration' => 18_000]],
+                ], 200);
+            }
+
+            return Http::response('unexpected url in test', 404);
+        });
+
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        Event::fake([CreateEvent::class]);
+        $user = $this->completeUser();
+        $car = $this->carWithPlateFor($user);
+        $manager = $this->manager();
+
+        $trip = $manager->create($user, $this->minimalCreatePayload());
+
+        $this->assertNotNull($trip);
+        $this->assertSame($car->id, (int) $trip->car_id);
+        Carbon::setTestNow();
+    }
+
+    public function test_create_driver_trip_requires_car_id_when_user_has_multiple_active_cars(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $user = $this->completeUser();
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'CAR001',
+            'description' => 'First',
+        ]);
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'CAR002',
+            'description' => 'Second',
+        ]);
+
+        $manager = $this->manager();
+        $result = $manager->create($user, $this->minimalCreatePayload());
+
+        $this->assertNull($result);
+        $this->assertTrue($manager->getErrors()->has('car_id'));
+        Carbon::setTestNow();
+    }
+
+    public function test_create_driver_trip_uses_selected_car_when_user_has_multiple_active_cars(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), 'route/v1/driving')) {
+                return Http::response([
+                    'code' => 'Ok',
+                    'routes' => [['distance' => 365_000, 'duration' => 18_000]],
+                ], 200);
+            }
+
+            return Http::response('unexpected url in test', 404);
+        });
+
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        Event::fake([CreateEvent::class]);
+        $user = $this->completeUser();
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'CAR001',
+            'description' => 'First',
+        ]);
+        $second = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'CAR002',
+            'description' => 'Second',
+        ]);
+
+        $trip = $this->manager()->create($user, $this->minimalCreatePayload([
+            'car_id' => $second->id,
+        ]));
+
+        $this->assertNotNull($trip);
+        $this->assertSame($second->id, (int) $trip->car_id);
+        Carbon::setTestNow();
+    }
+
     public function test_parent_trip_id_sets_return_trip_id_on_parent(): void
     {
         Http::fake(function ($request) {

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -680,6 +680,46 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_update_driver_trip_persists_selected_car_id(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), 'route/v1/driving')) {
+                return Http::response([
+                    'code' => 'Ok',
+                    'routes' => [['distance' => 365_000, 'duration' => 18_000]],
+                ], 200);
+            }
+
+            return Http::response('unexpected url in test', 404);
+        });
+
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        Event::fake([CreateEvent::class]);
+        $user = $this->completeUser();
+        $first = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'CAR001',
+            'description' => 'First',
+        ]);
+        $second = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'CAR002',
+            'description' => 'Second',
+        ]);
+        $manager = $this->manager();
+        $trip = $manager->create($user, $this->minimalCreatePayload([
+            'car_id' => $first->id,
+        ]));
+        $this->assertNotNull($trip);
+
+        $updated = $manager->update($user, $trip->id, [
+            'car_id' => $second->id,
+        ]);
+        $this->assertNotNull($updated);
+        $this->assertSame($second->id, (int) $updated->fresh()->car_id);
+        Carbon::setTestNow();
+    }
+
     public function test_create_driver_trip_uses_selected_car_when_user_has_multiple_active_cars(): void
     {
         Http::fake(function ($request) {

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Transformers;
 
+use STS\Models\Car;
 use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -338,5 +339,27 @@ class ProfileTransformerTest extends TestCase
         $payload = (new ProfileTransformer(null))->transform($user->fresh());
 
         $this->assertArrayNotHasKey('state', $payload);
+    }
+
+    public function test_transform_cars_for_own_profile_excludes_soft_deleted(): void
+    {
+        $user = User::factory()->create(['data_visibility' => '2']);
+        Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'ACT123',
+            'description' => 'Active',
+        ]);
+        $deleted = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'DEL456',
+            'description' => 'Removed',
+        ]);
+        $deleted->delete();
+
+        $payload = (new ProfileTransformer($user))->transform($user->fresh(['cars']));
+
+        $this->assertArrayHasKey('cars', $payload);
+        $patentes = collect($payload['cars'])->pluck('patente')->all();
+        $this->assertSame(['ACT123'], $patentes);
     }
 }

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Transformers;
 
 use Carbon\Carbon;
+use STS\Models\Car;
 use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -143,6 +144,27 @@ class TripTransformerTest extends TestCase
         $this->assertSame('2026-05-01 12:00:00', $deletedPayload['deleted_at']);
         $this->assertTrue($deletedPayload['deleted']);
         $this->assertArrayNotHasKey('hidden', $deletedPayload);
+    }
+
+    public function test_transform_marks_soft_deleted_car_on_trip(): void
+    {
+        $owner = User::factory()->create(['is_admin' => true]);
+        $car = Car::factory()->create([
+            'user_id' => $owner->id,
+            'patente' => 'DEL123',
+            'description' => 'Removed car',
+        ]);
+        $trip = $this->makeTrip([
+            'user_id' => $owner->id,
+            'car_id' => $car->id,
+        ]);
+        $car->delete();
+
+        $payload = (new TripTransformer($owner))->transform($trip->fresh(['car']));
+
+        $this->assertArrayHasKey('car', $payload);
+        $this->assertSame('DEL123', $payload['car']['patente']);
+        $this->assertTrue($payload['car']['deleted']);
     }
 
     public function test_transform_includes_owner_context_passenger_data_and_counts(): void


### PR DESCRIPTION
## Summary
Allow drivers to register and manage **multiple cars (patentes)** per user, associate a specific car when creating/editing a trip, and soft-delete cars without breaking historical trips.
---
## Backend (`carpoolear_backend`)
### Database
- **`2026_05_28_000000_add_deleted_at_to_cars_table`** — `deleted_at` on `cars` (soft deletes).
- **`2026_05_28_000001_allow_multiple_cars_per_user`** — removes `cars_user_id_unique` so one user can have many cars; adds `cars_user_id_index` for the FK.
> Run `php artisan migrate` on each environment before deploy.
### API / domain
- Users can **create multiple cars** (removed “one car per user” restriction).
- **Patente unique per user** among **active** (non-deleted) cars; same patente can be reused after soft-delete.
- **DELETE** `/api/cars/{id}` soft-deletes the car.
- **Trips**: auto-assign `car_id` when the driver has **one** active car; **require `car_id`** when they have **several**.
- Trip responses include the linked car (with `withTrashed()`); soft-deleted cars expose `car.deleted: true` for admins/owners on trip detail.
### Tests
- `CarsManager`, `CarsRepository`, `CarApi`, `TripsManager`, `TripTransformer` coverage for multi-car, soft-delete, and trip `car_id` behavior.
