### PR TITLE
Manual verification message

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -7,12 +7,15 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
-use STS\Models\User;
-use STS\Notifications\ManualIdentityValidationReviewNotification;
+use STS\Services\ManualIdentityValidationReviewNotifier;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ManualIdentityValidationController extends Controller
 {
+    public function __construct(
+        private readonly ManualIdentityValidationReviewNotifier $reviewNotifier,
+    ) {}
+
     /**
      * GET /api/admin/manual-identity-validations - list: paid first; within paid: with submitted_at (docs sent) first, then pending review, approved, rejected; then by waiting time (oldest first).
      * Waiting time = submitted_at (if submitted), else paid_at, else created_at.
@@ -159,24 +162,13 @@ class ManualIdentityValidationController extends Controller
         }
 
         if (in_array($validated['action'], ['approve', 'reject'], true)) {
-            $this->notifyUserOfManualReview(
+            $this->reviewNotifier->notify(
                 $user,
                 $validated['action'] === 'approve' ? 'approved' : 'rejected',
             );
         }
 
         return response()->json(['data' => $item->fresh(['user:id,name,nro_doc'])]);
-    }
-
-    private function notifyUserOfManualReview(User $user, string $action): void
-    {
-        $notification = new ManualIdentityValidationReviewNotification;
-        $notification->setAttribute('action', $action);
-        try {
-            $notification->notify($user);
-        } catch (\Throwable $e) {
-            report($e);
-        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationReviewNotification;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ManualIdentityValidationController extends Controller
@@ -156,7 +158,25 @@ class ManualIdentityValidationController extends Controller
             $user->save();
         }
 
+        if (in_array($validated['action'], ['approve', 'reject'], true)) {
+            $this->notifyUserOfManualReview(
+                $user,
+                $validated['action'] === 'approve' ? 'approved' : 'rejected',
+            );
+        }
+
         return response()->json(['data' => $item->fresh(['user:id,name,nro_doc'])]);
+    }
+
+    private function notifyUserOfManualReview(User $user, string $action): void
+    {
+        $notification = new ManualIdentityValidationReviewNotification;
+        $notification->setAttribute('action', $action);
+        try {
+            $notification->notify($user);
+        } catch (\Throwable $e) {
+            report($e);
+        }
     }
 
     /**

--- a/app/Notifications/ManualIdentityValidationReviewNotification.php
+++ b/app/Notifications/ManualIdentityValidationReviewNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace STS\Notifications;
+
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+
+class ManualIdentityValidationReviewNotification extends BaseNotification
+{
+    protected $via = [
+        DatabaseChannel::class,
+        PushChannel::class,
+    ];
+
+    public function toString()
+    {
+        $action = $this->getAttribute('action');
+
+        if ($action === 'rejected') {
+            return __('notifications.manual_identity_validation.rejected');
+        }
+
+        return __('notifications.manual_identity_validation.approved');
+    }
+
+    public function getExtras()
+    {
+        return [
+            'type' => 'identity_validation',
+            'action' => $this->getAttribute('action'),
+        ];
+    }
+
+    public function toPush($user, $device)
+    {
+        $action = $this->getAttribute('action');
+        $messageKey = $action === 'rejected'
+            ? 'notifications.manual_identity_validation.rejected'
+            : 'notifications.manual_identity_validation.approved';
+
+        return [
+            'message' => __($messageKey),
+            'url' => '/app/identity-validation',
+            'type' => 'identity_validation',
+            'extras' => [
+                'action' => $action,
+            ],
+            'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
+        ];
+    }
+}

--- a/app/Notifications/ManualIdentityValidationReviewNotification.php
+++ b/app/Notifications/ManualIdentityValidationReviewNotification.php
@@ -15,13 +15,7 @@ class ManualIdentityValidationReviewNotification extends BaseNotification
 
     public function toString()
     {
-        $action = $this->getAttribute('action');
-
-        if ($action === 'rejected') {
-            return __('notifications.manual_identity_validation.rejected');
-        }
-
-        return __('notifications.manual_identity_validation.approved');
+        return __($this->messageTranslationKey());
     }
 
     public function getExtras()
@@ -35,12 +29,9 @@ class ManualIdentityValidationReviewNotification extends BaseNotification
     public function toPush($user, $device)
     {
         $action = $this->getAttribute('action');
-        $messageKey = $action === 'rejected'
-            ? 'notifications.manual_identity_validation.rejected'
-            : 'notifications.manual_identity_validation.approved';
 
         return [
-            'message' => __($messageKey),
+            'message' => __($this->messageTranslationKey()),
             'url' => '/app/identity-validation',
             'type' => 'identity_validation',
             'extras' => [
@@ -48,5 +39,14 @@ class ManualIdentityValidationReviewNotification extends BaseNotification
             ],
             'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
         ];
+    }
+
+    private function messageTranslationKey(): string
+    {
+        if ($this->getAttribute('action') === 'rejected') {
+            return 'notifications.manual_identity_validation.rejected';
+        }
+
+        return 'notifications.manual_identity_validation.approved';
     }
 }

--- a/app/Services/ManualIdentityValidationReviewNotifier.php
+++ b/app/Services/ManualIdentityValidationReviewNotifier.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationReviewNotification;
+
+class ManualIdentityValidationReviewNotifier
+{
+    public function notify(User $user, string $action): void
+    {
+        if (! in_array($action, ['approved', 'rejected'], true)) {
+            return;
+        }
+
+        $notification = new ManualIdentityValidationReviewNotification;
+        $notification->setAttribute('action', $action);
+        try {
+            $notification->notify($user);
+        } catch (\Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -97,4 +97,8 @@ return [
     // UpdateTripNotification
     'update_trip.title' => ':name ha cambiado las condiciones del viaje.',
     'update_trip.message' => ':name ha cambiado las condiciones de su viaje.',
+
+    // ManualIdentityValidationReviewNotification
+    'manual_identity_validation.approved' => 'Tu verificación de cuenta fue aprobada. Click acá para ver más información.',
+    'manual_identity_validation.rejected' => 'Tu verificación de cuenta fue rechazada. Click acá para ver más información.',
 ];

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -97,4 +97,8 @@ return [
     // UpdateTripNotification
     'update_trip.title' => ':name ha cambiado las condiciones del viaje.',
     'update_trip.message' => ':name ha cambiado las condiciones de su viaje.',
+
+    // ManualIdentityValidationReviewNotification
+    'manual_identity_validation.approved' => 'Tu verificación de cuenta fue aprobada. Click acá para ver más información.',
+    'manual_identity_validation.rejected' => 'Tu verificación de cuenta fue rechazada. Click acá para ver más información.',
 ];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -97,4 +97,8 @@ return [
     // UpdateTripNotification
     'update_trip.title' => ':name has changed the trip conditions.',
     'update_trip.message' => ':name has changed the conditions of their trip.',
+
+    // ManualIdentityValidationReviewNotification
+    'manual_identity_validation.approved' => 'Your account verification was approved. Click here for more information.',
+    'manual_identity_validation.rejected' => 'Your account verification was rejected. Click here for more information.',
 ];

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -9,6 +9,8 @@ use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationReviewNotification;
+use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
 
 class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
@@ -265,5 +267,114 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
 
         $show = $this->getJson('api/admin/manual-identity-validations/'.$row->id)->assertOk();
         $this->assertSame('Internal follow-up next week.', $show->json('data.private_admin_note'));
+    }
+
+    public function test_review_approve_notifies_user_with_approved_action(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) use ($user) {
+            $mock->shouldReceive('send')
+                ->twice()
+                ->withArgs(function ($notification, $recipient, $channel) use ($user) {
+                    if (! $notification instanceof ManualIdentityValidationReviewNotification) {
+                        return false;
+                    }
+                    if ($notification->getAttribute('action') !== 'approved') {
+                        return false;
+                    }
+                    if (! $recipient instanceof User || (int) $recipient->id !== (int) $user->id) {
+                        return false;
+                    }
+
+                    return in_array($channel, [
+                        \STS\Services\Notifications\Channels\DatabaseChannel::class,
+                        \STS\Services\Notifications\Channels\PushChannel::class,
+                    ], true);
+                });
+        });
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/review', [
+            'action' => 'approve',
+            'note' => 'Documentación correcta.',
+        ])->assertOk();
+    }
+
+    public function test_review_reject_notifies_user_with_rejected_action(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) use ($user) {
+            $mock->shouldReceive('send')
+                ->twice()
+                ->withArgs(function ($notification, $recipient, $channel) use ($user) {
+                    if (! $notification instanceof ManualIdentityValidationReviewNotification) {
+                        return false;
+                    }
+                    if ($notification->getAttribute('action') !== 'rejected') {
+                        return false;
+                    }
+                    if (! $recipient instanceof User || (int) $recipient->id !== (int) $user->id) {
+                        return false;
+                    }
+
+                    return in_array($channel, [
+                        \STS\Services\Notifications\Channels\DatabaseChannel::class,
+                        \STS\Services\Notifications\Channels\PushChannel::class,
+                    ], true);
+                });
+        });
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/review', [
+            'action' => 'reject',
+            'note' => 'Fotos ilegibles.',
+        ])->assertOk();
+    }
+
+    public function test_review_pending_does_not_notify_user(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) {
+            $mock->shouldReceive('send')->never();
+        });
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/review', [
+            'action' => 'pending',
+            'note' => 'Necesitamos mejor calidad.',
+        ])->assertOk();
     }
 }

--- a/tests/Unit/Notifications/ManualIdentityValidationReviewNotificationTest.php
+++ b/tests/Unit/Notifications/ManualIdentityValidationReviewNotificationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Notifications;
+
+use STS\Notifications\ManualIdentityValidationReviewNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+use Tests\TestCase;
+
+class ManualIdentityValidationReviewNotificationTest extends TestCase
+{
+    public function test_via_contains_database_and_push_channels(): void
+    {
+        $notification = new ManualIdentityValidationReviewNotification;
+
+        $this->assertSame([
+            DatabaseChannel::class,
+            PushChannel::class,
+        ], $notification->getVia());
+    }
+
+    public function test_to_string_returns_approved_message_when_action_is_approved(): void
+    {
+        $notification = new ManualIdentityValidationReviewNotification;
+        $notification->setAttribute('action', 'approved');
+
+        $this->assertSame(
+            __('notifications.manual_identity_validation.approved'),
+            $notification->toString()
+        );
+    }
+
+    public function test_to_string_returns_rejected_message_when_action_is_rejected(): void
+    {
+        $notification = new ManualIdentityValidationReviewNotification;
+        $notification->setAttribute('action', 'rejected');
+
+        $this->assertSame(
+            __('notifications.manual_identity_validation.rejected'),
+            $notification->toString()
+        );
+    }
+
+    public function test_get_extras_returns_identity_validation_type(): void
+    {
+        $notification = new ManualIdentityValidationReviewNotification;
+        $notification->setAttribute('action', 'approved');
+
+        $this->assertSame([
+            'type' => 'identity_validation',
+            'action' => 'approved',
+        ], $notification->getExtras());
+    }
+
+    public function test_to_push_builds_identity_validation_url_and_extras(): void
+    {
+        $notification = new ManualIdentityValidationReviewNotification;
+        $notification->setAttribute('action', 'rejected');
+
+        $push = $notification->toPush(null, null);
+
+        $this->assertSame(
+            __('notifications.manual_identity_validation.rejected'),
+            $push['message']
+        );
+        $this->assertSame('/app/identity-validation', $push['url']);
+        $this->assertSame('identity_validation', $push['type']);
+        $this->assertSame('rejected', $push['extras']['action']);
+        $this->assertSame('https://carpoolear.com.ar/app/static/img/carpoolear_logo.png', $push['image']);
+    }
+}


### PR DESCRIPTION
## Summary
Manual identity verification review comments are now visible to users on the account verification page, and users receive in-app and push notifications when an admin approves or rejects their request.
## Backend
- **`ManualIdentityValidationReviewNotification`**: database + push notification on approve/reject with copy:
  - *"Tu verificación de cuenta fue aprobada/rechazada. Click acá para ver más información."*
- **`ManualIdentityValidationReviewNotifier`**: sends notification from admin review endpoint; **pending** does not notify.
- Push/deep link target: `/app/identity-validation`; in-app extras `type: `identity_validation``.
- i18n added in `arg`, `chl`, and `en` notification lang files.
- Tests: unit tests for the notification class; integration tests for approve/reject/pending behavior.
