### PR TITLE
Profile: show trip amount and created_at

### DIFF
--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -82,6 +82,8 @@ class ProfileTransformer extends TransformerAbstract
             'identity_validated' => $user->identity_validated ? true : false,
             'identity_validated_at' => $user->identity_validated_at ? $user->identity_validated_at->toDateTimeString() : null,
             'identity_validation_type' => $user->identity_validation_type,
+            'created_at' => $this->nullableDateTimeString($user->created_at),
+            'trips_count' => app(UsersManager::class)->tripsCount($user),
         ];
 
         if ($this->user && $user->id == $this->user->id) {
@@ -97,7 +99,6 @@ class ProfileTransformer extends TransformerAbstract
             $data['email'] = $user->email;
             $data['mobile_phone'] = $user->mobile_phone;
             $data['nro_doc'] = $user->nro_doc;
-            $data['created_at'] = $this->nullableDateTimeString($user->created_at);
             // bank data
             $data['account_number'] = $user->account_number;
             $data['account_type'] = $user->account_type;

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -22,6 +22,8 @@ class ProfileTransformer extends TransformerAbstract
 
     protected $tripLogic;
 
+    protected $usersManager;
+
     public function __construct($user)
     {
         $this->user = $user;
@@ -29,7 +31,8 @@ class ProfileTransformer extends TransformerAbstract
         $mercadoPagoService = app(MercadoPagoService::class);
         $mapboxDirectionsRouteService = app(MapboxDirectionsRouteService::class);
         $tripRepository = new TripRepository($geoService, $mercadoPagoService, $mapboxDirectionsRouteService);
-        $this->tripLogic = new TripsManager($tripRepository, new UsersManager(new UserRepository, $tripRepository));
+        $this->usersManager = new UsersManager(new UserRepository, $tripRepository);
+        $this->tripLogic = new TripsManager($tripRepository, $this->usersManager);
     }
 
     /**
@@ -83,7 +86,7 @@ class ProfileTransformer extends TransformerAbstract
             'identity_validated_at' => $user->identity_validated_at ? $user->identity_validated_at->toDateTimeString() : null,
             'identity_validation_type' => $user->identity_validation_type,
             'created_at' => $this->nullableDateTimeString($user->created_at),
-            'trips_count' => app(UsersManager::class)->tripsCount($user),
+            'trips_count' => $this->usersManager->tripsCount($user),
         ];
 
         if ($this->user && $user->id == $this->user->id) {

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -55,6 +55,8 @@ class ProfileTransformerTest extends TestCase
             'identity_validated',
             'identity_validated_at',
             'identity_validation_type',
+            'created_at',
+            'trips_count',
         ];
     }
 
@@ -237,14 +239,24 @@ class ProfileTransformerTest extends TestCase
         $this->assertSame('2024-03-15 12:34:56', $payload['created_at']);
     }
 
-    public function test_transform_does_not_expose_created_at_for_non_admin_viewing_other_user(): void
+    public function test_transform_exposes_created_at_and_trips_count_for_any_viewer(): void
     {
         $viewer = User::factory()->create(['is_admin' => false]);
-        $subject = User::factory()->create(['data_visibility' => '2']);
+        $subject = User::factory()->create([
+            'data_visibility' => '2',
+            'created_at' => '2024-03-15 12:34:56',
+        ]);
+        Trip::factory()->create([
+            'user_id' => $subject->id,
+            'trip_date' => now()->subDay(),
+        ]);
 
         $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
 
-        $this->assertArrayNotHasKey('created_at', $payload);
+        $this->assertArrayHasKey('created_at', $payload);
+        $this->assertSame('2024-03-15 12:34:56', $payload['created_at']);
+        $this->assertArrayHasKey('trips_count', $payload);
+        $this->assertSame(1, $payload['trips_count']);
     }
 
     public function test_transform_admin_branch_uses_loose_id_equality_for_string_subject_id(): void


### PR DESCRIPTION
## Summary
Show member join date and participated trip count on user profiles, below the positive/negative rating counters.
## Backend (`carpoolear_backend`)
### Cause
The profile API did not expose `created_at` or a public trip participation count. `created_at` was only available to admins/self, so the frontend could not render "Miembro desde" for other users.
### Fix
- `ProfileTransformer` now includes `created_at` and `trips_count` in the public profile payload for all viewers.
- `trips_count` uses existing `UsersManager::tripsCount()` logic (finished trips as driver + accepted passenger).
- Refactored to use the transformer's own `UsersManager` instance (not the container) to avoid breaking mocked API tests.
### Tests
- `ProfileTransformerTest::test_transform_exposes_created_at_and_trips_count_for_any_viewer`
