### PR TITLE
Support ticket: filters

### DIFF
--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -45,6 +45,18 @@ class SupportTicketController extends Controller
 
     public function index(Request $request): JsonResponse
     {
+        $query = $this->buildAdminIndexQuery($request);
+
+        return response()->json([
+            'data' => $query->orderByDesc('id')->get(),
+        ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Builder<SupportTicket>
+     */
+    private function buildAdminIndexQuery(Request $request)
+    {
         $query = SupportTicket::query()
             ->with(self::ticketIndexRelationships());
 
@@ -62,9 +74,7 @@ class SupportTicketController extends Controller
             $query->adminNeedsAttention();
         }
 
-        return response()->json([
-            'data' => $query->orderByDesc('id')->get(),
-        ]);
+        return $query;
     }
 
     public function show(int $id): JsonResponse

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -58,6 +58,10 @@ class SupportTicketController extends Controller
             $query->where('priority', $priority);
         }
 
+        if ($this->queryFlagIsTruthy($request->query('needs_reply'))) {
+            $query->adminNeedsAttention();
+        }
+
         return response()->json([
             'data' => $query->orderByDesc('id')->get(),
         ]);
@@ -312,5 +316,14 @@ class SupportTicketController extends Controller
         });
 
         return response()->json(['data' => $ticket->fresh()]);
+    }
+
+    private function queryFlagIsTruthy(mixed $value): bool
+    {
+        if ($value === null || $value === '') {
+            return false;
+        }
+
+        return in_array(strtolower((string) $value), ['1', 'true', 'yes'], true);
     }
 }

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -43,13 +43,18 @@ class SupportTicketController extends Controller
 
     public function __construct(private readonly SupportTicketService $supportTicketService) {}
 
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
+        $query = SupportTicket::query()
+            ->with(self::ticketIndexRelationships());
+
+        $type = $request->query('type');
+        if (is_string($type) && $type !== '' && in_array($type, SupportTicket::TYPES, true)) {
+            $query->where('type', $type);
+        }
+
         return response()->json([
-            'data' => SupportTicket::query()
-                ->with(self::ticketIndexRelationships())
-                ->orderByDesc('id')
-                ->get(),
+            'data' => $query->orderByDesc('id')->get(),
         ]);
     }
 

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -53,6 +53,11 @@ class SupportTicketController extends Controller
             $query->where('type', $type);
         }
 
+        $priority = $request->query('priority');
+        if (is_string($priority) && in_array($priority, ['low', 'normal', 'high'], true)) {
+            $query->where('priority', $priority);
+        }
+
         return response()->json([
             'data' => $query->orderByDesc('id')->get(),
         ]);

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -31,6 +31,13 @@ class SupportTicket extends Model
 
     public const STATUS_NEEDS_REVIEW = 'Necesita revisión';
 
+    /** Statuses where the help desk team should take action. */
+    private const ADMIN_ACTION_STATUSES = [
+        'Open',
+        'En revision',
+        self::STATUS_NEEDS_REVIEW,
+    ];
+
     /** @var list<string> */
     public const STATUSES = [
         'Open',
@@ -88,5 +95,19 @@ class SupportTicket extends Model
     public function attachments()
     {
         return $this->hasMany(SupportTicketAttachment::class, 'ticket_id');
+    }
+
+    /**
+     * Tickets waiting on admin attention: unread user messages or actionable status.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<self>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<self>
+     */
+    public function scopeAdminNeedsAttention($query)
+    {
+        return $query->where(function ($builder) {
+            $builder->where('unread_for_admin', '>', 0)
+                ->orWhereIn('status', self::ADMIN_ACTION_STATUSES);
+        });
     }
 }

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -41,6 +41,23 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         ], $overrides));
     }
 
+    public function test_index_filters_by_type_when_type_query_param_is_set(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $feedback = $this->makeTicket($owner, ['type' => 'feedback', 'subject' => 'feedback-only']);
+        $this->makeTicket($owner, ['type' => 'bug_report', 'subject' => 'bug-only']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets?type=feedback')->assertOk()->json('data'));
+        $ids = $rows->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains($feedback->id, $ids);
+        $this->assertTrue($rows->every(fn (array $row): bool => $row['type'] === 'feedback'));
+    }
+
     public function test_index_returns_data_ordered_newest_first(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -74,6 +74,32 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertTrue($rows->every(fn (array $row): bool => $row['priority'] === 'high'));
     }
 
+    public function test_index_filters_by_needs_reply_when_query_param_is_set(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $needsAttention = $this->makeTicket($owner, [
+            'status' => SupportTicket::STATUS_NEEDS_REVIEW,
+            'unread_for_admin' => 0,
+            'subject' => 'needs-attention',
+        ]);
+        $this->makeTicket($owner, [
+            'status' => 'Esperando respuesta',
+            'unread_for_admin' => 0,
+            'subject' => 'waiting-user',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets?needs_reply=1')->assertOk()->json('data'));
+        $ids = $rows->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains($needsAttention->id, $ids);
+        $this->assertTrue($rows->every(fn (array $row): bool => in_array($row['status'], ['Open', 'En revision', SupportTicket::STATUS_NEEDS_REVIEW], true)
+            || (int) ($row['unread_for_admin'] ?? 0) > 0));
+    }
+
     public function test_index_returns_data_ordered_newest_first(): void
     {
         $admin = $this->adminUser();

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -58,6 +58,22 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertTrue($rows->every(fn (array $row): bool => $row['type'] === 'feedback'));
     }
 
+    public function test_index_filters_by_priority_when_priority_query_param_is_set(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $high = $this->makeTicket($owner, ['priority' => 'high', 'subject' => 'high-only']);
+        $this->makeTicket($owner, ['priority' => 'low', 'subject' => 'low-only']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets?priority=high')->assertOk()->json('data'));
+
+        $this->assertContains($high->id, $rows->pluck('id')->map(fn ($id) => (int) $id)->all());
+        $this->assertTrue($rows->every(fn (array $row): bool => $row['priority'] === 'high'));
+    }
+
     public function test_index_returns_data_ordered_newest_first(): void
     {
         $admin = $this->adminUser();

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -21,6 +21,50 @@ class SupportTicketTest extends TestCase
         $this->assertContains(SupportTicket::STATUS_NEEDS_REVIEW, SupportTicket::STATUSES);
     }
 
+    public function test_scope_admin_needs_attention_includes_unread_and_actionable_statuses(): void
+    {
+        $user = User::factory()->create();
+        $withUnread = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'Esperando respuesta',
+            'unread_for_admin' => 1,
+        ]);
+        $needsReview = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => SupportTicket::STATUS_NEEDS_REVIEW,
+            'unread_for_admin' => 0,
+        ]);
+        $enRevision = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'En revision',
+            'unread_for_admin' => 0,
+        ]);
+        $open = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'Open',
+            'unread_for_admin' => 0,
+        ]);
+        $waitingUser = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'Esperando respuesta',
+            'unread_for_admin' => 0,
+        ]);
+        $resolved = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'Resuelto',
+            'unread_for_admin' => 0,
+        ]);
+
+        $ids = SupportTicket::query()->adminNeedsAttention()->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains($withUnread->id, $ids);
+        $this->assertContains($needsReview->id, $ids);
+        $this->assertContains($enRevision->id, $ids);
+        $this->assertContains($open->id, $ids);
+        $this->assertNotContains($waitingUser->id, $ids);
+        $this->assertNotContains($resolved->id, $ids);
+    }
+
     public function test_fillable_contains_expected_mass_assignable_attributes(): void
     {
         $this->assertSame([

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -1404,14 +1404,19 @@ class TripRepositoryTest extends TestCase
     {
         // Mutation intent: preserve admin-withTrashed gate and from/to date OR-branch handling.
         // Kills: adb8efe4d6d7b5c5, fe67f74c929986cf, 45c5a98301e1e6bc, e38c3f8f43a330bb, 8415cdc00871d360.
+        // Fixed dates: to_date is start-of-day (Y-m-d 00:00:00), so the trashed trip must fall on from_date
+        // and to_date must be the following day. Relative Carbon::now() fails around midnight in CI.
         $admin = User::factory()->create();
         $admin->forceFill(['is_admin' => true])->saveQuietly();
+
+        $fromDate = '2024-06-14';
+        $toDate = '2024-06-15';
 
         $trashed = Trip::factory()->create([
             'friendship_type_id' => Trip::PRIVACY_PUBLIC,
             'state' => Trip::STATE_READY,
             'needs_sellado' => 0,
-            'trip_date' => Carbon::now()->subHours(2),
+            'trip_date' => '2024-06-14 23:00:00',
         ]);
         $trashed->delete();
 
@@ -1419,17 +1424,14 @@ class TripRepositoryTest extends TestCase
             'friendship_type_id' => Trip::PRIVACY_PUBLIC,
             'state' => Trip::STATE_READY,
             'needs_sellado' => 0,
-            'trip_date' => Carbon::now()->addHours(3),
+            'trip_date' => '2024-06-16 10:00:00',
         ]);
         $old = Trip::factory()->create([
             'friendship_type_id' => Trip::PRIVACY_PUBLIC,
             'state' => Trip::STATE_READY,
             'needs_sellado' => 0,
-            'trip_date' => Carbon::now()->subDays(4),
+            'trip_date' => '2024-06-10 10:00:00',
         ]);
-
-        $fromDate = Carbon::now()->subDay()->format('Y-m-d');
-        $toDate = Carbon::now()->subHour()->format('Y-m-d');
 
         $withoutAdminFlag = $this->repo()->search($admin, [
             'from_date' => $fromDate,


### PR DESCRIPTION
## Summary
Adds server-side filters to the admin support tickets index endpoint.
### Changes
- **`GET /api/admin/support/tickets`** accepts optional query params:
  - `type` — ticket category (validated against `SupportTicket::TYPES`)
  - `priority` — `low`, `normal`, or `high`
  - `needs_reply=1` — tickets needing team action (`unread_for_admin > 0` or status `Open`, `En revision`, `Necesita revisión`)
- New `SupportTicket::scopeAdminNeedsAttention()` for the needs-reply filter
- Index query logic extracted into `buildAdminIndexQuery()`
- Integration and unit tests for all three filters
