### PR TITLE
Admin tweaks

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -83,9 +83,7 @@ class ManualIdentityValidationController extends Controller
             'back_image_url' => $item->back_image_path ? $imageUrl('back') : null,
             'selfie_image_url' => $item->selfie_image_path ? $imageUrl('selfie') : null,
             'has_images' => $item->hasImages(),
-            'support_tickets_count' => $item->user_id
-                ? SupportTicket::where('user_id', $item->user_id)->count()
-                : 0,
+            'support_tickets_count' => SupportTicket::countForUser($item->user_id),
         ];
     }
 

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\SupportTicket;
 use STS\Services\ManualIdentityValidationReviewNotifier;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -82,6 +83,9 @@ class ManualIdentityValidationController extends Controller
             'back_image_url' => $item->back_image_path ? $imageUrl('back') : null,
             'selfie_image_url' => $item->selfie_image_path ? $imageUrl('selfie') : null,
             'has_images' => $item->hasImages(),
+            'support_tickets_count' => $item->user_id
+                ? SupportTicket::where('user_id', $item->user_id)->count()
+                : 0,
         ];
     }
 

--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -138,9 +138,7 @@ class MercadoPagoRejectedValidationController extends Controller
             'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
             'reviewed_by' => $item->reviewed_by,
             'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
-            'support_tickets_count' => $item->user_id
-                ? SupportTicket::where('user_id', $item->user_id)->count()
-                : 0,
+            'support_tickets_count' => SupportTicket::countForUser($item->user_id),
         ];
     }
 }

--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
 use STS\Models\MercadoPagoRejectedValidation;
+use STS\Models\SupportTicket;
 
 class MercadoPagoRejectedValidationController extends Controller
 {
@@ -137,6 +138,9 @@ class MercadoPagoRejectedValidationController extends Controller
             'reviewed_at' => $item->reviewed_at ? $item->reviewed_at->toDateTimeString() : null,
             'reviewed_by' => $item->reviewed_by,
             'reviewed_by_name' => $item->reviewedBy ? $item->reviewedBy->name : null,
+            'support_tickets_count' => $item->user_id
+                ? SupportTicket::where('user_id', $item->user_id)->count()
+                : 0,
         ];
     }
 }

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -74,6 +74,11 @@ class SupportTicketController extends Controller
             $query->adminNeedsAttention();
         }
 
+        $userId = $request->query('user_id');
+        if (is_numeric($userId) && (int) $userId > 0) {
+            $query->where('user_id', (int) $userId);
+        }
+
         return $query;
     }
 

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -110,4 +110,13 @@ class SupportTicket extends Model
                 ->orWhereIn('status', self::ADMIN_ACTION_STATUSES);
         });
     }
+
+    public static function countForUser(?int $userId): int
+    {
+        if ($userId === null) {
+            return 0;
+        }
+
+        return (int) static::query()->where('user_id', $userId)->count();
+    }
 }

--- a/app/Services/AdminUserProfileCounts.php
+++ b/app/Services/AdminUserProfileCounts.php
@@ -3,9 +3,23 @@
 namespace STS\Services;
 
 use STS\Models\Rating;
+use STS\Models\User;
+use STS\Repository\TripRepository;
 
 class AdminUserProfileCounts
 {
+    public function __construct(private readonly TripRepository $tripRepository) {}
+
+    public function tripsCount(User $viewer, User $subject): int
+    {
+        $userId = $subject->id;
+
+        return $this->tripRepository->getTrips($viewer, $userId, true)->count()
+            + $this->tripRepository->getTrips($viewer, $userId, false)->count()
+            + $this->tripRepository->getOldTrips($viewer, $userId, true)->count()
+            + $this->tripRepository->getOldTrips($viewer, $userId, false)->count();
+    }
+
     public function ratingsCount(int $userId): int
     {
         return Rating::query()->where('user_id_to', $userId)->count()

--- a/app/Services/AdminUserProfileCounts.php
+++ b/app/Services/AdminUserProfileCounts.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\Rating;
+
+class AdminUserProfileCounts
+{
+    public function ratingsCount(int $userId): int
+    {
+        return Rating::query()->where('user_id_to', $userId)->count()
+            + Rating::query()->where('user_id_from', $userId)->count();
+    }
+}

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -5,6 +5,7 @@ namespace STS\Transformers;
 use Carbon\Carbon;
 use League\Fractal\TransformerAbstract;
 use STS\Helpers\IdentityValidationHelper;
+use STS\Models\SupportTicket;
 use STS\Models\User;
 use STS\Repository\TripRepository;
 use STS\Repository\UserRepository;
@@ -108,6 +109,7 @@ class ProfileTransformer extends TransformerAbstract
             $data['cars'] = $user->cars;
             $data['patente'] = $user->cars->first() ? $user->cars->first()->patente : null;
             $data['car_description'] = $user->cars->first() ? $user->cars->first()->description : null;
+            $data['support_tickets_count'] = SupportTicket::countForUser($user->id);
         }
 
         switch ($user->data_visibility) {

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -9,6 +9,7 @@ use STS\Models\SupportTicket;
 use STS\Models\User;
 use STS\Repository\TripRepository;
 use STS\Repository\UserRepository;
+use STS\Services\AdminUserProfileCounts;
 use STS\Services\GeoService;
 use STS\Services\Logic\TripsManager;
 use STS\Services\Logic\UsersManager;
@@ -110,6 +111,9 @@ class ProfileTransformer extends TransformerAbstract
             $data['patente'] = $user->cars->first() ? $user->cars->first()->patente : null;
             $data['car_description'] = $user->cars->first() ? $user->cars->first()->description : null;
             $data['support_tickets_count'] = SupportTicket::countForUser($user->id);
+            $profileCounts = app(AdminUserProfileCounts::class);
+            $data['admin_trips_count'] = $profileCounts->tripsCount($this->user, $user);
+            $data['admin_ratings_count'] = $profileCounts->ratingsCount($user->id);
         }
 
         switch ($user->data_visibility) {

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\SupportTicket;
 use STS\Models\User;
 use STS\Notifications\ManualIdentityValidationReviewNotification;
 use STS\Services\Notifications\NotificationServices;
@@ -376,5 +377,43 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
             'action' => 'pending',
             'note' => 'Necesitamos mejor calidad.',
         ])->assertOk();
+    }
+
+    public function test_show_includes_support_tickets_count_for_user(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $adminCreator = User::factory()->create(['is_admin' => true]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        SupportTicket::create([
+            'user_id' => $user->id,
+            'type' => 'account_verification',
+            'subject' => 'User opened ticket',
+            'status' => 'Open',
+            'priority' => 'high',
+        ]);
+        SupportTicket::create([
+            'user_id' => $user->id,
+            'type' => 'contact',
+            'subject' => 'Admin opened ticket',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'created_by' => $adminCreator->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $data = $this->getJson('api/admin/manual-identity-validations/'.$row->id)->assertOk()->json('data');
+
+        $this->assertArrayHasKey('support_tickets_count', $data);
+        $this->assertSame(2, $data['support_tickets_count']);
     }
 }

--- a/tests/Feature/Http/AdminMercadoPagoRejectedValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminMercadoPagoRejectedValidationControllerIntegrationTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\MercadoPagoRejectedValidation;
+use STS\Models\SupportTicket;
 use STS\Models\User;
 use Tests\TestCase;
 
@@ -324,5 +325,32 @@ class AdminMercadoPagoRejectedValidationControllerIntegrationTest extends TestCa
 
         $show = $this->getJson('api/admin/mercado-pago-rejected-validations/'.$row->id)->assertOk();
         $this->assertSame('Contacto por telefono, revisar en 48hs.', $show->json('data.private_admin_note'));
+    }
+
+    public function test_show_includes_support_tickets_count_for_user(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $row = MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'dni_mismatch',
+            'mp_payload' => ['sub' => 'mp-1'],
+        ]);
+
+        SupportTicket::create([
+            'user_id' => $user->id,
+            'type' => 'account_verification',
+            'subject' => 'Verification help',
+            'status' => 'Open',
+            'priority' => 'high',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $data = $this->getJson('api/admin/mercado-pago-rejected-validations/'.$row->id)->assertOk()->json('data');
+
+        $this->assertArrayHasKey('support_tickets_count', $data);
+        $this->assertSame(1, $data['support_tickets_count']);
     }
 }

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -100,6 +100,24 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
             || (int) ($row['unread_for_admin'] ?? 0) > 0));
     }
 
+    public function test_index_filters_by_user_id_when_query_param_is_set(): void
+    {
+        $admin = $this->adminUser();
+        $target = User::factory()->create();
+        $other = User::factory()->create();
+        $targetTicket = $this->makeTicket($target, ['subject' => 'target-user-ticket']);
+        $this->makeTicket($other, ['subject' => 'other-user-ticket']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets?user_id='.$target->id)->assertOk()->json('data'));
+        $ids = $rows->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains($targetTicket->id, $ids);
+        $this->assertTrue($rows->every(fn (array $row): bool => (int) ($row['user_id'] ?? 0) === $target->id));
+    }
+
     public function test_index_returns_data_ordered_newest_first(): void
     {
         $admin = $this->adminUser();

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -154,4 +154,21 @@ class SupportTicketTest extends TestCase
         $this->assertSame(1, $ticket->fresh()->attachments()->count());
         $this->assertSame('file.bin', $ticket->attachments()->first()->original_name);
     }
+
+    public function test_count_for_user_returns_zero_when_user_id_is_null(): void
+    {
+        $this->assertSame(0, SupportTicket::countForUser(null));
+    }
+
+    public function test_count_for_user_counts_all_tickets_for_user(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $this->makeTicket($user, ['subject' => 'One']);
+        $this->makeTicket($user, ['subject' => 'Two']);
+        $this->makeTicket($other, ['subject' => 'Other']);
+
+        $this->assertSame(2, SupportTicket::countForUser($user->id));
+    }
 }

--- a/tests/Unit/Services/AdminUserProfileCountsTest.php
+++ b/tests/Unit/Services/AdminUserProfileCountsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Services;
 
+use Carbon\Carbon;
+use STS\Models\Passenger;
 use STS\Models\Rating;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -30,5 +32,49 @@ class AdminUserProfileCountsTest extends TestCase
         $service = app(AdminUserProfileCounts::class);
 
         $this->assertSame(2, $service->ratingsCount($user->id));
+    }
+
+    public function test_trips_count_sums_active_and_old_driver_and_passenger_trips(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $otherDriver = User::factory()->create();
+
+        Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDay(),
+            'weekly_schedule' => 0,
+        ]);
+        Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDays(10),
+            'weekly_schedule' => 0,
+        ]);
+
+        $passengerTrip = Trip::factory()->create([
+            'user_id' => $otherDriver->id,
+            'trip_date' => Carbon::now()->addDay(),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $passengerTrip->id,
+            'user_id' => $passenger->id,
+        ]);
+
+        $oldPassengerTrip = Trip::factory()->create([
+            'user_id' => $otherDriver->id,
+            'trip_date' => Carbon::now()->subDays(10),
+            'weekly_schedule' => 0,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $oldPassengerTrip->id,
+            'user_id' => $passenger->id,
+        ]);
+
+        $service = app(AdminUserProfileCounts::class);
+
+        $this->assertSame(2, $service->tripsCount($admin, $driver));
+        $this->assertSame(2, $service->tripsCount($admin, $passenger));
     }
 }

--- a/tests/Unit/Services/AdminUserProfileCountsTest.php
+++ b/tests/Unit/Services/AdminUserProfileCountsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use STS\Models\Rating;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Services\AdminUserProfileCounts;
+use Tests\TestCase;
+
+class AdminUserProfileCountsTest extends TestCase
+{
+    public function test_ratings_count_sums_received_and_given_ratings(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $other->id]);
+
+        Rating::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id_to' => $user->id,
+            'user_id_from' => $other->id,
+        ]);
+        Rating::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id_from' => $user->id,
+            'user_id_to' => $other->id,
+        ]);
+
+        $service = app(AdminUserProfileCounts::class);
+
+        $this->assertSame(2, $service->ratingsCount($user->id));
+    }
+}

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Transformers;
 
 use STS\Models\Car;
 use STS\Models\Passenger;
+use STS\Models\Rating;
 use STS\Models\SupportTicket;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -399,5 +400,37 @@ class ProfileTransformerTest extends TestCase
         $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
 
         $this->assertArrayNotHasKey('support_tickets_count', $payload);
+    }
+
+    public function test_transform_includes_admin_profile_nav_counts_for_admin_viewing_other_user(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $subject = User::factory()->create();
+        $other = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $subject->id]);
+
+        Rating::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id_to' => $subject->id,
+            'user_id_from' => $other->id,
+        ]);
+
+        $payload = (new ProfileTransformer($admin))->transform($subject->fresh());
+
+        $this->assertArrayHasKey('admin_trips_count', $payload);
+        $this->assertArrayHasKey('admin_ratings_count', $payload);
+        $this->assertSame(1, $payload['admin_trips_count']);
+        $this->assertSame(1, $payload['admin_ratings_count']);
+    }
+
+    public function test_transform_does_not_expose_admin_profile_nav_counts_for_non_admin(): void
+    {
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $subject = User::factory()->create(['data_visibility' => '2']);
+
+        $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
+
+        $this->assertArrayNotHasKey('admin_trips_count', $payload);
+        $this->assertArrayNotHasKey('admin_ratings_count', $payload);
     }
 }

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Transformers;
 
 use STS\Models\Car;
 use STS\Models\Passenger;
+use STS\Models\SupportTicket;
 use STS\Models\Trip;
 use STS\Models\User;
 use STS\Transformers\ProfileTransformer;
@@ -361,5 +362,42 @@ class ProfileTransformerTest extends TestCase
         $this->assertArrayHasKey('cars', $payload);
         $patentes = collect($payload['cars'])->pluck('patente')->all();
         $this->assertSame(['ACT123'], $patentes);
+    }
+
+    public function test_transform_includes_support_tickets_count_for_admin_viewing_other_user(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $subject = User::factory()->create();
+
+        SupportTicket::create([
+            'user_id' => $subject->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+        ]);
+
+        $payload = (new ProfileTransformer($admin))->transform($subject->fresh());
+
+        $this->assertArrayHasKey('support_tickets_count', $payload);
+        $this->assertSame(1, $payload['support_tickets_count']);
+    }
+
+    public function test_transform_does_not_expose_support_tickets_count_for_non_admin_viewing_other_user(): void
+    {
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $subject = User::factory()->create(['data_visibility' => '2']);
+
+        SupportTicket::create([
+            'user_id' => $subject->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+        ]);
+
+        $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
+
+        $this->assertArrayNotHasKey('support_tickets_count', $payload);
     }
 }


### PR DESCRIPTION
## Summary
Improves admin identity verification workflows by surfacing support ticket history and richer user context during manual/MP reviews, and enhances the admin user profile with actionable counts and clearer navigation.
### Backend (`carpoolear_backend`)
- Add `SupportTicket::countForUser()` and expose `support_tickets_count` on:
  - `GET /api/admin/manual-identity-validations/{id}`
  - `GET /api/admin/mercado-pago-rejected-validations/{id}`
  - Admin user profile API (`ProfileTransformer`)
- Add `user_id` query filter to `GET /api/admin/support/tickets` for deep-linking from verification/user screens.
- Add `AdminUserProfileCounts` service and expose `admin_trips_count` / `admin_ratings_count` on admin user profile API (trips = active + old, driver + passenger; ratings = received + given).
