### PR TITLE
Restore rating interval to 15 days.

### DIFF
--- a/app/Console/Commands/CalculateActiveUsersPerMonth.php
+++ b/app/Console/Commands/CalculateActiveUsersPerMonth.php
@@ -77,7 +77,7 @@ class CalculateActiveUsersPerMonth extends Command
     {
         if ($monthOption = $this->option('month')) {
             try {
-                $targetMonth = Carbon::createFromFormat('Y-m', $monthOption);
+                $targetMonth = Carbon::createFromFormat('!Y-m', $monthOption);
             } catch (\Throwable) {
                 $this->error('Invalid month format. Use YYYY-MM (e.g., 2024-01)');
                 throw new \InvalidArgumentException('Invalid month format');

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -14,11 +14,12 @@ class Rating extends Model
     {
         return \Database\Factories\RatingFactory::new();
     }
+
     const STATE_NEGATIVO = 0;
 
     const STATE_POSITIVO = 1;
 
-    const RATING_INTERVAL = 25; // TODO: roll back to 15 on 2025-03-25
+    const RATING_INTERVAL = 15;
 
     protected $table = 'rating';
 
@@ -43,7 +44,7 @@ class Rating extends Model
             'reply_comment_created_at' => 'datetime',
             'rate_at' => 'datetime',
         ];
-    } 
+    }
 
     protected $hidden = [];
 

--- a/tests/Feature/Commands/CalculateActiveUsersPerMonthTest.php
+++ b/tests/Feature/Commands/CalculateActiveUsersPerMonthTest.php
@@ -9,63 +9,82 @@ use Tests\TestCase;
 
 class CalculateActiveUsersPerMonthTest extends TestCase
 {
+    private Carbon $targetMonth;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create(2026, 4, 15, 10, 0, 0));
+        $this->targetMonth = Carbon::create(2026, 3, 1);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function monthOption(): string
+    {
+        return $this->targetMonth->format('Y-m');
+    }
+
     public function test_calculates_active_users_for_previous_month()
     {
-        $lastMonth = Carbon::now()->subMonth();
-        $monthStr = $lastMonth->format('Y-m');
+        $monthStr = $this->monthOption();
 
         // Active user with connection last month
         User::factory()->create([
             'active' => true,
             'banned' => false,
-            'last_connection' => $lastMonth->copy()->startOfMonth()->addDays(5),
+            'last_connection' => $this->targetMonth->copy()->startOfMonth()->addDays(5),
         ]);
 
         // Another active user
         User::factory()->create([
             'active' => true,
             'banned' => false,
-            'last_connection' => $lastMonth->copy()->startOfMonth()->addDays(10),
+            'last_connection' => $this->targetMonth->copy()->startOfMonth()->addDays(10),
         ]);
 
         // Inactive user (should not count)
         User::factory()->create([
             'active' => false,
             'banned' => false,
-            'last_connection' => $lastMonth->copy()->startOfMonth()->addDays(3),
+            'last_connection' => $this->targetMonth->copy()->startOfMonth()->addDays(3),
         ]);
 
         // Banned user (should not count)
         User::factory()->create([
             'active' => true,
             'banned' => true,
-            'last_connection' => $lastMonth->copy()->startOfMonth()->addDays(3),
+            'last_connection' => $this->targetMonth->copy()->startOfMonth()->addDays(3),
         ]);
 
         // User with connection outside the target month (should not count)
         User::factory()->create([
             'active' => true,
             'banned' => false,
-            'last_connection' => $lastMonth->copy()->subMonths(2),
+            'last_connection' => $this->targetMonth->copy()->subMonths(2),
         ]);
 
         $this->artisan('users:calculate-active-per-month', ['--month' => $monthStr])
             ->assertSuccessful();
 
-        $record = ActiveUsersPerMonth::forYearMonth($lastMonth->year, $lastMonth->month)->first();
+        $record = ActiveUsersPerMonth::forYearMonth($this->targetMonth->year, $this->targetMonth->month)->first();
         $this->assertNotNull($record);
         $this->assertEquals(2, $record->value);
     }
 
     public function test_dry_run_does_not_save_to_database()
     {
-        $lastMonth = Carbon::now()->subMonth();
-        $monthStr = $lastMonth->format('Y-m');
+        $monthStr = $this->monthOption();
 
         User::factory()->create([
             'active' => true,
             'banned' => false,
-            'last_connection' => $lastMonth->copy()->startOfMonth()->addDays(5),
+            'last_connection' => $this->targetMonth->copy()->startOfMonth()->addDays(5),
         ]);
 
         $this->artisan('users:calculate-active-per-month', [
@@ -73,18 +92,17 @@ class CalculateActiveUsersPerMonthTest extends TestCase
             '--dry-run' => true,
         ])->assertSuccessful();
 
-        $record = ActiveUsersPerMonth::forYearMonth($lastMonth->year, $lastMonth->month)->first();
+        $record = ActiveUsersPerMonth::forYearMonth($this->targetMonth->year, $this->targetMonth->month)->first();
         $this->assertNull($record);
     }
 
     public function test_skips_if_data_already_exists()
     {
-        $lastMonth = Carbon::now()->subMonth();
-        $monthStr = $lastMonth->format('Y-m');
+        $monthStr = $this->monthOption();
 
         ActiveUsersPerMonth::create([
-            'year' => $lastMonth->year,
-            'month' => $lastMonth->month,
+            'year' => $this->targetMonth->year,
+            'month' => $this->targetMonth->month,
             'saved_at' => Carbon::now(),
             'value' => 99,
         ]);
@@ -93,18 +111,17 @@ class CalculateActiveUsersPerMonthTest extends TestCase
             ->assertSuccessful();
 
         // Original value should be preserved
-        $record = ActiveUsersPerMonth::forYearMonth($lastMonth->year, $lastMonth->month)->first();
+        $record = ActiveUsersPerMonth::forYearMonth($this->targetMonth->year, $this->targetMonth->month)->first();
         $this->assertEquals(99, $record->value);
     }
 
     public function test_force_recalculates()
     {
-        $lastMonth = Carbon::now()->subMonth();
-        $monthStr = $lastMonth->format('Y-m');
+        $monthStr = $this->monthOption();
 
         ActiveUsersPerMonth::create([
-            'year' => $lastMonth->year,
-            'month' => $lastMonth->month,
+            'year' => $this->targetMonth->year,
+            'month' => $this->targetMonth->month,
             'saved_at' => Carbon::now(),
             'value' => 99,
         ]);
@@ -112,7 +129,7 @@ class CalculateActiveUsersPerMonthTest extends TestCase
         User::factory()->create([
             'active' => true,
             'banned' => false,
-            'last_connection' => $lastMonth->copy()->startOfMonth()->addDays(5),
+            'last_connection' => $this->targetMonth->copy()->startOfMonth()->addDays(5),
         ]);
 
         $this->artisan('users:calculate-active-per-month', [
@@ -120,7 +137,7 @@ class CalculateActiveUsersPerMonthTest extends TestCase
             '--force' => true,
         ])->assertSuccessful();
 
-        $record = ActiveUsersPerMonth::forYearMonth($lastMonth->year, $lastMonth->month)->first();
+        $record = ActiveUsersPerMonth::forYearMonth($this->targetMonth->year, $this->targetMonth->month)->first();
         $this->assertNotEquals(99, $record->value);
     }
 }

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -115,7 +115,7 @@ class RatingTest extends TestCase
     {
         $this->assertSame(0, Rating::STATE_NEGATIVO);
         $this->assertSame(1, Rating::STATE_POSITIVO);
-        $this->assertSame(25, Rating::RATING_INTERVAL);
+        $this->assertSame(15, Rating::RATING_INTERVAL);
     }
 
     public function test_uses_rating_table_name(): void


### PR DESCRIPTION
Roll back the temporary 25-day interval and remove the scheduled TODO.