### PR TITLE
Deactivate device on fail

### DIFF
--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -243,7 +243,11 @@ class FirebaseService
         }
 
         try {
-            $body = json_decode($e->getResponse()->getBody()->getContents(), true);
+            $stream = $e->getResponse()->getBody();
+            if ($stream->isSeekable()) {
+                $stream->rewind();
+            }
+            $body = json_decode($stream->getContents(), true);
         } catch (\Exception) {
             return false;
         }

--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -269,16 +269,19 @@ class FirebaseService
             return true;
         }
 
-        if (stripos($message, 'not a valid fcm registration token') !== false) {
-            return true;
-        }
+        return self::fcmErrorMessageIndicatesUnusableToken($message);
+    }
 
-        if (stripos($message, 'InvalidRegistration') !== false) {
-            return true;
-        }
-
-        if (stripos($message, 'SenderId mismatch') !== false) {
-            return true;
+    private static function fcmErrorMessageIndicatesUnusableToken(string $message): bool
+    {
+        foreach ([
+            'not a valid fcm registration token',
+            'InvalidRegistration',
+            'SenderId mismatch',
+        ] as $needle) {
+            if (stripos($message, $needle) !== false) {
+                return true;
+            }
         }
 
         return false;

--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -234,7 +234,8 @@ class FirebaseService
     }
 
     /**
-     * Whether an FCM HTTP v1 error indicates the device registration token is no longer valid.
+     * Whether an FCM HTTP v1 error indicates the device registration token cannot be used
+     * with the configured Firebase project (stale, invalid, or wrong sender).
      */
     public static function isStaleRegistrationTokenError(\Throwable $e): bool
     {
@@ -273,6 +274,10 @@ class FirebaseService
         }
 
         if (stripos($message, 'InvalidRegistration') !== false) {
+            return true;
+        }
+
+        if (stripos($message, 'SenderId mismatch') !== false) {
             return true;
         }
 

--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -234,6 +234,48 @@ class FirebaseService
     }
 
     /**
+     * Whether an FCM HTTP v1 error indicates the device registration token is no longer valid.
+     */
+    public static function isStaleRegistrationTokenError(\Throwable $e): bool
+    {
+        if (! $e instanceof ClientException || ! $e->getResponse()) {
+            return false;
+        }
+
+        try {
+            $body = json_decode($e->getResponse()->getBody()->getContents(), true);
+        } catch (\Exception) {
+            return false;
+        }
+
+        if (! is_array($body) || ! isset($body['error']) || ! is_array($body['error'])) {
+            return false;
+        }
+
+        $error = $body['error'];
+        $status = strtoupper((string) ($error['status'] ?? ''));
+        $message = (string) ($error['message'] ?? '');
+
+        if ($status === 'UNREGISTERED') {
+            return true;
+        }
+
+        if ($status === 'NOT_FOUND' && strcasecmp($message, 'NotRegistered') === 0) {
+            return true;
+        }
+
+        if (stripos($message, 'not a valid fcm registration token') !== false) {
+            return true;
+        }
+
+        if (stripos($message, 'InvalidRegistration') !== false) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Unregisters a device from FCM by sending a delete request
      * This stops the device from receiving any future notifications
      */

--- a/app/Services/Notifications/Channels/PushChannel.php
+++ b/app/Services/Notifications/Channels/PushChannel.php
@@ -136,13 +136,15 @@ class PushChannel
 
             return $response;
         } catch (\Exception $e) {
-            \Log::error('PushChannel: sendAndroid error', [
-                'device_id' => $device->id ?? null,
-                'device_token' => substr($device->device_id ?? '', 0, 20).'...',
-                'error' => $e->getMessage(),
-                'error_trace' => $e->getTraceAsString(),
-                'input_data' => $data ?? null,
-            ]);
+            if (! FirebaseService::isStaleRegistrationTokenError($e)) {
+                \Log::error('PushChannel: sendAndroid error', [
+                    'device_id' => $device->id ?? null,
+                    'device_token' => substr($device->device_id ?? '', 0, 20).'...',
+                    'error' => $e->getMessage(),
+                    'error_trace' => $e->getTraceAsString(),
+                    'input_data' => $data ?? null,
+                ]);
+            }
             throw $e;
         }
     }

--- a/app/Services/Notifications/Channels/PushChannel.php
+++ b/app/Services/Notifications/Channels/PushChannel.php
@@ -46,14 +46,18 @@ class PushChannel
                         $this->sendBrowser($device, $data);
                     }
                 } catch (\Exception $e) {
-                    \Log::error('PushChannel: Error sending push notification', [
-                        'user_id' => $user->id ?? null,
-                        'device_id' => $device->id ?? null,
-                        'device_token' => substr($device->device_id ?? '', 0, 20).'...',
-                        'device_type' => $device->device_type,
-                        'error' => $e->getMessage(),
-                        'error_trace' => $e->getTraceAsString(),
-                    ]);
+                    if (FirebaseService::isStaleRegistrationTokenError($e)) {
+                        $this->deactivateDeviceAfterStaleToken($device, $user, $e);
+                    } else {
+                        \Log::error('PushChannel: Error sending push notification', [
+                            'user_id' => $user->id ?? null,
+                            'device_id' => $device->id ?? null,
+                            'device_token' => substr($device->device_id ?? '', 0, 20).'...',
+                            'device_type' => $device->device_type,
+                            'error' => $e->getMessage(),
+                            'error_trace' => $e->getTraceAsString(),
+                        ]);
+                    }
                 }
             }
         }
@@ -268,5 +272,20 @@ class PushChannel
         $factory = $this->firebaseFactory;
 
         return $factory();
+    }
+
+    protected function deactivateDeviceAfterStaleToken(Device $device, $user, \Throwable $e): void
+    {
+        if ($device->exists) {
+            $device->update(['notifications' => false]);
+        }
+
+        \Log::warning('PushChannel: Deactivated device after stale push token', [
+            'user_id' => $user->id ?? null,
+            'device_id' => $device->id ?? null,
+            'device_token' => substr($device->device_id ?? '', 0, 20).'...',
+            'device_type' => $device->device_type,
+            'error' => $e->getMessage(),
+        ]);
     }
 }

--- a/tests/Unit/Services/FirebaseServiceTest.php
+++ b/tests/Unit/Services/FirebaseServiceTest.php
@@ -561,6 +561,75 @@ class FirebaseServiceTest extends TestCase
         }
     }
 
+    public function test_is_stale_registration_token_error_detects_fcm_not_registered_response(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'NotRegistered',
+                'status' => 'NOT_FOUND',
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $exception = new ClientException('NotRegistered', $request, $response);
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
+    public function test_is_stale_registration_token_error_detects_unregistered_status(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'Requested entity was not found.',
+                'status' => 'UNREGISTERED',
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $exception = new ClientException('unregistered', $request, $response);
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
+    public function test_is_stale_registration_token_error_detects_invalid_registration_message(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 400,
+                'message' => 'The registration token is not a valid FCM registration token',
+                'status' => 'INVALID_ARGUMENT',
+            ],
+        ];
+        $response = new Response(400, [], json_encode($payload));
+        $exception = new ClientException('invalid token', $request, $response);
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
+    public function test_is_stale_registration_token_error_returns_false_for_other_fcm_errors(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 400,
+                'message' => 'Invalid JSON',
+                'status' => 'INVALID_ARGUMENT',
+            ],
+        ];
+        $response = new Response(400, [], json_encode($payload));
+        $exception = new ClientException('bad request', $request, $response);
+
+        $this->assertFalse(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
+    public function test_is_stale_registration_token_error_returns_false_for_non_client_exceptions(): void
+    {
+        $this->assertFalse(FirebaseService::isStaleRegistrationTokenError(new \RuntimeException('network down')));
+    }
+
     public function test_fetch_messaging_access_token_returns_google_client_payload(): void
     {
         $mock = Mockery::mock(GoogleClient::class);

--- a/tests/Unit/Services/FirebaseServiceTest.php
+++ b/tests/Unit/Services/FirebaseServiceTest.php
@@ -630,6 +630,23 @@ class FirebaseServiceTest extends TestCase
         $this->assertFalse(FirebaseService::isStaleRegistrationTokenError(new \RuntimeException('network down')));
     }
 
+    public function test_is_stale_registration_token_error_can_be_checked_multiple_times_on_same_exception(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'NotRegistered',
+                'status' => 'NOT_FOUND',
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $exception = new ClientException('NotRegistered', $request, $response);
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
     public function test_fetch_messaging_access_token_returns_google_client_payload(): void
     {
         $mock = Mockery::mock(GoogleClient::class);

--- a/tests/Unit/Services/FirebaseServiceTest.php
+++ b/tests/Unit/Services/FirebaseServiceTest.php
@@ -609,6 +609,22 @@ class FirebaseServiceTest extends TestCase
         $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
     }
 
+    public function test_is_stale_registration_token_error_detects_sender_id_mismatch(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/carpoolear-production/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 403,
+                'message' => 'SenderId mismatch',
+                'status' => 'PERMISSION_DENIED',
+            ],
+        ];
+        $response = new Response(403, [], json_encode($payload));
+        $exception = new ClientException('SenderId mismatch', $request, $response);
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
     public function test_is_stale_registration_token_error_returns_false_for_other_fcm_errors(): void
     {
         $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
@@ -621,6 +637,22 @@ class FirebaseServiceTest extends TestCase
         ];
         $response = new Response(400, [], json_encode($payload));
         $exception = new ClientException('bad request', $request, $response);
+
+        $this->assertFalse(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
+    public function test_is_stale_registration_token_error_returns_false_for_other_permission_denied_errors(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 403,
+                'message' => 'Cloud Messaging API has not been used in project 123 before or it is disabled.',
+                'status' => 'PERMISSION_DENIED',
+            ],
+        ];
+        $response = new Response(403, [], json_encode($payload));
+        $exception = new ClientException('permission denied', $request, $response);
 
         $this->assertFalse(FirebaseService::isStaleRegistrationTokenError($exception));
     }

--- a/tests/Unit/Services/FirebaseServiceTest.php
+++ b/tests/Unit/Services/FirebaseServiceTest.php
@@ -679,6 +679,14 @@ class FirebaseServiceTest extends TestCase
         $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
     }
 
+    public function test_is_stale_registration_token_error_can_be_checked_multiple_times_for_sender_id_mismatch(): void
+    {
+        $exception = $this->fcmClientException(403, 'SenderId mismatch', 'PERMISSION_DENIED');
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
     public function test_fetch_messaging_access_token_returns_google_client_payload(): void
     {
         $mock = Mockery::mock(GoogleClient::class);
@@ -698,5 +706,20 @@ class FirebaseServiceTest extends TestCase
             ['access_token' => 'from-assertion', 'expires_in' => 3600],
             $m->invoke($service)
         );
+    }
+
+    private function fcmClientException(int $code, string $message, string $status): ClientException
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+                'status' => $status,
+            ],
+        ];
+        $response = new Response($code, [], json_encode($payload));
+
+        return new ClientException($message, $request, $response);
     }
 }

--- a/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
+++ b/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
@@ -153,6 +153,12 @@ class PushChannelTest extends TestCase
             ->andReturnUsing(function () use (&$errors): void {
                 $errors++;
             });
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($this->fcmInternalErrorException());
 
         $user = User::factory()->create();
         Device::query()->create([
@@ -170,7 +176,7 @@ class PushChannelTest extends TestCase
         $notification->setAttribute('message', 'Hello');
         $notification->setAttribute('title', 'T');
 
-        (new PushChannel)->send($notification, $user);
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
 
         $this->assertGreaterThan(0, $errors);
     }
@@ -185,6 +191,12 @@ class PushChannelTest extends TestCase
             ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
                 $logged[] = ['message' => $message, 'context' => $context];
             });
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($this->fcmInternalErrorException());
 
         $user = User::factory()->create();
         $device = Device::query()->create([
@@ -202,7 +214,7 @@ class PushChannelTest extends TestCase
         $notification->setAttribute('message', 'Hello');
         $notification->setAttribute('title', 'T');
 
-        (new PushChannel)->send($notification, $user);
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
 
         $outer = $this->firstLogMatching($logged, 'PushChannel: Error sending push notification');
         $this->assertNotNull($outer, 'Expected outer PushChannel catch to log once.');
@@ -259,6 +271,12 @@ class PushChannelTest extends TestCase
             ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
                 $logged[] = ['message' => $message, 'context' => $context];
             });
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($this->fcmInternalErrorException());
 
         $user = User::factory()->create();
         $device = Device::query()->create([
@@ -276,7 +294,7 @@ class PushChannelTest extends TestCase
         $notification->setAttribute('message', 'Hello browser');
         $notification->setAttribute('title', 'TB');
 
-        (new PushChannel)->send($notification, $user);
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
 
         $outer = $this->firstLogMatching($logged, 'PushChannel: Error sending push notification');
         $this->assertNotNull($outer);
@@ -341,6 +359,12 @@ class PushChannelTest extends TestCase
             ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
                 $logged[] = ['message' => $message, 'context' => $context];
             });
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($this->fcmInternalErrorException());
 
         $user = User::factory()->create();
         Device::query()->create([
@@ -373,7 +397,7 @@ class PushChannelTest extends TestCase
             }
         };
 
-        (new PushChannel)->send($notification, $user);
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
 
         $inner = $this->firstLogMatching($logged, 'PushChannel: sendAndroid error');
         $this->assertNotNull($inner);
@@ -446,6 +470,58 @@ class PushChannelTest extends TestCase
         $this->assertSame('android', $deactivateLog['context']['device_type']);
 
         $this->assertNull($this->firstLogMatching($logged, 'PushChannel: Error sending push notification'));
+        $this->assertNull($this->firstLogMatching($logged, 'PushChannel: sendAndroid error'));
+    }
+
+    public function test_send_deactivates_browser_device_when_fcm_returns_not_registered(): void
+    {
+        Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
+
+        $logged = [];
+        Log::shouldReceive('error')->zeroOrMoreTimes();
+        Log::shouldReceive('warning')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context];
+            });
+
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/carpoolear-production/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'NotRegistered',
+                'status' => 'NOT_FOUND',
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $fcmException = new ClientException('NotRegistered', $request, $response);
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($fcmException);
+
+        $user = User::factory()->create();
+        $device = Device::query()->create([
+            'user_id' => $user->id,
+            'device_id' => 'stale-browser-token',
+            'device_type' => 'browser',
+            'session_id' => 's-stale-browser',
+            'notifications' => true,
+            'last_activity' => now()->toDateTimeString(),
+        ]);
+
+        $user->load('devices');
+
+        $notification = new AnnouncementNotification;
+        $notification->setAttribute('message', 'Hello browser');
+        $notification->setAttribute('title', 'TB');
+
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
+
+        $device->refresh();
+        $this->assertFalse($device->notifications);
+        $this->assertNotNull($this->firstLogMatching($logged, 'PushChannel: Deactivated device after stale push token'));
     }
 
     public function test_send_still_logs_error_when_android_send_fails_for_non_stale_token(): void
@@ -512,5 +588,20 @@ class PushChannelTest extends TestCase
         }
 
         return null;
+    }
+
+    private function fcmInternalErrorException(): ClientException
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 500,
+                'message' => 'Internal error',
+                'status' => 'INTERNAL',
+            ],
+        ];
+        $response = new Response(500, [], json_encode($payload));
+
+        return new ClientException('Internal error', $request, $response);
     }
 }

--- a/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
+++ b/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
@@ -473,6 +473,63 @@ class PushChannelTest extends TestCase
         $this->assertNull($this->firstLogMatching($logged, 'PushChannel: sendAndroid error'));
     }
 
+    public function test_send_deactivates_android_device_when_fcm_returns_sender_id_mismatch(): void
+    {
+        Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
+
+        $logged = [];
+        Log::shouldReceive('error')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context, 'level' => 'error'];
+            });
+        Log::shouldReceive('warning')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context, 'level' => 'warning'];
+            });
+
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/carpoolear-production/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 403,
+                'message' => 'SenderId mismatch',
+                'status' => 'PERMISSION_DENIED',
+            ],
+        ];
+        $response = new Response(403, [], json_encode($payload));
+        $fcmException = new ClientException('SenderId mismatch', $request, $response);
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($fcmException);
+
+        $user = User::factory()->create();
+        $device = Device::query()->create([
+            'user_id' => $user->id,
+            'device_id' => 'wrong-sender-android-token',
+            'device_type' => 'Android',
+            'session_id' => 's-sender-mismatch',
+            'notifications' => true,
+            'last_activity' => now()->toDateTimeString(),
+        ]);
+
+        $user->load('devices');
+
+        $notification = new AnnouncementNotification;
+        $notification->setAttribute('message', 'Hello');
+        $notification->setAttribute('title', 'T');
+
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
+
+        $device->refresh();
+        $this->assertFalse($device->notifications);
+        $this->assertNotNull($this->firstLogMatching($logged, 'PushChannel: Deactivated device after stale push token'));
+        $this->assertNull($this->firstLogMatching($logged, 'PushChannel: Error sending push notification'));
+        $this->assertNull($this->firstLogMatching($logged, 'PushChannel: sendAndroid error'));
+    }
+
     public function test_send_deactivates_browser_device_when_fcm_returns_not_registered(): void
     {
         Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);

--- a/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
+++ b/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit\Services\Notifications\Channels;
 
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Mockery;
@@ -381,6 +384,119 @@ class PushChannelTest extends TestCase
         $this->assertSame('custom_type', $data['type']);
         $this->assertSame('https://cdn.example/push.png', $data['image']);
         $this->assertSame(['from_get_extras' => '1'], $data['extras']);
+    }
+
+    public function test_send_deactivates_android_device_when_fcm_returns_not_registered(): void
+    {
+        Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
+
+        $logged = [];
+        Log::shouldReceive('error')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context, 'level' => 'error'];
+            });
+        Log::shouldReceive('warning')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context, 'level' => 'warning'];
+            });
+
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/carpoolear-production/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'NotRegistered',
+                'status' => 'NOT_FOUND',
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $fcmException = new ClientException('NotRegistered', $request, $response);
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($fcmException);
+
+        $user = User::factory()->create();
+        $device = Device::query()->create([
+            'user_id' => $user->id,
+            'device_id' => 'stale-android-token',
+            'device_type' => 'android',
+            'session_id' => 's-stale-android',
+            'notifications' => true,
+            'last_activity' => now()->toDateTimeString(),
+        ]);
+
+        $user->load('devices');
+
+        $notification = new AnnouncementNotification;
+        $notification->setAttribute('message', 'Hello');
+        $notification->setAttribute('title', 'T');
+
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
+
+        $device->refresh();
+        $this->assertFalse($device->notifications);
+
+        $deactivateLog = $this->firstLogMatching($logged, 'PushChannel: Deactivated device after stale push token');
+        $this->assertNotNull($deactivateLog);
+        $this->assertSame($user->id, $deactivateLog['context']['user_id']);
+        $this->assertSame($device->id, $deactivateLog['context']['device_id']);
+        $this->assertSame('android', $deactivateLog['context']['device_type']);
+
+        $this->assertNull($this->firstLogMatching($logged, 'PushChannel: Error sending push notification'));
+    }
+
+    public function test_send_still_logs_error_when_android_send_fails_for_non_stale_token(): void
+    {
+        Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
+
+        $logged = [];
+        Log::shouldReceive('error')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context];
+            });
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 500,
+                'message' => 'Internal error',
+                'status' => 'INTERNAL',
+            ],
+        ];
+        $response = new Response(500, [], json_encode($payload));
+        $fcmException = new ClientException('Internal error', $request, $response);
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($fcmException);
+
+        $user = User::factory()->create();
+        $device = Device::query()->create([
+            'user_id' => $user->id,
+            'device_id' => 'valid-android-token',
+            'device_type' => 'android',
+            'session_id' => 's-valid-android',
+            'notifications' => true,
+            'last_activity' => now()->toDateTimeString(),
+        ]);
+
+        $user->load('devices');
+
+        $notification = new AnnouncementNotification;
+        $notification->setAttribute('message', 'Hello');
+        $notification->setAttribute('title', 'T');
+
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
+
+        $device->refresh();
+        $this->assertTrue($device->notifications);
+        $this->assertNotNull($this->firstLogMatching($logged, 'PushChannel: Error sending push notification'));
     }
 
     /**


### PR DESCRIPTION
## Summary
Automatically deactivate push devices when FCM reports the registration token cannot be used with the configured Firebase project, preventing repeated ERROR logs on every notification attempt.
### Backend
- Add `FirebaseService::isStaleRegistrationTokenError()` to detect unusable FCM tokens:
  - `NotRegistered` / `NOT_FOUND`
  - `UNREGISTERED`
  - Invalid registration token / `InvalidRegistration`
  - **`SenderId mismatch`** (403 `PERMISSION_DENIED`) — token belongs to a different Firebase project
- Other `PERMISSION_DENIED` errors (e.g. disabled API) still log as ERROR and leave the device active
- Update `PushChannel` to deactivate affected devices (`notifications = false`) and log a **warning** instead of an **error**
- Skip duplicate `sendAndroid` error logs for known unusable tokens
- Rewind FCM response bodies so detection works when checked more than once on the same exception
- Unit tests cover stale-token detection, SenderId mismatch, and device deactivation (Android + browser)
