### PR TITLE
Delete cars tweaks

### DIFF
--- a/app/Repository/CarsRepository.php
+++ b/app/Repository/CarsRepository.php
@@ -36,4 +36,12 @@ class CarsRepository
     {
         return CarModel::where('user_id', $userId)->first();
     }
+
+    public function findByUserAndPatenteIncludingTrashed($userId, $patente)
+    {
+        return CarModel::withTrashed()
+            ->where('user_id', $userId)
+            ->where('patente', $patente)
+            ->first();
+    }
 }

--- a/app/Services/Logic/CarsManager.php
+++ b/app/Services/Logic/CarsManager.php
@@ -46,10 +46,10 @@ class CarsManager extends BaseManager
 
             return;
         } else {
-            $existing = CarModel::withTrashed()
-                ->where('user_id', $user->id)
-                ->where('patente', $data['patente'])
-                ->first();
+            $existing = $this->repo->findByUserAndPatenteIncludingTrashed(
+                $user->id,
+                $data['patente']
+            );
 
             if ($existing && $existing->trashed()) {
                 $existing->restore();

--- a/app/Services/Logic/CarsManager.php
+++ b/app/Services/Logic/CarsManager.php
@@ -46,6 +46,19 @@ class CarsManager extends BaseManager
 
             return;
         } else {
+            $existing = CarModel::withTrashed()
+                ->where('user_id', $user->id)
+                ->where('patente', $data['patente'])
+                ->first();
+
+            if ($existing && $existing->trashed()) {
+                $existing->restore();
+                $existing->description = $data['description'];
+                $this->repo->update($existing);
+
+                return $existing;
+            }
+
             $car = new CarModel;
             $car->description = $data['description'];
             $car->patente = $data['patente'];

--- a/tests/Unit/Repository/CarsRepositoryTest.php
+++ b/tests/Unit/Repository/CarsRepositoryTest.php
@@ -145,6 +145,22 @@ class CarsRepositoryTest extends TestCase
         $this->assertNull($this->repo()->getUserCar($user->id));
     }
 
+    public function test_find_by_user_and_patente_including_trashed_returns_soft_deleted_car(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'TR-'.substr(uniqid('', true), 0, 6),
+        ]);
+        $car->delete();
+
+        $found = $this->repo()->findByUserAndPatenteIncludingTrashed($user->id, $car->patente);
+
+        $this->assertNotNull($found);
+        $this->assertTrue($found->is($car));
+        $this->assertTrue($found->trashed());
+    }
+
     public function test_create_returns_false_when_save_fails(): void
     {
         $car = Mockery::mock(Car::class);

--- a/tests/Unit/Services/Logic/CarsManagerTest.php
+++ b/tests/Unit/Services/Logic/CarsManagerTest.php
@@ -122,6 +122,34 @@ class CarsManagerTest extends TestCase
         $this->assertSame($patente, $car->patente);
     }
 
+    public function test_create_restores_soft_deleted_car_with_same_patente_instead_of_creating_new_row(): void
+    {
+        $user = User::factory()->create();
+        $patente = 'RS'.substr(uniqid('', true), 0, 6);
+        $old = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => $patente,
+            'description' => 'Old car',
+        ]);
+        $oldId = $old->id;
+        $old->delete();
+
+        $manager = $this->manager();
+        $car = $manager->create($user, [
+            'patente' => $patente,
+            'description' => 'Restored car',
+        ]);
+
+        $this->assertInstanceOf(Car::class, $car);
+        $this->assertSame($oldId, $car->id);
+        $this->assertSame('Restored car', $car->fresh()->description);
+        $this->assertNull($car->fresh()->deleted_at);
+        $this->assertSame(
+            1,
+            Car::withTrashed()->where('user_id', $user->id)->where('patente', $patente)->count()
+        );
+    }
+
     public function test_create_persists_car_when_valid(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
Improves patente (car) management in profile edit: users can remove a saved patente with confirmation, and re-adding a previously removed patente restores the existing DB row instead of creating a duplicate.
### Backend (`carpoolear_backend`)
- **`CarsManager::create()`** — when a user adds a patente that matches a soft-deleted car they own, the existing row is restored (same `id`) and its description is updated, instead of inserting a new record
- **`CarsRepository::findByUserAndPatenteIncludingTrashed()`** — extracted lookup used by the restore logic
- Uniqueness validation unchanged: only active (non-deleted) patentes must be unique per user
- Tests added/updated in `CarsManagerTest` and `CarsRepositoryTest`
