### PR TITLE
Allow editing names

### DIFF
--- a/app/Services/Logic/SocialManager.php
+++ b/app/Services/Logic/SocialManager.php
@@ -88,7 +88,7 @@ class SocialManager extends BaseManager implements Social
                 $img = file_get_contents($userData['image']);
                 $userData['image'] = $this->filesRepo->createFromData($img, 'jpg', 'image/profile/');
             }
-            $userData = app(UserEditablePropertiesService::class)->filterForUser($userData, false);
+            $userData = app(UserEditablePropertiesService::class)->filterForUser($userData, false, $user);
             $user = $this->userLogic->update($user, $userData);
             if (! $user) {
                 $this->setErrors($this->userLogic->getErrors());

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -273,7 +273,7 @@ class UsersManager extends BaseManager
             $data = $this->prepareFacebookProfileUrl($data);
         }
         $requestData = $data;
-        $data = $this->userEditablePropertiesService->filterForUser($data, $is_admin);
+        $data = $this->userEditablePropertiesService->filterForUser($data, $is_admin, $user);
 
         // Alert when non-admin tries to change forbidden/flagged props (but don't block - allow old apps)
         $bannedProperties = $this->userEditablePropertiesService->getBlockedFlaggedPropertiesThatDiffer(

--- a/app/Services/UserEditablePropertiesService.php
+++ b/app/Services/UserEditablePropertiesService.php
@@ -2,8 +2,8 @@
 
 namespace STS\Services;
 
-use STS\Models\User;
 use Illuminate\Support\Facades\Http;
+use STS\Models\User;
 
 class UserEditablePropertiesService
 {
@@ -57,10 +57,14 @@ class UserEditablePropertiesService
     /**
      * Check if a property is allowed for the given role.
      */
-    public function isPropertyAllowed(string $property, bool $isAdmin): bool
+    public function isPropertyAllowed(string $property, bool $isAdmin, ?User $user = null): bool
     {
         $forbidden = $this->getForbiddenProperties();
         if (in_array($property, $forbidden)) {
+            return false;
+        }
+
+        if ($property === 'name' && ! $isAdmin && $user && $this->isNameLockedByIdentityValidation($user)) {
             return false;
         }
 
@@ -71,6 +75,7 @@ class UserEditablePropertiesService
 
         if ($isAdmin) {
             $adminAllowed = $this->getAdminAllowedProperties();
+
             return in_array($property, $adminAllowed);
         }
 
@@ -78,10 +83,18 @@ class UserEditablePropertiesService
     }
 
     /**
+     * Whether the user's name is locked because identity has been validated.
+     */
+    public function isNameLockedByIdentityValidation(User $user): bool
+    {
+        return (bool) $user->identity_validated && $user->identity_validated_at;
+    }
+
+    /**
      * Filter data to only include editable keys for the given role.
      * Returns the filtered array. Does not modify the input.
      */
-    public function filterForUser(array $data, bool $isAdmin): array
+    public function filterForUser(array $data, bool $isAdmin, ?User $user = null): array
     {
         $filtered = [];
         $forbidden = $this->getForbiddenProperties();
@@ -93,9 +106,13 @@ class UserEditablePropertiesService
             if (in_array($key, $forbidden)) {
                 continue;
             }
-            if (in_array($key, $editableKeys)) {
-                $filtered[$key] = $value;
+            if (! in_array($key, $editableKeys)) {
+                continue;
             }
+            if ($key === 'name' && ! $isAdmin && $user && $this->isNameLockedByIdentityValidation($user)) {
+                continue;
+            }
+            $filtered[$key] = $value;
         }
 
         return $filtered;
@@ -117,7 +134,7 @@ class UserEditablePropertiesService
         $actuallyChanged = [];
 
         foreach ($blockedKeys as $key) {
-            if (!array_key_exists($key, $requestData)) {
+            if (! array_key_exists($key, $requestData)) {
                 continue;
             }
             if (array_key_exists($key, $filteredData)) {
@@ -144,6 +161,7 @@ class UserEditablePropertiesService
         if (in_array($key, $booleanAttrs)) {
             $reqBool = filter_var($requested, FILTER_VALIDATE_BOOLEAN);
             $curBool = (bool) $current;
+
             return $reqBool !== $curBool;
         }
         if (is_string($requested)) {
@@ -158,6 +176,7 @@ class UserEditablePropertiesService
         if (is_string($requested) && preg_match('/^\d{4}-\d{2}-\d{2}/', $requested)) {
             $requested = substr($requested, 0, 10);
         }
+
         return $requested != $current;
     }
 
@@ -166,7 +185,7 @@ class UserEditablePropertiesService
      */
     public function frontendAdminProfileUrl(int $userId): string
     {
-        return rtrim(config('carpoolear.frontend_url'), '/') . '/app/profile/' . $userId;
+        return rtrim(config('carpoolear.frontend_url'), '/').'/app/profile/'.$userId;
     }
 
     /**
@@ -185,7 +204,7 @@ class UserEditablePropertiesService
 
         try {
             $response = Http::timeout(3)->post($webhookUrl, ['text' => $slackMessage]);
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 \Log::warning('Slack forbidden edit webhook failed', [
                     'status' => $response->status(),
                     'body' => $response->body(),

--- a/app/Services/UserEditablePropertiesService.php
+++ b/app/Services/UserEditablePropertiesService.php
@@ -97,22 +97,11 @@ class UserEditablePropertiesService
     public function filterForUser(array $data, bool $isAdmin, ?User $user = null): array
     {
         $filtered = [];
-        $forbidden = $this->getForbiddenProperties();
-        $allowed = $this->getAllowedProperties();
-        $adminAllowed = $isAdmin ? $this->getAdminAllowedProperties() : [];
-        $editableKeys = array_merge($allowed, $adminAllowed);
 
         foreach ($data as $key => $value) {
-            if (in_array($key, $forbidden)) {
-                continue;
+            if ($this->isPropertyAllowed($key, $isAdmin, $user)) {
+                $filtered[$key] = $value;
             }
-            if (! in_array($key, $editableKeys)) {
-                continue;
-            }
-            if ($key === 'name' && ! $isAdmin && $user && $this->isNameLockedByIdentityValidation($user)) {
-                continue;
-            }
-            $filtered[$key] = $value;
         }
 
         return $filtered;

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -147,9 +147,10 @@ return [
         // NEVER editable by anyone (including admins)
         'forbidden' => ['is_admin'],
 
-        // Editable by regular users (self-edit). name and email are only set at registration.
+        // Editable by regular users (self-edit). email is only set at registration.
+        // name is editable until identity is validated (see UserEditablePropertiesService).
         'allowed' => [
-            'password', 'password_confirmation', 'birthday', 'gender', 'description',
+            'name', 'password', 'password_confirmation', 'birthday', 'gender', 'description',
             'mobile_phone', 'emails_notifications', 'nro_doc',
             'data_visibility',
             'do_not_alert_request_seat', 'do_not_alert_accept_passenger',
@@ -161,9 +162,9 @@ return [
             'facebook_profile_url',
         ],
 
-        // Additional properties editable only by admin (name/email only at registration for users)
+        // Additional properties editable only by admin (email only at registration for users)
         'admin_allowed' => [
-            'name', 'email', 'banned', 'active', 'driver_is_verified',
+            'email', 'banned', 'active', 'driver_is_verified',
             'patente', 'car_description', 'private_note',
             'facebook_profile_url',
             'identity_validated', 'identity_validated_at',

--- a/tests/Feature/ApiAuthTest.php
+++ b/tests/Feature/ApiAuthTest.php
@@ -154,17 +154,27 @@ class ApiAuthTest extends TestCase
         $this->assertTrue($response->status() == 200);
         $this->assertEquals(0, \STS\Models\User::find($user->id)->banned);
 
-        // Sending name: request succeeds, name is not persisted (still Original)
+        // Unverified user: name is persisted
+        $response = $this->call('PUT', 'api/users', ['name' => 'Updated Name']);
+        $this->assertTrue($response->status() == 200);
+        $this->assertEquals('Updated Name', \STS\Models\User::find($user->id)->name);
+
+        // After identity validation, name changes are blocked
+        $user->forceFill([
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+        ])->save();
+
         $response = $this->call('PUT', 'api/users', ['name' => 'Hacker']);
         $this->assertTrue($response->status() == 200);
-        $this->assertEquals('Original', \STS\Models\User::find($user->id)->name);
+        $this->assertEquals('Updated Name', \STS\Models\User::find($user->id)->name);
 
         // Mixed: allowed + forbidden in same request - allowed is saved, forbidden ignored
         $response = $this->call('PUT', 'api/users', ['description' => 'New desc', 'name' => 'IgnoredName', 'email' => 'other@x.com']);
         $this->assertTrue($response->status() == 200);
         $reloaded = \STS\Models\User::find($user->id);
         $this->assertEquals('New desc', $reloaded->description);
-        $this->assertEquals('Original', $reloaded->name);
+        $this->assertEquals('Updated Name', $reloaded->name);
         $this->assertEquals($user->email, $reloaded->email);
     }
 

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -192,6 +192,51 @@ class UserControllerApiTest extends TestCase
         $this->assertSame('Bio without declaring driver intent.', $user->fresh()->description);
     }
 
+    public function test_update_persists_name_for_unverified_user(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Original Name',
+            'active' => true,
+            'banned' => false,
+            'identity_validated' => false,
+            'identity_validated_at' => null,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->putJson('api/users/', [
+            'name' => 'Updated Name',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Updated Name');
+
+        $this->assertSame('Updated Name', $user->fresh()->name);
+    }
+
+    public function test_update_ignores_name_change_for_identity_validated_user(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Verified Name',
+            'active' => true,
+            'banned' => false,
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->putJson('api/users/', [
+            'name' => 'Attempted Change',
+            'description' => 'Still editable bio.',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Verified Name')
+            ->assertJsonPath('data.description', 'Still editable bio.');
+
+        $this->assertSame('Verified Name', $user->fresh()->name);
+        $this->assertSame('Still editable bio.', $user->fresh()->description);
+    }
+
     public function test_registration_persists_facebook_profile_url_when_module_enabled(): void
     {
         config(['carpoolear.module_facebook_profile_url_enabled' => true]);

--- a/tests/Unit/Services/Logic/SocialManagerTest.php
+++ b/tests/Unit/Services/Logic/SocialManagerTest.php
@@ -315,7 +315,7 @@ class SocialManagerTest extends TestCase
         $filter = Mockery::mock(UserEditablePropertiesService::class);
         $filter->shouldReceive('filterForUser')
             ->once()
-            ->with(Mockery::type('array'), false)
+            ->with(Mockery::type('array'), false, Mockery::on(fn ($u) => $u->is($user)))
             ->andReturn(['name' => 'After']);
         $this->app->instance(UserEditablePropertiesService::class, $filter);
 
@@ -364,7 +364,7 @@ class SocialManagerTest extends TestCase
         $filter = Mockery::mock(UserEditablePropertiesService::class);
         $filter->shouldReceive('filterForUser')
             ->once()
-            ->with(Mockery::type('array'), false)
+            ->with(Mockery::type('array'), false, Mockery::on(fn ($u) => $u->is($user)))
             ->andReturn(['name' => 'After']);
         $this->app->instance(UserEditablePropertiesService::class, $filter);
 

--- a/tests/Unit/Services/Logic/UsersManagerTest.php
+++ b/tests/Unit/Services/Logic/UsersManagerTest.php
@@ -648,7 +648,7 @@ class UsersManagerTest extends TestCase
         $editableService = Mockery::mock(UserEditablePropertiesService::class);
         $editableService->shouldReceive('filterForUser')
             ->once()
-            ->with(Mockery::type('array'), false)
+            ->with(Mockery::type('array'), false, $user)
             ->andReturnUsing(fn ($data) => $data);
         $editableService->shouldReceive('getBlockedFlaggedPropertiesThatDiffer')
             ->once()
@@ -690,7 +690,7 @@ class UsersManagerTest extends TestCase
         $editableService = Mockery::mock(UserEditablePropertiesService::class);
         $editableService->shouldReceive('filterForUser')
             ->once()
-            ->with(Mockery::type('array'), false)
+            ->with(Mockery::type('array'), false, $user)
             ->andReturnUsing(fn ($data) => $data);
         $editableService->shouldReceive('getBlockedFlaggedPropertiesThatDiffer')
             ->once()
@@ -739,7 +739,7 @@ class UsersManagerTest extends TestCase
         $editableService = Mockery::mock(UserEditablePropertiesService::class);
         $editableService->shouldReceive('filterForUser')
             ->once()
-            ->with($requestData, false)
+            ->with($requestData, false, $user)
             ->andReturn($filteredData);
         $editableService->shouldReceive('getBlockedFlaggedPropertiesThatDiffer')
             ->once()
@@ -794,7 +794,7 @@ class UsersManagerTest extends TestCase
         $editableService = Mockery::mock(UserEditablePropertiesService::class);
         $editableService->shouldReceive('filterForUser')
             ->once()
-            ->with($requestData, true)
+            ->with($requestData, true, $user)
             ->andReturn($requestData);
         $editableService->shouldReceive('getBlockedFlaggedPropertiesThatDiffer')
             ->once()

--- a/tests/Unit/UserEditablePropertiesServiceTest.php
+++ b/tests/Unit/UserEditablePropertiesServiceTest.php
@@ -225,4 +225,66 @@ class UserEditablePropertiesServiceTest extends TestCase
         $this->assertNotContains('banned', $keys);
         $this->assertNotContains('active', $keys);
     }
+
+    public function test_filter_for_user_includes_name_for_unverified_user(): void
+    {
+        $service = new UserEditablePropertiesService;
+        $user = User::factory()->make([
+            'identity_validated' => false,
+            'identity_validated_at' => null,
+        ]);
+
+        $filtered = $service->filterForUser(['name' => 'New Name', 'description' => 'Bio'], false, $user);
+
+        $this->assertSame(['name' => 'New Name', 'description' => 'Bio'], $filtered);
+    }
+
+    public function test_filter_for_user_excludes_name_for_identity_validated_user(): void
+    {
+        $service = new UserEditablePropertiesService;
+        $user = User::factory()->make([
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+        ]);
+
+        $filtered = $service->filterForUser(['name' => 'New Name', 'description' => 'Bio'], false, $user);
+
+        $this->assertSame(['description' => 'Bio'], $filtered);
+    }
+
+    public function test_filter_for_user_includes_name_for_admin_even_when_identity_validated(): void
+    {
+        $service = new UserEditablePropertiesService;
+        $user = User::factory()->make([
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+        ]);
+
+        $filtered = $service->filterForUser(['name' => 'Admin Name', 'description' => 'Bio'], true, $user);
+
+        $this->assertSame(['name' => 'Admin Name', 'description' => 'Bio'], $filtered);
+    }
+
+    public function test_is_name_locked_by_identity_validation_requires_both_flags(): void
+    {
+        $service = new UserEditablePropertiesService;
+
+        $validated = User::factory()->make([
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+        ]);
+        $this->assertTrue($service->isNameLockedByIdentityValidation($validated));
+
+        $flagOnly = User::factory()->make([
+            'identity_validated' => true,
+            'identity_validated_at' => null,
+        ]);
+        $this->assertFalse($service->isNameLockedByIdentityValidation($flagOnly));
+
+        $unverified = User::factory()->make([
+            'identity_validated' => false,
+            'identity_validated_at' => null,
+        ]);
+        $this->assertFalse($service->isNameLockedByIdentityValidation($unverified));
+    }
 }


### PR DESCRIPTION
- Moved `name` from `admin_allowed` to `allowed` in `user_edit_properties` config
- Added identity-gated name editing in `UserEditablePropertiesService`:
  - `isNameLockedByIdentityValidation()` — locks when both `identity_validated` and `identity_validated_at` are set
  - `filterForUser()` and `isPropertyAllowed()` now accept an optional `User` and block name changes for verified non-admin users
- Passed the user through `filterForUser()` in `UsersManager` and `SocialManager`
- Added unit and HTTP tests for unverified (name persists) and verified (name ignored) update flows
