### PR TITLE
Fix admin tickets filter

### DIFF
--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -105,10 +105,11 @@ class SupportTicket extends Model
      */
     public function scopeAdminNeedsAttention($query)
     {
-        return $query->where(function ($builder) {
-            $builder->where('unread_for_admin', '>', 0)
-                ->orWhereIn('status', self::ADMIN_ACTION_STATUSES);
-        });
+        return $query->whereNotIn('status', ['Resuelto', 'Cerrado'])
+            ->where(function ($builder) {
+                $builder->where('unread_for_admin', '>', 0)
+                    ->orWhereIn('status', self::ADMIN_ACTION_STATUSES);
+            });
     }
 
     public static function countForUser(?int $userId): int

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -38,6 +38,12 @@ class SupportTicket extends Model
         self::STATUS_NEEDS_REVIEW,
     ];
 
+    /** Statuses where admin attention is no longer required. */
+    private const ADMIN_TERMINAL_STATUSES = [
+        'Resuelto',
+        'Cerrado',
+    ];
+
     /** @var list<string> */
     public const STATUSES = [
         'Open',
@@ -105,7 +111,7 @@ class SupportTicket extends Model
      */
     public function scopeAdminNeedsAttention($query)
     {
-        return $query->whereNotIn('status', ['Resuelto', 'Cerrado'])
+        return $query->whereNotIn('status', self::ADMIN_TERMINAL_STATUSES)
             ->where(function ($builder) {
                 $builder->where('unread_for_admin', '>', 0)
                     ->orWhereIn('status', self::ADMIN_ACTION_STATUSES);

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -100,6 +100,38 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
             || (int) ($row['unread_for_admin'] ?? 0) > 0));
     }
 
+    public function test_index_needs_reply_filter_excludes_closed_and_resolved_tickets(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $openNeedsReply = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'unread_for_admin' => 1,
+            'subject' => 'open-needs-reply',
+        ]);
+        $resolvedUnread = $this->makeTicket($owner, [
+            'status' => 'Resuelto',
+            'unread_for_admin' => 1,
+            'subject' => 'resolved-unread',
+        ]);
+        $closedUnread = $this->makeTicket($owner, [
+            'status' => 'Cerrado',
+            'unread_for_admin' => 1,
+            'subject' => 'closed-unread',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets?needs_reply=1')->assertOk()->json('data'));
+        $ids = $rows->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains($openNeedsReply->id, $ids);
+        $this->assertNotContains($resolvedUnread->id, $ids);
+        $this->assertNotContains($closedUnread->id, $ids);
+        $this->assertTrue($rows->every(fn (array $row): bool => ! in_array($row['status'], ['Resuelto', 'Cerrado'], true)));
+    }
+
     public function test_index_filters_by_user_id_when_query_param_is_set(): void
     {
         $admin = $this->adminUser();

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -65,6 +65,26 @@ class SupportTicketTest extends TestCase
         $this->assertNotContains($resolved->id, $ids);
     }
 
+    public function test_scope_admin_needs_attention_excludes_closed_and_resolved_even_with_unread(): void
+    {
+        $user = User::factory()->create();
+        $resolvedUnread = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'Resuelto',
+            'unread_for_admin' => 1,
+        ]);
+        $closedUnread = $this->makeTicket($user, [
+            'type' => 'feedback',
+            'status' => 'Cerrado',
+            'unread_for_admin' => 1,
+        ]);
+
+        $ids = SupportTicket::query()->adminNeedsAttention()->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertNotContains($resolvedUnread->id, $ids);
+        $this->assertNotContains($closedUnread->id, $ids);
+    }
+
     public function test_fillable_contains_expected_mass_assignable_attributes(): void
     {
         $this->assertSame([


### PR DESCRIPTION
## Summary
Fixes the admin support tickets filter **"Requiere respuesta del equipo"** so it no longer returns closed (`Cerrado`) or resolved (`Resuelto`) tickets.
### Backend (`carpoolear_backend`)
- Updated `SupportTicket::scopeAdminNeedsAttention()` to exclude terminal statuses before applying attention criteria.
- Previously, tickets with `unread_for_admin > 0` were included regardless of status, so closed/resolved tickets could still appear.
- Added `ADMIN_TERMINAL_STATUSES` (`Resuelto`, `Cerrado`) to make the exclusion explicit.
- Added unit and integration test coverage for this behavior.
