### PR TITLE
Remove device on unregistered

### DIFF
--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -261,19 +261,18 @@ class FirebaseService
         $status = strtoupper((string) ($error['status'] ?? ''));
         $message = (string) ($error['message'] ?? '');
 
+        return self::fcmTopLevelStatusIndicatesUnregistered($status, $message)
+            || self::fcmErrorDetailsIndicateUnregistered($error['details'] ?? null)
+            || self::fcmErrorMessageIndicatesUnusableToken($message);
+    }
+
+    private static function fcmTopLevelStatusIndicatesUnregistered(string $status, string $message): bool
+    {
         if ($status === 'UNREGISTERED') {
             return true;
         }
 
-        if ($status === 'NOT_FOUND' && strcasecmp($message, 'NotRegistered') === 0) {
-            return true;
-        }
-
-        if (self::fcmErrorDetailsIndicateUnregistered($error['details'] ?? null)) {
-            return true;
-        }
-
-        return self::fcmErrorMessageIndicatesUnusableToken($message);
+        return $status === 'NOT_FOUND' && strcasecmp($message, 'NotRegistered') === 0;
     }
 
     /**

--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -269,7 +269,33 @@ class FirebaseService
             return true;
         }
 
+        if (self::fcmErrorDetailsIndicateUnregistered($error['details'] ?? null)) {
+            return true;
+        }
+
         return self::fcmErrorMessageIndicatesUnusableToken($message);
+    }
+
+    /**
+     * @param  mixed  $details
+     */
+    private static function fcmErrorDetailsIndicateUnregistered($details): bool
+    {
+        if (! is_array($details)) {
+            return false;
+        }
+
+        foreach ($details as $detail) {
+            if (! is_array($detail)) {
+                continue;
+            }
+
+            if (strtoupper((string) ($detail['errorCode'] ?? '')) === 'UNREGISTERED') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static function fcmErrorMessageIndicatesUnusableToken(string $message): bool

--- a/tests/Unit/Services/FirebaseServiceTest.php
+++ b/tests/Unit/Services/FirebaseServiceTest.php
@@ -725,6 +725,24 @@ class FirebaseServiceTest extends TestCase
         $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
     }
 
+    public function test_is_stale_registration_token_error_can_be_checked_multiple_times_for_unregistered_details(): void
+    {
+        $exception = $this->fcmClientException(
+            404,
+            'Requested entity was not found.',
+            'NOT_FOUND',
+            [
+                [
+                    '@type' => 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                    'errorCode' => 'UNREGISTERED',
+                ],
+            ],
+        );
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
     public function test_fetch_messaging_access_token_returns_google_client_payload(): void
     {
         $mock = Mockery::mock(GoogleClient::class);
@@ -746,16 +764,18 @@ class FirebaseServiceTest extends TestCase
         );
     }
 
-    private function fcmClientException(int $code, string $message, string $status): ClientException
+    private function fcmClientException(int $code, string $message, string $status, array $details = []): ClientException
     {
         $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
-        $payload = [
-            'error' => [
-                'code' => $code,
-                'message' => $message,
-                'status' => $status,
-            ],
+        $error = [
+            'code' => $code,
+            'message' => $message,
+            'status' => $status,
         ];
+        if ($details !== []) {
+            $error['details'] = $details;
+        }
+        $payload = ['error' => $error];
         $response = new Response($code, [], json_encode($payload));
 
         return new ClientException($message, $request, $response);

--- a/tests/Unit/Services/FirebaseServiceTest.php
+++ b/tests/Unit/Services/FirebaseServiceTest.php
@@ -593,6 +593,44 @@ class FirebaseServiceTest extends TestCase
         $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
     }
 
+    public function test_is_stale_registration_token_error_detects_unregistered_in_fcm_error_details(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/carpoolear-production/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'Requested entity was not found.',
+                'status' => 'NOT_FOUND',
+                'details' => [
+                    [
+                        '@type' => 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode' => 'UNREGISTERED',
+                    ],
+                ],
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $exception = new ClientException('Requested entity was not found.', $request, $response);
+
+        $this->assertTrue(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
+    public function test_is_stale_registration_token_error_returns_false_for_not_found_without_unregistered_details(): void
+    {
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'Requested entity was not found.',
+                'status' => 'NOT_FOUND',
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $exception = new ClientException('Requested entity was not found.', $request, $response);
+
+        $this->assertFalse(FirebaseService::isStaleRegistrationTokenError($exception));
+    }
+
     public function test_is_stale_registration_token_error_detects_invalid_registration_message(): void
     {
         $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/myproj/messages:send');

--- a/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
+++ b/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
@@ -473,6 +473,63 @@ class PushChannelTest extends TestCase
         $this->assertNull($this->firstLogMatching($logged, 'PushChannel: sendAndroid error'));
     }
 
+    public function test_send_deactivates_android_device_when_fcm_returns_not_found_with_unregistered_details(): void
+    {
+        Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
+
+        $logged = [];
+        Log::shouldReceive('error')->zeroOrMoreTimes();
+        Log::shouldReceive('warning')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context];
+            });
+
+        $request = new Request('POST', 'https://fcm.googleapis.com/v1/projects/carpoolear-production/messages:send');
+        $payload = [
+            'error' => [
+                'code' => 404,
+                'message' => 'Requested entity was not found.',
+                'status' => 'NOT_FOUND',
+                'details' => [
+                    [
+                        '@type' => 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode' => 'UNREGISTERED',
+                    ],
+                ],
+            ],
+        ];
+        $response = new Response(404, [], json_encode($payload));
+        $fcmException = new ClientException('Requested entity was not found.', $request, $response);
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($fcmException);
+
+        $user = User::factory()->create();
+        $device = Device::query()->create([
+            'user_id' => $user->id,
+            'device_id' => 'stale-android-token-v2',
+            'device_type' => 'android',
+            'session_id' => 's-stale-android-v2',
+            'notifications' => true,
+            'last_activity' => now()->toDateTimeString(),
+        ]);
+
+        $user->load('devices');
+
+        $notification = new AnnouncementNotification;
+        $notification->setAttribute('message', 'Hello');
+        $notification->setAttribute('title', 'T');
+
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
+
+        $device->refresh();
+        $this->assertFalse($device->notifications);
+        $this->assertNotNull($this->firstLogMatching($logged, 'PushChannel: Deactivated device after stale push token'));
+    }
+
     public function test_send_deactivates_android_device_when_fcm_returns_sender_id_mismatch(): void
     {
         Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);


### PR DESCRIPTION
## Summary
Detect FCM HTTP v1 stale tokens when `UNREGISTERED` appears in `error.details` (production format), not only in top-level `status`/`message`.
### Backend
- Extend `FirebaseService::isStaleRegistrationTokenError()` to inspect `error.details[].errorCode === 'UNREGISTERED'`
- Handles production responses like:
  - `status`: `NOT_FOUND`
  - `message`: `Requested entity was not found.`
  - `details`: `[{ "errorCode": "UNREGISTERED" }]`
- Generic `NOT_FOUND` without `UNREGISTERED` in details still logs as ERROR (device stays active)
- Existing `PushChannel` deactivation path applies automatically — sets `notifications = false` and logs a warning
- Refactor: split top-level status vs details vs message matching into focused helpers
