### PR TITLE
Persist car_id after soft-deleted car and guard privacy

### DIFF
--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -5,6 +5,7 @@ namespace STS\Services\Logic;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\MessageBag;
+use Illuminate\Validation\Rule;
 use STS\Events\Trip\Create as CreateEvent;
 use STS\Events\Trip\Delete as DeleteEvent;
 use STS\Events\Trip\Update as UpdateEvent;
@@ -40,7 +41,7 @@ class TripsManager extends BaseManager
                 'description' => 'string',
                 'return_trip_id' => 'exists:trips,id',
                 'parent_trip_id' => 'exists:trips,id',
-                'car_id' => 'exists:cars,id,user_id,'.$user_id,
+                'car_id' => $this->activeCarIdRule($user_id),
                 'weekly_schedule' => 'required_without:trip_date|nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
 
@@ -62,7 +63,7 @@ class TripsManager extends BaseManager
                 'co2' => 'numeric',
                 'return_trip_id' => 'exists:trips,id',
                 'parent_trip_id' => 'exists:trips,id',
-                'car_id' => 'exists:cars,id,user_id,'.$user_id,
+                'car_id' => $this->activeCarIdRule($user_id),
                 'weekly_schedule' => 'nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
 
@@ -76,7 +77,7 @@ class TripsManager extends BaseManager
 
     public function create($user, array $data)
     {
-        $this->assignDriverCarWhenPossible($user, $data);
+        $this->prepareDriverCarForSave($user, $data);
         $v = $this->validator($data, $user->id);
         if ($v->fails()) {
             $this->setErrors($v->errors());
@@ -188,9 +189,44 @@ class TripsManager extends BaseManager
         }
     }
 
-    private function assignDriverCarWhenPossible($user, array &$data): void
+    private function activeCarIdRule($user_id): array
     {
-        if (! $this->isDriverTrip($data) || ! empty($data['car_id'])) {
+        return [
+            'nullable',
+            Rule::exists('cars', 'id')->where(function ($query) use ($user_id) {
+                $query->where('user_id', $user_id)->whereNull('deleted_at');
+            }),
+        ];
+    }
+
+    private function prepareDriverCarForSave($user, array &$data, ?Trip $existingTrip = null): void
+    {
+        if (! $this->isDriverTrip($data, $existingTrip)) {
+            return;
+        }
+
+        if (! empty($data['car_id'])) {
+            $car = $user->cars()->whereKey($data['car_id'])->first();
+            if (! $car || ! $this->hasValue($car->patente)) {
+                unset($data['car_id']);
+            }
+        }
+
+        if ($existingTrip && empty($data['car_id']) && $existingTrip->car_id) {
+            $tripCarStillActive = $user->cars()->whereKey($existingTrip->car_id)->first();
+            if (! $tripCarStillActive) {
+                $this->assignDriverCarWhenPossible($user, $data, $existingTrip);
+
+                return;
+            }
+        }
+
+        $this->assignDriverCarWhenPossible($user, $data, $existingTrip);
+    }
+
+    private function assignDriverCarWhenPossible($user, array &$data, ?Trip $existingTrip = null): void
+    {
+        if (! $this->isDriverTrip($data, $existingTrip) || ! empty($data['car_id'])) {
             return;
         }
 
@@ -200,9 +236,17 @@ class TripsManager extends BaseManager
         }
     }
 
-    private function isDriverTrip(array $data): bool
+    private function isDriverTrip(array $data, ?Trip $existingTrip = null): bool
     {
-        return array_key_exists('is_passenger', $data) && (string) $data['is_passenger'] === '0';
+        if (array_key_exists('is_passenger', $data)) {
+            return (string) $data['is_passenger'] === '0';
+        }
+
+        if ($existingTrip) {
+            return ! $existingTrip->is_passenger;
+        }
+
+        return false;
     }
 
     private function userHasRequiredProfileFields($user): bool
@@ -247,12 +291,21 @@ class TripsManager extends BaseManager
         $trip = $this->tripRepo->show($user, $trip_id);
         if ($trip) {
             if ($user->id == $trip->user->id || $user->is_admin) {
+                $this->prepareDriverCarForSave($user, $data, $trip);
                 $v = $this->validator($data, $user->id, $trip_id);
                 if ($v->fails()) {
                     $this->setErrors($v->errors());
 
                     return;
                 } else {
+                    if ($this->isDriverTrip($data, $trip) && ! $this->driverTripHasPlate($user, $data)) {
+                        $messageBag = new MessageBag;
+                        $messageBag->add('car_id', 'The driver must have a car with a plate.');
+                        $this->setErrors($messageBag);
+
+                        return;
+                    }
+
                     if (isset($data['total_seats']) && $data['total_seats'] < $trip->passengerAccepted()->count()) {
                         $this->setErrors(['error' => 'trip_invalid_seats']);
 

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -720,6 +720,72 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_update_driver_trip_replaces_soft_deleted_car_with_new_active_car(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), 'route/v1/driving')) {
+                return Http::response([
+                    'code' => 'Ok',
+                    'routes' => [['distance' => 365_000, 'duration' => 18_000]],
+                ], 200);
+            }
+
+            return Http::response('unexpected url in test', 404);
+        });
+
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        Event::fake([CreateEvent::class]);
+        $user = $this->completeUser();
+        $deletedCar = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'OLD001',
+            'description' => 'Removed',
+        ]);
+        $replacementCar = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'NEW002',
+            'description' => 'Replacement',
+        ]);
+        $manager = $this->manager();
+        $trip = $manager->create($user, $this->minimalCreatePayload([
+            'car_id' => $deletedCar->id,
+        ]));
+        $this->assertNotNull($trip);
+
+        $deletedCar->delete();
+        $this->assertSoftDeleted($deletedCar);
+
+        $updated = $manager->update($user, $trip->id, [
+            'car_id' => $replacementCar->id,
+        ]);
+
+        $this->assertNotNull($updated);
+        $fresh = $updated->fresh();
+        $this->assertSame($replacementCar->id, (int) $fresh->car_id);
+        $this->assertSame('NEW002', $fresh->car->patente);
+        Carbon::setTestNow();
+    }
+
+    public function test_validator_rejects_soft_deleted_car_id(): void
+    {
+        $user = $this->completeUser();
+        $deletedCar = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'OLD001',
+            'description' => 'Removed',
+        ]);
+        $deletedCar->delete();
+
+        $validator = $this->manager()->validator(
+            ['car_id' => $deletedCar->id],
+            $user->id,
+            1
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertTrue($validator->errors()->has('car_id'));
+    }
+
     public function test_create_driver_trip_uses_selected_car_when_user_has_multiple_active_cars(): void
     {
         Http::fake(function ($request) {

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -90,6 +90,42 @@ class TripTransformerTest extends TestCase
         $this->assertNull($payload['sellado_pending_label']);
         $this->assertSame('', $payload['request']);
         $this->assertSame([], $payload['passenger']);
+        $this->assertArrayNotHasKey('car', $payload);
+    }
+
+    public function test_transform_omits_car_for_unrelated_viewer_on_driver_trip(): void
+    {
+        $owner = User::factory()->create(['is_admin' => false]);
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $car = Car::factory()->create([
+            'user_id' => $owner->id,
+            'patente' => 'VIEW123',
+            'description' => 'Driver car',
+        ]);
+        $trip = $this->makeTrip([
+            'user_id' => $owner->id,
+            'car_id' => $car->id,
+            'is_passenger' => false,
+        ]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh(['car']));
+
+        $this->assertArrayNotHasKey('car', $payload);
+        $this->assertArrayNotHasKey('allPassengerRequest', $payload);
+    }
+
+    public function test_transform_omits_car_on_passenger_trip(): void
+    {
+        $owner = User::factory()->create();
+        $viewer = User::factory()->create();
+        $trip = $this->makeTrip([
+            'user_id' => $owner->id,
+            'is_passenger' => true,
+        ]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh());
+
+        $this->assertArrayNotHasKey('car', $payload);
     }
 
     public function test_transform_includes_rear_max_two_passengers(): void


### PR DESCRIPTION
Validate car_id against active cars only, normalize driver car on update, and add regression tests for reassignment and patente API visibility rules.