### PR TITLE
Admin: change ticket category

### DIFF
--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -238,6 +238,7 @@ class SupportTicketController extends Controller
         ]);
         $ticket = SupportTicket::findOrFail($id);
         $ticket->type = $validated['type'];
+        $ticket->priority = SupportTicket::TYPE_DEFAULT_PRIORITIES[$validated['type']] ?? 'normal';
         $ticket->updated_by = auth()->id();
         $ticket->save();
 

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -231,6 +231,19 @@ class SupportTicketController extends Controller
         return response()->json(['data' => $ticket]);
     }
 
+    public function updateType(int $id, Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'type' => SupportTicket::typeValidationRule(),
+        ]);
+        $ticket = SupportTicket::findOrFail($id);
+        $ticket->type = $validated['type'];
+        $ticket->updated_by = auth()->id();
+        $ticket->save();
+
+        return response()->json(['data' => $ticket]);
+    }
+
     public function updateInternalNote(int $id, Request $request): JsonResponse
     {
         $validated = $request->validate([

--- a/routes/api.php
+++ b/routes/api.php
@@ -264,6 +264,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('support/tickets/{id}/replies', [AdminSupportTicketController::class, 'reply'])->middleware('throttle:support-ticket-admin-reply');
         Route::match(['patch', 'put'], 'support/tickets/{id}/status', [AdminSupportTicketController::class, 'updateStatus']);
         Route::match(['patch', 'put'], 'support/tickets/{id}/priority', [AdminSupportTicketController::class, 'updatePriority']);
+        Route::match(['patch', 'put'], 'support/tickets/{id}/type', [AdminSupportTicketController::class, 'updateType']);
         Route::match(['patch', 'put'], 'support/tickets/{id}/internal-note', [AdminSupportTicketController::class, 'updateInternalNote']);
         Route::post('support/tickets/{id}/resolve', [AdminSupportTicketController::class, 'resolve']);
         Route::post('support/tickets/{id}/close', [AdminSupportTicketController::class, 'close']);

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -780,7 +780,7 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
     {
         $admin = $this->adminUser();
         $owner = User::factory()->create();
-        $ticket = $this->makeTicket($owner, ['type' => 'feedback']);
+        $ticket = $this->makeTicket($owner, ['type' => 'feedback', 'priority' => 'low']);
 
         $this->actingAs($admin, 'api');
         $this->withoutMiddleware(UserAdmin::class);
@@ -789,10 +789,51 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
             'type' => 'bug_report',
         ])
             ->assertOk()
-            ->assertJsonPath('data.type', 'bug_report');
+            ->assertJsonPath('data.type', 'bug_report')
+            ->assertJsonPath('data.priority', 'normal');
 
-        $this->assertSame('bug_report', $ticket->fresh()->type);
-        $this->assertSame($admin->id, (int) $ticket->fresh()->updated_by);
+        $fresh = $ticket->fresh();
+        $this->assertSame('bug_report', $fresh->type);
+        $this->assertSame('normal', $fresh->priority);
+        $this->assertSame($admin->id, (int) $fresh->updated_by);
+    }
+
+    public function test_update_type_syncs_priority_to_category_default(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['type' => 'feedback', 'priority' => 'high']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->putJson('api/admin/support/tickets/'.$ticket->id.'/type', [
+            'type' => 'report',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.type', 'report')
+            ->assertJsonPath('data.priority', 'high');
+
+        $this->assertSame('high', $ticket->fresh()->priority);
+    }
+
+    public function test_update_type_downgrades_priority_when_new_category_defaults_lower(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['type' => 'account_verification', 'priority' => 'high']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->putJson('api/admin/support/tickets/'.$ticket->id.'/type', [
+            'type' => 'feedback',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.type', 'feedback')
+            ->assertJsonPath('data.priority', 'low');
+
+        $this->assertSame('low', $ticket->fresh()->priority);
     }
 
     public function test_update_type_rejects_invalid_value(): void

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -776,6 +776,39 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         ])->assertUnprocessable();
     }
 
+    public function test_update_type_persists_and_returns_ticket_payload(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['type' => 'feedback']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->putJson('api/admin/support/tickets/'.$ticket->id.'/type', [
+            'type' => 'bug_report',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.type', 'bug_report');
+
+        $this->assertSame('bug_report', $ticket->fresh()->type);
+        $this->assertSame($admin->id, (int) $ticket->fresh()->updated_by);
+    }
+
+    public function test_update_type_rejects_invalid_value(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->putJson('api/admin/support/tickets/'.$ticket->id.'/type', [
+            'type' => 'invalid_category',
+        ])->assertUnprocessable();
+    }
+
     public function test_update_internal_note_persists_text_and_can_clear(): void
     {
         $admin = $this->adminUser();


### PR DESCRIPTION
- Added `PUT/PATCH /api/admin/support/tickets/{id}/type` endpoint
- Validates against existing ticket type rules
- Updates `type` and sets `priority` from `SupportTicket::TYPE_DEFAULT_PRIORITIES`
- Integration tests cover successful updates, invalid types, and priority sync (including upgrades and downgrades)
