### PR TITLE
Migrate user tickets

### DIFF
--- a/app/Console/Commands/UpdateUser.php
+++ b/app/Console/Commands/UpdateUser.php
@@ -84,17 +84,7 @@ class UpdateUser extends Command
             $reference->save();
         }
 
-        $supportTickets = SupportTicket::where('user_id', '=', $originalId)->get();
-        foreach ($supportTickets as $supportTicket) {
-            $supportTicket->user_id = $newId;
-            $supportTicket->save();
-        }
-
-        $supportTicketReplies = SupportTicketReply::where('user_id', '=', $originalId)->get();
-        foreach ($supportTicketReplies as $supportTicketReply) {
-            $supportTicketReply->user_id = $newId;
-            $supportTicketReply->save();
-        }
+        $this->migrateSupportTicketOwnership($originalId, $newId);
 
         if ($this->option('remove') && $this->confirm('Do you wish to continue? This will remove the user from the database [y|N]')) {
             $user = User::find($originalId);
@@ -104,5 +94,16 @@ class UpdateUser extends Command
         }
 
         $this->info('Trips, references ratings and passenger have been updated.');
+    }
+
+    private function migrateSupportTicketOwnership(int|string $originalId, int|string $newId): void
+    {
+        SupportTicket::query()
+            ->where('user_id', '=', $originalId)
+            ->update(['user_id' => $newId]);
+
+        SupportTicketReply::query()
+            ->where('user_id', '=', $originalId)
+            ->update(['user_id' => $newId]);
     }
 }

--- a/app/Console/Commands/UpdateUser.php
+++ b/app/Console/Commands/UpdateUser.php
@@ -7,6 +7,7 @@ use STS\Models\Passenger;
 use STS\Models\Rating;
 use STS\Models\References;
 use STS\Models\SupportTicket;
+use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -84,7 +85,7 @@ class UpdateUser extends Command
             $reference->save();
         }
 
-        $this->migrateSupportTicketOwnership($originalId, $newId);
+        $this->migrateSupportTicketData($originalId, $newId);
 
         if ($this->option('remove') && $this->confirm('Do you wish to continue? This will remove the user from the database [y|N]')) {
             $user = User::find($originalId);
@@ -96,13 +97,17 @@ class UpdateUser extends Command
         $this->info('Trips, references ratings and passenger have been updated.');
     }
 
-    private function migrateSupportTicketOwnership(int|string $originalId, int|string $newId): void
+    private function migrateSupportTicketData(int|string $originalId, int|string $newId): void
     {
         SupportTicket::query()
             ->where('user_id', '=', $originalId)
             ->update(['user_id' => $newId]);
 
         SupportTicketReply::query()
+            ->where('user_id', '=', $originalId)
+            ->update(['user_id' => $newId]);
+
+        SupportTicketAttachment::query()
             ->where('user_id', '=', $originalId)
             ->update(['user_id' => $newId]);
     }

--- a/app/Console/Commands/UpdateUser.php
+++ b/app/Console/Commands/UpdateUser.php
@@ -2,12 +2,14 @@
 
 namespace STS\Console\Commands;
 
-use STS\Models\User;
-use STS\Models\Trip;
-use STS\Models\Rating;
-use STS\Models\Passenger;
 use Illuminate\Console\Command;
+use STS\Models\Passenger;
+use STS\Models\Rating;
 use STS\Models\References;
+use STS\Models\SupportTicket;
+use STS\Models\SupportTicketReply;
+use STS\Models\Trip;
+use STS\Models\User;
 
 class UpdateUser extends Command
 {
@@ -42,7 +44,7 @@ class UpdateUser extends Command
      */
     public function handle()
     {
-        \Log::info("COMMAND UpdateUser");
+        \Log::info('COMMAND UpdateUser');
         $originalId = $this->argument('original');
         $newId = $this->argument('new');
 
@@ -70,20 +72,29 @@ class UpdateUser extends Command
             $trip->save();
         }
 
-        
         $referencesFrom = References::where('user_id_from', '=', $originalId)->get();
         foreach ($referencesFrom as $reference) {
             $reference->user_id_from = $newId;
             $reference->save();
         }
 
-        
         $referencesTo = References::where('user_id_to', '=', $originalId)->get();
         foreach ($referencesTo as $reference) {
             $reference->user_id_to = $newId;
             $reference->save();
         }
 
+        $supportTickets = SupportTicket::where('user_id', '=', $originalId)->get();
+        foreach ($supportTickets as $supportTicket) {
+            $supportTicket->user_id = $newId;
+            $supportTicket->save();
+        }
+
+        $supportTicketReplies = SupportTicketReply::where('user_id', '=', $originalId)->get();
+        foreach ($supportTicketReplies as $supportTicketReply) {
+            $supportTicketReply->user_id = $newId;
+            $supportTicketReply->save();
+        }
 
         if ($this->option('remove') && $this->confirm('Do you wish to continue? This will remove the user from the database [y|N]')) {
             $user = User::find($originalId);

--- a/tests/Unit/Console/Commands/UpdateUserTest.php
+++ b/tests/Unit/Console/Commands/UpdateUserTest.php
@@ -9,6 +9,7 @@ use STS\Models\Passenger;
 use STS\Models\Rating;
 use STS\Models\References;
 use STS\Models\SupportTicket;
+use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -88,6 +89,15 @@ class UpdateUserTest extends TestCase
             'is_admin' => false,
             'message_markdown' => 'I need assistance',
         ]);
+        $attachment = SupportTicketAttachment::query()->create([
+            'ticket_id' => $ticket->id,
+            'reply_id' => null,
+            'user_id' => $original->id,
+            'path' => 'tickets/'.$ticket->id.'/screenshot.png',
+            'original_name' => 'screenshot.png',
+            'mime' => 'image/png',
+            'size_bytes' => 100,
+        ]);
 
         $this->artisan('user:update', [
             'original' => $original->id,
@@ -96,6 +106,7 @@ class UpdateUserTest extends TestCase
 
         $this->assertSame($new->id, (int) $ticket->fresh()->user_id);
         $this->assertSame($new->id, (int) $reply->fresh()->user_id);
+        $this->assertSame($new->id, (int) $attachment->fresh()->user_id);
     }
 
     public function test_handle_with_remove_deactivates_original_user_after_confirmation(): void

--- a/tests/Unit/Console/Commands/UpdateUserTest.php
+++ b/tests/Unit/Console/Commands/UpdateUserTest.php
@@ -8,6 +8,8 @@ use STS\Console\Commands\UpdateUser;
 use STS\Models\Passenger;
 use STS\Models\Rating;
 use STS\Models\References;
+use STS\Models\SupportTicket;
+use STS\Models\SupportTicketReply;
 use STS\Models\Trip;
 use STS\Models\User;
 use Tests\TestCase;
@@ -66,6 +68,34 @@ class UpdateUserTest extends TestCase
         Event::assertDispatched(MessageLogged::class, function (MessageLogged $e): bool {
             return $e->level === 'info' && $e->message === 'COMMAND UpdateUser';
         });
+    }
+
+    public function test_handle_reassigns_support_tickets_and_replies_to_new_user(): void
+    {
+        $original = User::factory()->create(['active' => true]);
+        $new = User::factory()->create(['active' => true]);
+
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $original->id,
+            'type' => 'contact',
+            'subject' => 'Help with account',
+            'status' => 'Open',
+            'priority' => 'normal',
+        ]);
+        $reply = SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $original->id,
+            'is_admin' => false,
+            'message_markdown' => 'I need assistance',
+        ]);
+
+        $this->artisan('user:update', [
+            'original' => $original->id,
+            'new' => $new->id,
+        ])->assertExitCode(0);
+
+        $this->assertSame($new->id, (int) $ticket->fresh()->user_id);
+        $this->assertSame($new->id, (int) $reply->fresh()->user_id);
     }
 
     public function test_handle_with_remove_deactivates_original_user_after_confirmation(): void


### PR DESCRIPTION
- **`user:update` command** (`UpdateUser`): reassigns `user_id` on:
  - `support_tickets`
  - `support_ticket_replies`
  - `support_ticket_attachments`
- Logic is grouped in `migrateSupportTicketData()` using bulk updates.
- **Tests**: `UpdateUserTest` covers ticket, reply, and attachment reassignment.
