### PR TITLE
Migrate account changes

### DIFF
--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -64,16 +64,11 @@ class UserMigrationController extends Controller
 
     public function store(Request $request): JsonResponse
     {
-        $validated = $request->validate([
+        $validated = $request->validate(array_merge([
             'user_id_kept' => 'required|integer|exists:users,id',
             'user_id_removed' => 'required|integer|exists:users,id|different:user_id_kept',
             'field_sources' => 'sometimes|array',
-            'field_sources.email' => 'sometimes|in:removed,kept',
-            'field_sources.password' => 'sometimes|in:removed,kept',
-            'field_sources.nro_doc' => 'sometimes|in:removed,kept',
-            'field_sources.mobile_phone' => 'sometimes|in:removed,kept',
-            'field_sources.created_at' => 'sometimes|in:removed,kept',
-        ]);
+        ], $this->fieldSourceRules()));
 
         $admin = $request->user();
         $keptId = (int) $validated['user_id_kept'];
@@ -113,6 +108,19 @@ class UserMigrationController extends Controller
                 'created_at' => $row->created_at?->toAtomString(),
             ],
         ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fieldSourceRules(): array
+    {
+        $rules = [];
+        foreach (UserMigrationFieldMerger::MERGEABLE_FIELDS as $field) {
+            $rules['field_sources.'.$field] = 'sometimes|in:removed,kept';
+        }
+
+        return $rules;
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -13,6 +13,7 @@ use STS\Models\UserMigration;
 use STS\Services\AnonymizationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\UserDeletionService;
+use STS\Services\UserMigrationFieldMerger;
 use Throwable;
 
 class UserMigrationController extends Controller
@@ -21,6 +22,7 @@ class UserMigrationController extends Controller
         private readonly UserDeletionService $userDeletionService,
         private readonly AnonymizationService $anonymizationService,
         private readonly DeviceManager $deviceLogic,
+        private readonly UserMigrationFieldMerger $fieldMerger,
     ) {}
 
     public function index(Request $request): JsonResponse
@@ -65,16 +67,27 @@ class UserMigrationController extends Controller
         $validated = $request->validate([
             'user_id_kept' => 'required|integer|exists:users,id',
             'user_id_removed' => 'required|integer|exists:users,id|different:user_id_kept',
+            'field_sources' => 'sometimes|array',
+            'field_sources.email' => 'sometimes|in:removed,kept',
+            'field_sources.password' => 'sometimes|in:removed,kept',
+            'field_sources.nro_doc' => 'sometimes|in:removed,kept',
+            'field_sources.mobile_phone' => 'sometimes|in:removed,kept',
+            'field_sources.created_at' => 'sometimes|in:removed,kept',
         ]);
 
         $admin = $request->user();
         $keptId = (int) $validated['user_id_kept'];
         $removedId = (int) $validated['user_id_removed'];
+        $fieldSources = $validated['field_sources'] ?? [];
 
         Artisan::call('user:update', [
             'original' => (string) $removedId,
             'new' => (string) $keptId,
         ]);
+
+        $kept = User::findOrFail($keptId);
+        $removed = User::findOrFail($removedId);
+        $this->fieldMerger->apply($kept, $removed, $fieldSources);
 
         $removalAction = $this->removeOrAnonymize($removedId, $admin);
 

--- a/app/Services/UserMigrationFieldMerger.php
+++ b/app/Services/UserMigrationFieldMerger.php
@@ -6,19 +6,33 @@ use STS\Models\User;
 
 class UserMigrationFieldMerger
 {
+    /** @var list<string> */
+    public const MERGEABLE_FIELDS = [
+        'email',
+        'password',
+        'nro_doc',
+        'mobile_phone',
+        'created_at',
+    ];
+
+    /** @var array<string, 'removed'|'kept'> */
+    public const DEFAULT_FIELD_SOURCES = [
+        'email' => 'removed',
+        'password' => 'kept',
+        'nro_doc' => 'removed',
+        'mobile_phone' => 'kept',
+        'created_at' => 'removed',
+    ];
+
     /**
      * @param  array<string, 'removed'|'kept'>  $fieldSources
      */
-    public function apply(User $kept, User $removed, array $fieldSources): void
+    public function apply(User $kept, User $removed, array $fieldSources = []): void
     {
-        $fields = ['email', 'password', 'nro_doc', 'mobile_phone', 'created_at'];
+        $resolved = array_merge(self::DEFAULT_FIELD_SOURCES, $fieldSources);
 
-        foreach ($fields as $field) {
-            $source = $fieldSources[$field] ?? null;
-            if ($source === null) {
-                continue;
-            }
-
+        foreach (self::MERGEABLE_FIELDS as $field) {
+            $source = $resolved[$field];
             $from = $source === 'removed' ? $removed : $kept;
             $kept->{$field} = $from->{$field};
         }

--- a/app/Services/UserMigrationFieldMerger.php
+++ b/app/Services/UserMigrationFieldMerger.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\User;
+
+class UserMigrationFieldMerger
+{
+    /**
+     * @param  array<string, 'removed'|'kept'>  $fieldSources
+     */
+    public function apply(User $kept, User $removed, array $fieldSources): void
+    {
+        $fields = ['email', 'password', 'nro_doc', 'mobile_phone', 'created_at'];
+
+        foreach ($fields as $field) {
+            $source = $fieldSources[$field] ?? null;
+            if ($source === null) {
+                continue;
+            }
+
+            $from = $source === 'removed' ? $removed : $kept;
+            $kept->{$field} = $from->{$field};
+        }
+
+        $kept->save();
+    }
+}

--- a/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Http;
 
+use Illuminate\Support\Facades\Hash;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\AdminActionLog;
 use STS\Models\Trip;
@@ -113,6 +114,99 @@ class AdminUserMigrationControllerIntegrationTest extends TestCase
             'user_id_kept' => $kept->id,
             'user_id_removed' => $removed->id,
         ]);
+    }
+
+    public function test_store_applies_field_sources_to_kept_user_with_defaults(): void
+    {
+        $admin = $this->admin();
+        $kept = User::factory()->create([
+            'email' => 'new@example.test',
+            'password' => Hash::make('new-password'),
+            'nro_doc' => '22222222',
+            'mobile_phone' => '+5492222222222',
+        ]);
+        $removed = User::factory()->create([
+            'email' => 'old@example.test',
+            'password' => Hash::make('old-password'),
+            'nro_doc' => '11111111',
+            'mobile_phone' => '+5491111111111',
+        ]);
+        Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $response->assertOk();
+
+        $kept->refresh();
+        $this->assertSame('old@example.test', $kept->email);
+        $this->assertTrue(Hash::check('new-password', $kept->password));
+        $this->assertSame('11111111', $kept->nro_doc);
+        $this->assertSame('+5492222222222', $kept->mobile_phone);
+    }
+
+    public function test_store_applies_custom_field_sources_to_kept_user(): void
+    {
+        $admin = $this->admin();
+        $kept = User::factory()->create([
+            'email' => 'new@example.test',
+            'password' => Hash::make('new-password'),
+            'nro_doc' => '22222222',
+            'mobile_phone' => '+5492222222222',
+        ]);
+        $removed = User::factory()->create([
+            'email' => 'old@example.test',
+            'password' => Hash::make('old-password'),
+            'nro_doc' => '11111111',
+            'mobile_phone' => '+5491111111111',
+        ]);
+        Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+            'field_sources' => [
+                'email' => 'kept',
+                'password' => 'removed',
+                'nro_doc' => 'kept',
+                'mobile_phone' => 'removed',
+                'created_at' => 'kept',
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $kept->refresh();
+        $this->assertSame('new@example.test', $kept->email);
+        $this->assertTrue(Hash::check('old-password', $kept->password));
+        $this->assertSame('22222222', $kept->nro_doc);
+        $this->assertSame('+5491111111111', $kept->mobile_phone);
+    }
+
+    public function test_store_rejects_invalid_field_source_value(): void
+    {
+        $admin = $this->admin();
+        $kept = User::factory()->create();
+        $removed = User::factory()->create();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+            'field_sources' => [
+                'email' => 'other',
+            ],
+        ])->assertUnprocessable();
     }
 
     public function test_store_deletes_removed_user_when_deletion_succeeds(): void

--- a/tests/Unit/Services/UserMigrationFieldMergerTest.php
+++ b/tests/Unit/Services/UserMigrationFieldMergerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Hash;
+use STS\Models\User;
+use STS\Services\UserMigrationFieldMerger;
+use Tests\TestCase;
+
+class UserMigrationFieldMergerTest extends TestCase
+{
+    public function test_apply_merges_selected_fields_from_removed_and_kept_users(): void
+    {
+        $oldCreatedAt = Carbon::parse('2018-03-15 10:00:00');
+        $newCreatedAt = Carbon::parse('2024-06-20 14:30:00');
+
+        $removed = User::factory()->create([
+            'email' => 'old@example.test',
+            'password' => Hash::make('old-password'),
+            'nro_doc' => '11111111',
+            'mobile_phone' => '+5491111111111',
+            'created_at' => $oldCreatedAt,
+            'updated_at' => $oldCreatedAt,
+        ]);
+        $kept = User::factory()->create([
+            'email' => 'new@example.test',
+            'password' => Hash::make('new-password'),
+            'nro_doc' => '22222222',
+            'mobile_phone' => '+5492222222222',
+            'created_at' => $newCreatedAt,
+            'updated_at' => $newCreatedAt,
+        ]);
+
+        $merger = new UserMigrationFieldMerger;
+        $merger->apply($kept, $removed, [
+            'email' => 'removed',
+            'password' => 'kept',
+            'nro_doc' => 'removed',
+            'mobile_phone' => 'kept',
+            'created_at' => 'removed',
+        ]);
+
+        $kept->refresh();
+
+        $this->assertSame('old@example.test', $kept->email);
+        $this->assertTrue(Hash::check('new-password', $kept->password));
+        $this->assertSame('11111111', $kept->nro_doc);
+        $this->assertSame('+5492222222222', $kept->mobile_phone);
+        $this->assertSame(
+            $oldCreatedAt->toDateTimeString(),
+            $kept->created_at->toDateTimeString()
+        );
+    }
+}

--- a/tests/Unit/Services/UserMigrationFieldMergerTest.php
+++ b/tests/Unit/Services/UserMigrationFieldMergerTest.php
@@ -33,13 +33,7 @@ class UserMigrationFieldMergerTest extends TestCase
         ]);
 
         $merger = new UserMigrationFieldMerger;
-        $merger->apply($kept, $removed, [
-            'email' => 'removed',
-            'password' => 'kept',
-            'nro_doc' => 'removed',
-            'mobile_phone' => 'kept',
-            'created_at' => 'removed',
-        ]);
+        $merger->apply($kept, $removed, UserMigrationFieldMerger::DEFAULT_FIELD_SOURCES);
 
         $kept->refresh();
 


### PR DESCRIPTION
- Added `UserMigrationFieldMerger` to apply per-field choices onto the kept user after `user:update`.
- Extended `POST /api/admin/user-migrations` with optional `field_sources` (`removed` | `kept` per field).
- Defaults when omitted:
  - **From removed (old):** email, DNI, creation date
  - **From kept (new):** password, phone
- Validates `field_sources` and rejects invalid values.
- Existing delete/anonymize flow for the removed user is unchanged.
