### PR TITLE
Solicitudes de asiento

### DIFF
--- a/app/Http/Controllers/Api/v1/PassengerController.php
+++ b/app/Http/Controllers/Api/v1/PassengerController.php
@@ -7,6 +7,7 @@ use STS\Helpers\IdentityValidationHelper;
 use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
 use STS\Services\Logic\PassengersManager;
+use STS\Transformers\PassengerSeatRequestTransformer;
 use STS\Transformers\PassengerTransformer;
 
 class PassengerController extends Controller
@@ -59,6 +60,16 @@ class PassengerController extends Controller
         $toPay = $this->passengerLogic->getPendingPaymentRequests(null, $this->user, $data);
 
         return $this->collection($toPay, new PassengerTransformer($this->user));
+    }
+
+    public function seatRequests(Request $request)
+    {
+        $this->user = auth()->user();
+        $data = $request->all();
+
+        $seatRequests = $this->passengerLogic->getSeatRequests($this->user, $data);
+
+        return $this->collection($seatRequests, new PassengerSeatRequestTransformer($this->user));
     }
 
     public function newRequest($tripId, Request $request)

--- a/app/Repository/PassengersRepository.php
+++ b/app/Repository/PassengersRepository.php
@@ -12,7 +12,7 @@ class PassengersRepository
     {
         $passengers = Passenger::where('trip_id', $tripId);
 
-        $passengers->whereIn('request_state', [Passenger::STATE_ACCEPTED]); //TODO: ver si hace falta obtener pasajeros con otro request_state
+        $passengers->whereIn('request_state', [Passenger::STATE_ACCEPTED]); // TODO: ver si hace falta obtener pasajeros con otro request_state
 
         $pageNumber = isset($data['page']) ? $data['page'] : null;
         $pageSize = isset($data['page_size']) ? $data['page_size'] : null;
@@ -45,6 +45,33 @@ class PassengersRepository
         return $passengers->get(); // make_pagination($passengers, $pageNumber, $pageSize);
     }
 
+    public function getSeatRequests($user, $data)
+    {
+        $passengers = Passenger::query();
+        $passengers->join('trips', 'trips.id', '=', 'trip_passengers.trip_id');
+        $passengers->whereNull('trips.deleted_at');
+        $passengers->where('trip_passengers.user_id', $user->id);
+        $passengers->where(function ($q) {
+            $q->where('trips.trip_date', '>=', Carbon::Now())
+                ->orWhere('trips.weekly_schedule', '>', 0);
+        });
+        $passengers->whereIn('request_state', [
+            Passenger::STATE_PENDING,
+            Passenger::STATE_REJECTED,
+            Passenger::STATE_ACCEPTED,
+        ]);
+        $passengers->with([
+            'trip.user',
+            'trip.points',
+            'trip.passengerAccepted',
+            'trip.passengerAccepted.user',
+            'trip.car',
+        ]);
+        $passengers->select('trip_passengers.*');
+        $passengers->orderBy('trips.trip_date');
+
+        return $passengers->get();
+    }
 
     public function getPendingPaymentRequests($tripId, $user, $data)
     {
@@ -103,6 +130,7 @@ class PassengersRepository
                 $passenger->{$key} = $value;
             }
             $passenger->save();
+
             return $passenger;
         } else {
             return null;
@@ -176,8 +204,8 @@ class PassengersRepository
         return $rejectedRequest;
     }
 
-
-    public function tripsWithTransactions ($user) {
+    public function tripsWithTransactions($user)
+    {
         /* $query = Trip::where(function ($q) use ($user) {
             $q->where('user_id', $user->id);
             $q->orWhereHas('passenger', function ($q) use ($user) {
@@ -199,13 +227,14 @@ class PassengersRepository
 
         $query->with([
             'user',
-            'passenger.trip.user'
+            'passenger.trip.user',
         ]);
+
         // $r = $query->toSql();
         // var_dump($r);die;
         return $query->get();
     }
-    
+
     public function userHasActiveRequest($tripId, $userId)
     {
         $query = Passenger::where('trip_id', $tripId);
@@ -215,7 +244,7 @@ class PassengersRepository
         $query->whereIn('request_state', [
             Passenger::STATE_WAITING_PAYMENT,
             Passenger::STATE_ACCEPTED,
-            Passenger::STATE_PENDING
+            Passenger::STATE_PENDING,
         ]);
 
         return $query->get()->count() > 0;

--- a/app/Services/Logic/PassengersManager.php
+++ b/app/Services/Logic/PassengersManager.php
@@ -70,6 +70,11 @@ class PassengersManager extends BaseManager
         return $this->passengerRepository->getPendingPaymentRequests($tripId, $user, $data);
     }
 
+    public function getSeatRequests($user, $data)
+    {
+        return $this->passengerRepository->getSeatRequests($user, $data);
+    }
+
     private function validateInput($input)
     {
         return Validator::make($input, [

--- a/app/Transformers/PassengerSeatRequestTransformer.php
+++ b/app/Transformers/PassengerSeatRequestTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace STS\Transformers;
+
+use League\Fractal\TransformerAbstract;
+use STS\Models\Passenger;
+
+class PassengerSeatRequestTransformer extends TransformerAbstract
+{
+    protected $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * @return array
+     */
+    public function transform(Passenger $passenger)
+    {
+        $tripTransformer = new TripTransformer($this->user);
+
+        return [
+            'id' => $passenger->id,
+            'trip_id' => $passenger->trip_id,
+            'request_state' => $passenger->request_state,
+            'created_at' => $passenger->created_at->toDateTimeString(),
+            'trip' => $tripTransformer->transform($passenger->trip),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,6 +68,7 @@ Route::middleware(['api'])->group(function () {
         Route::get('/my-trips', [TripController::class, 'getTrips']);
         Route::get('/my-old-trips', [TripController::class, 'getOldTrips']);
         Route::get('/requests', [PassengerController::class, 'allRequests']);
+        Route::get('/seat-requests', [PassengerController::class, 'seatRequests']);
         Route::get('/payment-pending', [PassengerController::class, 'paymentPendingRequest']);
         Route::get('/sellado-viaje', [TripController::class, 'selladoViaje']);
 

--- a/tests/Feature/Http/PassengerControllerIntegrationTest.php
+++ b/tests/Feature/Http/PassengerControllerIntegrationTest.php
@@ -42,6 +42,7 @@ class PassengerControllerIntegrationTest extends TestCase
             ['GET', '/api/trips/requests'],
             ['GET', '/api/users/requests'],
             ['GET', '/api/users/payment-pending'],
+            ['GET', '/api/users/seat-requests'],
             ['GET', '/api/trips/transactions'],
             ['POST', "/api/trips/{$trip->id}/requests"],
             ['POST', "/api/trips/{$trip->id}/requests/{$otherId}/cancel"],
@@ -396,5 +397,49 @@ class PassengerControllerIntegrationTest extends TestCase
             ->getJson('/api/users/payment-pending')
             ->assertOk()
             ->assertJsonStructure(['data']);
+    }
+
+    public function test_seat_requests_endpoint_returns_pending_rejected_and_accepted_trips(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+
+        $pendingTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(2),
+        ]);
+        $rejectedTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(3),
+        ]);
+        $acceptedTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(4),
+        ]);
+
+        Passenger::factory()->create([
+            'trip_id' => $pendingTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_PENDING,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $rejectedTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_REJECTED,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $acceptedTrip->id,
+            'user_id' => $passenger->id,
+        ]);
+
+        $this->actingAs($passenger, 'api')
+            ->getJson('/api/users/seat-requests')
+            ->assertOk()
+            ->assertJsonCount(3, 'data')
+            ->assertJsonPath('data.0.trip_id', $pendingTrip->id)
+            ->assertJsonPath('data.0.request_state', Passenger::STATE_PENDING)
+            ->assertJsonPath('data.0.trip.id', $pendingTrip->id)
+            ->assertJsonPath('data.1.request_state', Passenger::STATE_REJECTED)
+            ->assertJsonPath('data.2.request_state', Passenger::STATE_ACCEPTED);
     }
 }

--- a/tests/Unit/Repository/PassengersRepositoryTest.php
+++ b/tests/Unit/Repository/PassengersRepositoryTest.php
@@ -887,4 +887,76 @@ class PassengersRepositoryTest extends TestCase
 
         $this->assertFalse($this->repo()->userHasActiveRequest($trip->id, $alice->id));
     }
+
+    public function test_get_seat_requests_returns_pending_rejected_and_accepted_on_active_future_trips(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+
+        $pendingTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(2),
+        ]);
+        $rejectedTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(3),
+        ]);
+        $acceptedTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(4),
+        ]);
+        $pastTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDay(),
+        ]);
+        $waitingPaymentTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(5),
+        ]);
+        $canceledTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDays(6),
+        ]);
+
+        Passenger::factory()->create([
+            'trip_id' => $pendingTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_PENDING,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $rejectedTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_REJECTED,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $acceptedTrip->id,
+            'user_id' => $passenger->id,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $pastTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_PENDING,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $waitingPaymentTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_WAITING_PAYMENT,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $canceledTrip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_CANCELED,
+        ]);
+
+        $rows = $this->repo()->getSeatRequests($passenger, []);
+
+        $this->assertCount(3, $rows);
+        $tripIds = $rows->pluck('trip_id')->all();
+        $this->assertContains($pendingTrip->id, $tripIds);
+        $this->assertContains($rejectedTrip->id, $tripIds);
+        $this->assertContains($acceptedTrip->id, $tripIds);
+        $this->assertSame($pendingTrip->id, $rows->first()->trip_id);
+        $this->assertSame($acceptedTrip->id, $rows->last()->trip_id);
+        $this->assertTrue($rows->first()->relationLoaded('trip'));
+    }
 }


### PR DESCRIPTION
## Summary
Adds a **Solicitudes de asiento** section to My Trips, replacing **Próximos viajes como pasajero**. Passengers now see all their upcoming seat requests (pending, rejected, and accepted) in one place, each trip card showing a colored status footer.
## Cause
Accepted passenger trips lived under "Próximos viajes como pasajero", while pending/rejected requests had no dedicated section. Passengers could not easily track the status of their seat requests from My Trips.
## Fix
### Backend
- New `GET /api/users/seat-requests` endpoint returns the logged-in user's seat requests on active upcoming trips.
- Includes `request_state` pending (0), accepted (1), and rejected (2); excludes canceled, waiting-for-payment, and past trips.
- Response includes full trip data via `PassengerSeatRequestTransformer`.
