### PR TITLE
Chat show user ratings

### DIFF
--- a/app/Transformers/ConversationsTransformer.php
+++ b/app/Transformers/ConversationsTransformer.php
@@ -85,6 +85,8 @@ class ConversationsTransformer extends TransformerAbstract
                 'name' => $u->name,
                 'last_connection' => $u->last_connection ? $u->last_connection->toDateTimeString() : null,
                 'identity_validated_at' => $u->identity_validated_at ? $u->identity_validated_at->toDateTimeString() : null,
+                'positive_ratings' => $u->positive_ratings,
+                'negative_ratings' => $u->negative_ratings,
             ];
         }
 

--- a/tests/Unit/Transformers/ConversationsTransformerTest.php
+++ b/tests/Unit/Transformers/ConversationsTransformerTest.php
@@ -164,7 +164,14 @@ class ConversationsTransformerTest extends TestCase
 
         $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
 
-        $expectedKeys = ['id', 'name', 'last_connection', 'identity_validated_at'];
+        $expectedKeys = [
+            'id',
+            'name',
+            'last_connection',
+            'identity_validated_at',
+            'positive_ratings',
+            'negative_ratings',
+        ];
         foreach ($payload['users'] as $row) {
             $this->assertSame($expectedKeys, array_keys($row));
         }

--- a/tests/Unit/Transformers/ConversationsTransformerTest.php
+++ b/tests/Unit/Transformers/ConversationsTransformerTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use STS\Models\Conversation;
 use STS\Models\Message;
+use STS\Models\Rating;
 use STS\Models\Trip;
 use STS\Models\User;
 use STS\Transformers\ConversationsTransformer;
@@ -202,6 +203,54 @@ class ConversationsTransformerTest extends TestCase
         $this->assertSame('Trip room title', $payload['title']);
         $this->assertSame('', $payload['image']);
         $this->assertNull($payload['other_user_identity_validated_at']);
+    }
+
+    public function test_transform_users_include_positive_and_negative_ratings(): void
+    {
+        $viewer = User::factory()->create();
+        $other = User::factory()->create(['name' => 'Rated User']);
+        $raterOne = User::factory()->create();
+        $raterTwo = User::factory()->create();
+        $raterThree = User::factory()->create();
+        $tripOne = Trip::factory()->create(['user_id' => $other->id]);
+        $tripTwo = Trip::factory()->create(['user_id' => $other->id]);
+        $tripThree = Trip::factory()->create(['user_id' => $other->id]);
+
+        Rating::factory()->create([
+            'trip_id' => $tripOne->id,
+            'user_id_to' => $other->id,
+            'user_id_from' => $raterOne->id,
+            'rating' => Rating::STATE_POSITIVO,
+            'available' => 1,
+        ]);
+        Rating::factory()->create([
+            'trip_id' => $tripTwo->id,
+            'user_id_to' => $other->id,
+            'user_id_from' => $raterTwo->id,
+            'rating' => Rating::STATE_POSITIVO,
+            'available' => 1,
+        ]);
+        Rating::factory()->create([
+            'trip_id' => $tripThree->id,
+            'user_id_to' => $other->id,
+            'user_id_from' => $raterThree->id,
+            'rating' => Rating::STATE_NEGATIVO,
+            'available' => 1,
+        ]);
+
+        $conversation = Conversation::query()->create([
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+            'title' => 'Chat',
+        ]);
+        $conversation->users()->attach($viewer->id, ['read' => true]);
+        $conversation->users()->attach($other->id, ['read' => true]);
+
+        $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
+
+        $otherRow = collect($payload['users'])->firstWhere('id', $other->id);
+        $this->assertNotNull($otherRow);
+        $this->assertSame(2, $otherRow['positive_ratings']);
+        $this->assertSame(1, $otherRow['negative_ratings']);
     }
 
     public function test_transform_users_list_includes_identity_and_last_connection_fields(): void


### PR DESCRIPTION
## Summary
Show the other participant's positive and negative ratings in the chat header using thumbs-up/thumbs-down icons and counts.
- **Desktop:** ratings appear to the right of the user name in the conversation header.
- **Mobile:** ratings appear below the last-connection line in the action bar; header height is increased slightly (52px → 64px) when ratings are shown.
## Backend
**Cause:** The conversations API returned user rows with `id`, `name`, `last_connection`, and `identity_validated_at`, but not `positive_ratings` / `negative_ratings`, so the chat UI had no data to display.
**Fix:** `ConversationsTransformer` now includes `positive_ratings` and `negative_ratings` on each user in the `users` array, using the existing `User` model accessors.
