### PR TITLE
Price depends on seats

### DIFF
--- a/app/Helpers/TripPriceHelper.php
+++ b/app/Helpers/TripPriceHelper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace STS\Helpers;
+
+class TripPriceHelper
+{
+    public static function occupantsForPriceCalculation($rearMaxTwoPassengers): int
+    {
+        return (int) $rearMaxTwoPassengers > 0 ? 4 : 5;
+    }
+
+    public static function seatPriceCentsFromTripPriceCents(
+        int $tripPriceCents,
+        $rearMaxTwoPassengers
+    ): int {
+        return (int) round(
+            $tripPriceCents / self::occupantsForPriceCalculation($rearMaxTwoPassengers)
+        );
+    }
+}

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DB;
 use Illuminate\Support\Facades\Http;
 use STS\Events\Trip\Create as CreateEvent;
+use STS\Helpers\TripPriceHelper;
 use STS\Models\NodeGeo;
 use STS\Models\Passenger;
 use STS\Models\PaymentAttempt;
@@ -98,9 +99,12 @@ class TripRepository
 
         // Calculate maximum allowed price if seat_price_cents is provided
         if (isset($data['seat_price_cents']) && config('carpoolear.module_max_price_enabled')) {
-            $total_seats = $data['total_seats'];
+            $rearMaxTwoPassengers = $data['rear_max_two_passengers'] ?? false;
             if ($tripInfo['status'] && isset($tripInfo['data']['maximum_trip_price_cents'])) {
-                $maximum_seat_price_cents = round($tripInfo['data']['maximum_trip_price_cents'] / ($total_seats + 1));
+                $maximum_seat_price_cents = TripPriceHelper::seatPriceCentsFromTripPriceCents(
+                    (int) $tripInfo['data']['maximum_trip_price_cents'],
+                    $rearMaxTwoPassengers
+                );
                 if ($data['seat_price_cents'] > $maximum_seat_price_cents) {
                     \Log::info('TripRepository::create seat_price_cents is greater than maximum_seat_price_cents, setting to maximum_seat_price_cents', [$maximum_seat_price_cents]);
                     $data['seat_price_cents'] = $maximum_seat_price_cents;
@@ -209,9 +213,12 @@ class TripRepository
 
             // Calculate maximum allowed price if seat_price_cents is provided
             if (isset($data['seat_price_cents']) && config('carpoolear.module_max_price_enabled')) {
-                $total_seats = $data['total_seats'] ?? $trip->total_seats;
+                $rearMaxTwoPassengers = $data['rear_max_two_passengers'] ?? $trip->rear_max_two_passengers;
                 if ($tripInfo['status'] && isset($tripInfo['data']['maximum_trip_price_cents'])) {
-                    $maximum_seat_price_cents = round($tripInfo['data']['maximum_trip_price_cents'] / ($total_seats + 1));
+                    $maximum_seat_price_cents = TripPriceHelper::seatPriceCentsFromTripPriceCents(
+                        (int) $tripInfo['data']['maximum_trip_price_cents'],
+                        $rearMaxTwoPassengers
+                    );
                     if ($data['seat_price_cents'] > $maximum_seat_price_cents) {
                         \Log::info('TripRepository::update seat_price_cents is greater than maximum_seat_price_cents, setting to maximum_seat_price_cents', [$maximum_seat_price_cents]);
                         $data['seat_price_cents'] = $maximum_seat_price_cents;

--- a/tests/Unit/Helpers/TripPriceHelperTest.php
+++ b/tests/Unit/Helpers/TripPriceHelperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\TripPriceHelper;
+use PHPUnit\Framework\TestCase;
+
+class TripPriceHelperTest extends TestCase
+{
+    public function test_occupants_for_price_calculation_uses_four_when_rear_max_two_is_enabled(): void
+    {
+        $this->assertSame(4, TripPriceHelper::occupantsForPriceCalculation(true));
+        $this->assertSame(4, TripPriceHelper::occupantsForPriceCalculation(1));
+        $this->assertSame(4, TripPriceHelper::occupantsForPriceCalculation('1'));
+    }
+
+    public function test_occupants_for_price_calculation_uses_five_when_rear_max_two_is_disabled(): void
+    {
+        $this->assertSame(5, TripPriceHelper::occupantsForPriceCalculation(false));
+        $this->assertSame(5, TripPriceHelper::occupantsForPriceCalculation(0));
+        $this->assertSame(5, TripPriceHelper::occupantsForPriceCalculation(null));
+    }
+
+    public function test_seat_price_cents_from_trip_price_cents_uses_comfort_based_divisor(): void
+    {
+        $tripPriceCents = 6345351;
+
+        $this->assertSame(
+            (int) round($tripPriceCents / 5),
+            TripPriceHelper::seatPriceCentsFromTripPriceCents($tripPriceCents, false)
+        );
+        $this->assertSame(
+            (int) round($tripPriceCents / 4),
+            TripPriceHelper::seatPriceCentsFromTripPriceCents($tripPriceCents, true)
+        );
+    }
+}

--- a/tests/Unit/Helpers/TripPriceHelperTest.php
+++ b/tests/Unit/Helpers/TripPriceHelperTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Helpers;
 
-use App\Helpers\TripPriceHelper;
 use PHPUnit\Framework\TestCase;
+use STS\Helpers\TripPriceHelper;
 
 class TripPriceHelperTest extends TestCase
 {

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -3316,9 +3316,10 @@ class TripRepositoryTest extends TestCase
             ['lat' => -34.59, 'lng' => -58.39, 'json_address' => ['id' => 802, 'ciudad' => 'B']],
         ]);
 
-        // 1003 / (3 + 1) = 250.75 -> round = 251; must use payload total_seats (3), not trip->total_seats (1).
+        // 1003 / 4 rear-comfort occupants = 250.75 -> round = 251.
         $updated1 = $repo->update($trip, [
             'total_seats' => 3,
+            'rear_max_two_passengers' => true,
             'seat_price_cents' => 900,
             'points' => [
                 ['lat' => -34.61, 'lng' => -58.41, 'json_address' => ['id' => 803, 'ciudad' => 'C']],
@@ -3328,9 +3329,10 @@ class TripRepositoryTest extends TestCase
         $updated1->refresh();
         $this->assertSame(251, (int) $updated1->seat_price_cents);
 
-        // 1001 / (3 + 1) = 250.25 -> round = 250 (different from ceil=251).
+        // 1001 / 4 = 250.25 -> round = 250 (different from ceil=251).
         $updated2 = $repo->update($trip->fresh(), [
             'total_seats' => 3,
+            'rear_max_two_passengers' => true,
             'seat_price_cents' => 900,
             'points' => [
                 ['lat' => -34.62, 'lng' => -58.42, 'json_address' => ['id' => 805, 'ciudad' => 'E']],
@@ -3343,6 +3345,7 @@ class TripRepositoryTest extends TestCase
         // Below cap should remain unchanged (protects `>` branch against <= mutation).
         $updated3 = $repo->update($trip->fresh(), [
             'total_seats' => 3,
+            'rear_max_two_passengers' => true,
             'seat_price_cents' => 240,
             'points' => [
                 ['lat' => -34.63, 'lng' => -58.43, 'json_address' => ['id' => 807, 'ciudad' => 'G']],

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -2652,14 +2652,52 @@ class TripRepositoryTest extends TestCase
         ]);
 
         $trip->refresh();
-        $this->assertSame(500, (int) $trip->seat_price_cents);
+        $this->assertSame(200, (int) $trip->seat_price_cents);
         $this->assertSame(700, (int) $trip->recommended_trip_price_cents);
     }
 
-    public function test_create_caps_seat_price_using_round_not_floor_when_maximum_divisor_three(): void
+    public function test_create_caps_seat_price_using_rear_max_two_passengers_divisor(): void
     {
-        // Mutation intent: `round(maximum / (total_seats + 1))` must stay `round` (335/3 → 112, not floor 111).
-        // Kills: `Line 115: RoundToFloor`, `Line 115: RoundToCeil` (create cap), `Line 101: IncrementInteger` on divisor.
+        Config::set('carpoolear.module_max_price_enabled', true);
+        Config::set('carpoolear.module_trip_creation_payment_enabled', false);
+
+        $repo = $this->makeTripRepoPartialForCreate([
+            'status' => true,
+            'data' => [
+                'maximum_trip_price_cents' => 335,
+                'recommended_trip_price_cents' => 300,
+            ],
+        ], false);
+        $user = User::factory()->create();
+
+        $trip = $repo->create([
+            'user_id' => $user->id,
+            'is_passenger' => 0,
+            'from_town' => 'A',
+            'to_town' => 'B',
+            'trip_date' => Carbon::now()->addHour(),
+            'total_seats' => 2,
+            'rear_max_two_passengers' => true,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'estimated_time' => '01:00',
+            'distance' => 10,
+            'co2' => 1,
+            'description' => 'test',
+            'mail_send' => false,
+            'seat_price_cents' => 400,
+            'points' => [
+                ['lat' => -34.6, 'lng' => -58.4, 'json_address' => ['id' => 601, 'ciudad' => 'Origen']],
+            ],
+        ]);
+
+        $trip->refresh();
+        $this->assertSame(84, (int) $trip->seat_price_cents);
+    }
+
+    public function test_create_caps_seat_price_using_round_not_floor_when_maximum_divisor_five(): void
+    {
+        // Mutation intent: `round(maximum / comfort occupants)` must stay `round` (335/5 → 67, not floor 66).
+        // Kills: `Line 115: RoundToFloor`, `Line 115: RoundToCeil` (create cap).
         Config::set('carpoolear.module_max_price_enabled', true);
         Config::set('carpoolear.module_trip_creation_payment_enabled', false);
 
@@ -2692,7 +2730,7 @@ class TripRepositoryTest extends TestCase
         ]);
 
         $trip->refresh();
-        $this->assertSame(112, (int) $trip->seat_price_cents);
+        $this->assertSame(67, (int) $trip->seat_price_cents);
     }
 
     public function test_create_does_not_lower_seat_price_when_it_equals_computed_maximum(): void
@@ -2723,14 +2761,14 @@ class TripRepositoryTest extends TestCase
             'co2' => 1,
             'description' => 'test',
             'mail_send' => false,
-            'seat_price_cents' => 500,
+            'seat_price_cents' => 200,
             'points' => [
                 ['lat' => -34.6, 'lng' => -58.4, 'json_address' => ['id' => 602, 'ciudad' => 'Origen']],
             ],
         ]);
 
         $trip->refresh();
-        $this->assertSame(500, (int) $trip->seat_price_cents);
+        $this->assertSame(200, (int) $trip->seat_price_cents);
     }
 
     public function test_create_keeps_seat_price_when_cap_not_required_or_module_disabled(): void
@@ -3340,7 +3378,8 @@ class TripRepositoryTest extends TestCase
 
         $trip = Trip::factory()->create([
             'total_seats' => 1,
-            'seat_price_cents' => 500,
+            'rear_max_two_passengers' => false,
+            'seat_price_cents' => 200,
             'state' => Trip::STATE_READY,
         ]);
         $repo->addPoints($trip, [
@@ -3350,7 +3389,7 @@ class TripRepositoryTest extends TestCase
 
         $updated = $repo->update($trip, [
             'total_seats' => 1,
-            'seat_price_cents' => 500,
+            'seat_price_cents' => 200,
             'points' => [
                 ['lat' => -34.61, 'lng' => -58.41, 'json_address' => ['id' => 813, 'ciudad' => 'C']],
                 ['lat' => -34.58, 'lng' => -58.38, 'json_address' => ['id' => 814, 'ciudad' => 'D']],
@@ -3358,7 +3397,7 @@ class TripRepositoryTest extends TestCase
         ]);
 
         $updated->refresh();
-        $this->assertSame(500, (int) $updated->seat_price_cents);
+        $this->assertSame(200, (int) $updated->seat_price_cents);
     }
 
     public function test_update_replaces_points_persists_recommended_price_and_maps_payment_coords(): void


### PR DESCRIPTION
## Summary
Recommended and max per-seat prices now depend on the **“Atrás viajan sólo 2 personas”** comfort preference instead of the selected seat count:
- Checked → divide trip total by **4** occupants
- Unchecked → divide trip total by **5** occupants
The reference contribution on trip detail uses the same rule, and the consumption copy was updated to **“auto promedio de consumo 8L/100km”**.

### Backend (`carpoolear_backend`)
- Added `TripPriceHelper` with the same 4/5 occupant logic
- **TripRepository** create/update max price cap now uses `rear_max_two_passengers` instead of `total_seats + 1`
- Updated repository tests to match the new behavior