### PR TITLE
Admin user detail all properties

### DIFF
--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -97,9 +97,7 @@ class ProfileTransformer extends TransformerAbstract
             $data['email'] = $user->email;
             $data['mobile_phone'] = $user->mobile_phone;
             $data['nro_doc'] = $user->nro_doc;
-            $data['created_at'] = $user->created_at instanceof Carbon
-                ? $user->created_at->toDateTimeString()
-                : null;
+            $data['created_at'] = $this->nullableDateTimeString($user->created_at);
             // bank data
             $data['account_number'] = $user->account_number;
             $data['account_type'] = $user->account_type;
@@ -115,12 +113,10 @@ class ProfileTransformer extends TransformerAbstract
             $data['admin_trips_count'] = $profileCounts->tripsCount($this->user, $user);
             $data['admin_ratings_count'] = $profileCounts->ratingsCount($user->id);
             $data['phone_verified'] = intval($user->phone_verified);
-            $data['phone_verified_at'] = $user->phone_verified_at instanceof Carbon
-                ? $user->phone_verified_at->toDateTimeString()
-                : null;
-            $data['identity_validation_rejected_at'] = $user->identity_validation_rejected_at instanceof Carbon
-                ? $user->identity_validation_rejected_at->toDateTimeString()
-                : null;
+            $data['phone_verified_at'] = $this->nullableDateTimeString($user->phone_verified_at);
+            $data['identity_validation_rejected_at'] = $this->nullableDateTimeString(
+                $user->identity_validation_rejected_at
+            );
             $data['identity_validation_reject_reason'] = $user->identity_validation_reject_reason;
             $data['validate_by_date'] = $user->validate_by_date
                 ? $user->validate_by_date->format('Y-m-d')
@@ -154,5 +150,10 @@ class ProfileTransformer extends TransformerAbstract
         }
 
         return $data;
+    }
+
+    private function nullableDateTimeString(mixed $value): ?string
+    {
+        return $value instanceof Carbon ? $value->toDateTimeString() : null;
     }
 }

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -114,6 +114,17 @@ class ProfileTransformer extends TransformerAbstract
             $profileCounts = app(AdminUserProfileCounts::class);
             $data['admin_trips_count'] = $profileCounts->tripsCount($this->user, $user);
             $data['admin_ratings_count'] = $profileCounts->ratingsCount($user->id);
+            $data['phone_verified'] = intval($user->phone_verified);
+            $data['phone_verified_at'] = $user->phone_verified_at instanceof Carbon
+                ? $user->phone_verified_at->toDateTimeString()
+                : null;
+            $data['identity_validation_rejected_at'] = $user->identity_validation_rejected_at instanceof Carbon
+                ? $user->identity_validation_rejected_at->toDateTimeString()
+                : null;
+            $data['identity_validation_reject_reason'] = $user->identity_validation_reject_reason;
+            $data['validate_by_date'] = $user->validate_by_date
+                ? $user->validate_by_date->format('Y-m-d')
+                : null;
         }
 
         switch ($user->data_visibility) {

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -433,4 +433,43 @@ class ProfileTransformerTest extends TestCase
         $this->assertArrayNotHasKey('admin_trips_count', $payload);
         $this->assertArrayNotHasKey('admin_ratings_count', $payload);
     }
+
+    public function test_transform_exposes_extended_admin_detail_fields_for_admin_viewing_other_user(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $subject = User::factory()->create();
+        $subject->forceFill([
+            'phone_verified' => true,
+            'phone_verified_at' => '2025-05-10 08:00:00',
+            'identity_validation_rejected_at' => '2025-05-11 09:00:00',
+            'identity_validation_reject_reason' => 'Document unreadable',
+            'validate_by_date' => '2025-06-30',
+        ])->saveQuietly();
+
+        $payload = (new ProfileTransformer($admin))->transform($subject->fresh());
+
+        $this->assertSame(1, $payload['phone_verified']);
+        $this->assertSame('2025-05-10 08:00:00', $payload['phone_verified_at']);
+        $this->assertSame('2025-05-11 09:00:00', $payload['identity_validation_rejected_at']);
+        $this->assertSame('Document unreadable', $payload['identity_validation_reject_reason']);
+        $this->assertSame('2025-06-30', $payload['validate_by_date']);
+    }
+
+    public function test_transform_does_not_expose_extended_admin_detail_fields_for_non_admin(): void
+    {
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $subject = User::factory()->create(['data_visibility' => '2']);
+        $subject->forceFill([
+            'phone_verified' => true,
+            'validate_by_date' => '2025-06-30',
+        ])->saveQuietly();
+
+        $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
+
+        $this->assertArrayNotHasKey('phone_verified', $payload);
+        $this->assertArrayNotHasKey('phone_verified_at', $payload);
+        $this->assertArrayNotHasKey('identity_validation_rejected_at', $payload);
+        $this->assertArrayNotHasKey('identity_validation_reject_reason', $payload);
+        $this->assertArrayNotHasKey('validate_by_date', $payload);
+    }
 }


### PR DESCRIPTION
### Backend (`carpoolear_backend`)
- `ProfileTransformer` now exposes additional admin-only fields when an admin views another user: `phone_verified`, `phone_verified_at`, `identity_validation_rejected_at`, `identity_validation_reject_reason`, and `validate_by_date`.
- Non-admin viewers do not receive these fields.
- TDD: PHPUnit tests added; 3 commits (red/green/refactor).
