### PR TITLE
Remove Empresas

### DIFF
--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -85,11 +85,6 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="http://carpoolearmas.com.ar" target="_blank">
-                                    Empresas
-                                </a>
-                            </li>
-                            <li>
                                 <a href="contacto">
                                     Contacto
                                 </a>

--- a/tests/Feature/Http/StaticPageNavigationTest.php
+++ b/tests/Feature/Http/StaticPageNavigationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class StaticPageNavigationTest extends TestCase
+{
+    #[DataProvider('staticPageProvider')]
+    public function test_static_page_navigation_does_not_include_empresas_link(string $path): void
+    {
+        Config::set('carpoolear.home_redirection', '');
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertDontSee('>Empresas<', false);
+        $response->assertDontSee('carpoolearmas.com.ar', false);
+    }
+
+    public static function staticPageProvider(): array
+    {
+        return [
+            'home' => ['/home'],
+            'contacto' => ['/contacto'],
+            'acerca de proyecto' => ['/acerca-de-proyecto'],
+        ];
+    }
+}

--- a/tests/Feature/Http/StaticPageNavigationTest.php
+++ b/tests/Feature/Http/StaticPageNavigationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Http;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
@@ -16,6 +17,12 @@ class StaticPageNavigationTest extends TestCase
         $response = $this->get($path);
 
         $response->assertOk();
+        $this->assertNavigationExcludesEmpresasLink($response);
+        $response->assertSee('href="contacto"', false);
+    }
+
+    private function assertNavigationExcludesEmpresasLink(TestResponse $response): void
+    {
         $response->assertDontSee('>Empresas<', false);
         $response->assertDontSee('carpoolearmas.com.ar', false);
     }


### PR DESCRIPTION
## Summary
Remove the external "Empresas" link from static page navigation in the backend.
### Backend
- Removed the "Empresas" nav item (`carpoolearmas.com.ar`) from `resources/views/layouts/navbar.blade.php`
- Added `StaticPageNavigationTest` to assert the Empresas link is absent on static pages (`/home`, `/contacto`, `/acerca-de-proyecto`) while core navigation (e.g. Contacto) remains present
- Implemented via TDD: failing test → minimal fix → test refactor
