### PR TITLE
Home: ongoing trip

### DIFF
--- a/app/Helpers/OngoingTripHelper.php
+++ b/app/Helpers/OngoingTripHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace STS\Helpers;
+
+use Carbon\Carbon;
+
+class OngoingTripHelper
+{
+    public const LEAD_MINUTES = 60;
+
+    public const GRACE_MINUTES = 30;
+
+    public static function estimatedTimeToMinutes(?string $estimatedTime): int
+    {
+        if ($estimatedTime === null || $estimatedTime === '') {
+            return 0;
+        }
+
+        $parts = explode(':', $estimatedTime);
+        $hours = (int) ($parts[0] ?? 0);
+        $minutes = (int) ($parts[1] ?? 0);
+
+        return ($hours * 60) + $minutes;
+    }
+
+    public static function isWithinOngoingTripWindow(
+        Carbon $now,
+        Carbon $tripStart,
+        ?string $estimatedTime
+    ): bool {
+        $durationMinutes = self::estimatedTimeToMinutes($estimatedTime);
+        $windowStart = $tripStart->copy()->subMinutes(self::LEAD_MINUTES);
+        $windowEnd = $tripStart->copy()->addMinutes($durationMinutes + self::GRACE_MINUTES);
+
+        return $now->greaterThanOrEqualTo($windowStart)
+            && $now->lessThanOrEqualTo($windowEnd);
+    }
+}

--- a/app/Http/Controllers/Api/v1/TripController.php
+++ b/app/Http/Controllers/Api/v1/TripController.php
@@ -175,6 +175,18 @@ class TripController extends Controller
         // return response()->json(['data' => $trips]);
     }
 
+    public function getOngoingTrip(Request $request)
+    {
+        $this->user = auth()->user();
+        $trip = $this->tripsLogic->getOngoingTrip($this->user);
+
+        if (! $trip) {
+            return response()->json(['data' => null]);
+        }
+
+        return $this->item($trip, new TripTransformer($this->user));
+    }
+
     public function getOldTrips(Request $request)
     {
         $this->user = auth()->user();

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DB;
 use Illuminate\Support\Facades\Http;
 use STS\Events\Trip\Create as CreateEvent;
+use STS\Helpers\OngoingTripHelper;
 use STS\Helpers\TripPriceHelper;
 use STS\Models\NodeGeo;
 use STS\Models\Passenger;
@@ -372,6 +373,46 @@ class TripRepository
         $trips->with(['user', 'points', 'passengerAccepted', 'passengerAccepted.user', 'car']);
 
         return $trips->get();
+    }
+
+    public function getOngoingTrip(User $user): ?Trip
+    {
+        $now = Carbon::now();
+        $candidateStart = $now->copy()->subDay();
+        $candidateEnd = $now->copy()->addHour();
+
+        $driverTrips = Trip::query()
+            ->where('user_id', $user->id)
+            ->where('weekly_schedule', 0)
+            ->whereBetween('trip_date', [$candidateStart, $candidateEnd])
+            ->with(['user', 'points', 'passengerAccepted', 'passengerAccepted.user', 'car'])
+            ->get();
+
+        $passengerTrips = Trip::query()
+            ->where('weekly_schedule', 0)
+            ->whereBetween('trip_date', [$candidateStart, $candidateEnd]);
+        $this->applyAcceptedPassengerFilter($passengerTrips, $user->id);
+        $passengerTrips->select('trips.*');
+        $passengerTrips = $passengerTrips
+            ->with(['user', 'points', 'passengerAccepted', 'passengerAccepted.user', 'car'])
+            ->get();
+
+        $candidates = $driverTrips
+            ->concat($passengerTrips)
+            ->unique('id')
+            ->filter(fn (Trip $trip) => OngoingTripHelper::isWithinOngoingTripWindow(
+                $now,
+                $trip->trip_date,
+                $trip->estimated_time
+            ));
+
+        if ($candidates->isEmpty()) {
+            return null;
+        }
+
+        return $candidates
+            ->sortBy(fn (Trip $trip) => $trip->trip_date->timestamp)
+            ->first();
     }
 
     public function search($user, $data)

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -467,6 +467,16 @@ class TripsManager extends BaseManager
         return $trips;
     }
 
+    public function getOngoingTrip($user)
+    {
+        $trip = $this->tripRepo->getOngoingTrip($user);
+        if (! $trip) {
+            return null;
+        }
+
+        return $this->proccessTrips(collect([$trip]))->first();
+    }
+
     public function tripOwner($user, $trip)
     {
         $trip = $trip instanceof Model ? $trip : $this->tripRepo->show($user, $trip);

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,6 +66,7 @@ Route::middleware(['api'])->group(function () {
         Route::get('/get-trips', [TripController::class, 'getTrips']);
         Route::get('/get-old-trips', [TripController::class, 'getOldTrips']);
         Route::get('/my-trips', [TripController::class, 'getTrips']);
+        Route::get('/ongoing-trip', [TripController::class, 'getOngoingTrip']);
         Route::get('/my-old-trips', [TripController::class, 'getOldTrips']);
         Route::get('/requests', [PassengerController::class, 'allRequests']);
         Route::get('/seat-requests', [PassengerController::class, 'seatRequests']);

--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -564,6 +564,51 @@ class TripControllerIntegrationTest extends TestCase
             ->assertJsonFragment(['id' => $asPassengerTrip->id]);
     }
 
+    public function test_ongoing_trip_endpoint_returns_trip_within_visibility_window(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 15:45:00'));
+        try {
+            $user = User::factory()->create();
+            $trip = Trip::factory()->create([
+                'user_id' => $user->id,
+                'trip_date' => Carbon::parse('2026-06-02 16:00:00'),
+                'estimated_time' => '01:00',
+                'weekly_schedule' => 0,
+            ]);
+
+            $this->actingAs($user, 'api')
+                ->getJson('/api/users/ongoing-trip')
+                ->assertOk()
+                ->assertJsonPath('data.id', $trip->id)
+                ->assertJsonStructure([
+                    'data' => ['id', 'from_town', 'to_town', 'trip_date', 'estimated_time', 'user'],
+                ]);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_ongoing_trip_endpoint_returns_null_when_no_trip_in_window(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 14:00:00'));
+        try {
+            $user = User::factory()->create();
+            Trip::factory()->create([
+                'user_id' => $user->id,
+                'trip_date' => Carbon::parse('2026-06-02 16:00:00'),
+                'estimated_time' => '01:00',
+                'weekly_schedule' => 0,
+            ]);
+
+            $this->actingAs($user, 'api')
+                ->getJson('/api/users/ongoing-trip')
+                ->assertOk()
+                ->assertJsonPath('data', null);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     public function test_admin_can_list_trips_for_another_user_via_user_id(): void
     {
         $admin = User::factory()->create(['is_admin' => true]);

--- a/tests/Unit/Helpers/OngoingTripHelperTest.php
+++ b/tests/Unit/Helpers/OngoingTripHelperTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use Carbon\Carbon;
+use STS\Helpers\OngoingTripHelper;
+use Tests\TestCase;
+
+class OngoingTripHelperTest extends TestCase
+{
+    public function test_estimated_time_to_minutes_parses_hh_mm(): void
+    {
+        $this->assertSame(242, OngoingTripHelper::estimatedTimeToMinutes('04:02'));
+        $this->assertSame(90, OngoingTripHelper::estimatedTimeToMinutes('01:30'));
+    }
+
+    public function test_estimated_time_to_minutes_returns_zero_when_missing(): void
+    {
+        $this->assertSame(0, OngoingTripHelper::estimatedTimeToMinutes(null));
+        $this->assertSame(0, OngoingTripHelper::estimatedTimeToMinutes(''));
+    }
+
+    public function test_is_within_window_one_hour_before_start(): void
+    {
+        $start = Carbon::parse('2026-06-02 16:00:00');
+        $now = $start->copy()->subMinutes(30);
+
+        $this->assertTrue(
+            OngoingTripHelper::isWithinOngoingTripWindow($now, $start, '01:00')
+        );
+    }
+
+    public function test_is_within_window_during_trip(): void
+    {
+        $start = Carbon::parse('2026-06-02 16:00:00');
+        $now = $start->copy()->addMinutes(20);
+
+        $this->assertTrue(
+            OngoingTripHelper::isWithinOngoingTripWindow($now, $start, '01:00')
+        );
+    }
+
+    public function test_is_within_window_thirty_minutes_after_estimated_end(): void
+    {
+        $start = Carbon::parse('2026-06-02 16:00:00');
+        $now = $start->copy()->addMinutes(80);
+
+        $this->assertTrue(
+            OngoingTripHelper::isWithinOngoingTripWindow($now, $start, '00:50')
+        );
+    }
+
+    public function test_is_outside_window_more_than_one_hour_before_start(): void
+    {
+        $start = Carbon::parse('2026-06-02 16:00:00');
+        $now = $start->copy()->subMinutes(61);
+
+        $this->assertFalse(
+            OngoingTripHelper::isWithinOngoingTripWindow($now, $start, '01:00')
+        );
+    }
+
+    public function test_is_outside_window_more_than_thirty_minutes_after_estimated_end(): void
+    {
+        $start = Carbon::parse('2026-06-02 16:00:00');
+        $now = $start->copy()->addMinutes(81);
+
+        $this->assertFalse(
+            OngoingTripHelper::isWithinOngoingTripWindow($now, $start, '00:50')
+        );
+    }
+}

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -1162,6 +1162,79 @@ class TripRepositoryTest extends TestCase
         ));
     }
 
+    public function test_get_ongoing_trip_returns_driver_trip_within_window(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 15:30:00'));
+        try {
+            $user = User::factory()->create();
+            $ongoing = Trip::factory()->create([
+                'user_id' => $user->id,
+                'trip_date' => Carbon::parse('2026-06-02 16:00:00'),
+                'estimated_time' => '01:00',
+                'weekly_schedule' => 0,
+            ]);
+            Trip::factory()->create([
+                'user_id' => $user->id,
+                'trip_date' => Carbon::parse('2026-06-10 10:00:00'),
+                'estimated_time' => '01:00',
+                'weekly_schedule' => 0,
+            ]);
+
+            $result = $this->repo()->getOngoingTrip($user);
+
+            $this->assertNotNull($result);
+            $this->assertSame($ongoing->id, $result->id);
+            $this->assertTrue($result->relationLoaded('user'));
+            $this->assertTrue($result->relationLoaded('points'));
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_get_ongoing_trip_returns_passenger_trip_within_window(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 16:20:00'));
+        try {
+            $driver = User::factory()->create();
+            $passenger = User::factory()->create();
+            $trip = Trip::factory()->create([
+                'user_id' => $driver->id,
+                'trip_date' => Carbon::parse('2026-06-02 16:00:00'),
+                'estimated_time' => '01:00',
+                'weekly_schedule' => 0,
+            ]);
+            Passenger::factory()->aceptado()->create([
+                'trip_id' => $trip->id,
+                'user_id' => $passenger->id,
+            ]);
+
+            $result = $this->repo()->getOngoingTrip($passenger);
+
+            $this->assertNotNull($result);
+            $this->assertSame($trip->id, $result->id);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_get_ongoing_trip_returns_null_when_outside_window(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 14:00:00'));
+        try {
+            $user = User::factory()->create();
+            Trip::factory()->create([
+                'user_id' => $user->id,
+                'trip_date' => Carbon::parse('2026-06-02 16:00:00'),
+                'estimated_time' => '01:00',
+                'weekly_schedule' => 0,
+            ]);
+
+            $this->assertNull($this->repo()->getOngoingTrip($user));
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     public function test_get_old_trips_excludes_weekly_schedule_and_past_only(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -1164,6 +1164,8 @@ class TripRepositoryTest extends TestCase
 
     public function test_get_ongoing_trip_returns_driver_trip_within_window(): void
     {
+        Trip::query()->forceDelete();
+        Passenger::query()->delete();
         Carbon::setTestNow(Carbon::parse('2026-06-02 15:30:00'));
         try {
             $user = User::factory()->create();
@@ -1193,13 +1195,15 @@ class TripRepositoryTest extends TestCase
 
     public function test_get_ongoing_trip_returns_passenger_trip_within_window(): void
     {
-        Carbon::setTestNow(Carbon::parse('2026-06-02 16:20:00'));
+        Trip::query()->forceDelete();
+        Passenger::query()->delete();
+        Carbon::setTestNow(Carbon::parse('2026-06-03 10:00:00'));
         try {
             $driver = User::factory()->create();
             $passenger = User::factory()->create();
             $trip = Trip::factory()->create([
                 'user_id' => $driver->id,
-                'trip_date' => Carbon::parse('2026-06-02 16:00:00'),
+                'trip_date' => Carbon::parse('2026-06-03 09:30:00'),
                 'estimated_time' => '01:00',
                 'weekly_schedule' => 0,
             ]);
@@ -1212,6 +1216,7 @@ class TripRepositoryTest extends TestCase
 
             $this->assertNotNull($result);
             $this->assertSame($trip->id, $result->id);
+            $this->assertSame($driver->id, $result->user_id);
         } finally {
             Carbon::setTestNow();
         }
@@ -1219,6 +1224,8 @@ class TripRepositoryTest extends TestCase
 
     public function test_get_ongoing_trip_returns_null_when_outside_window(): void
     {
+        Trip::query()->forceDelete();
+        Passenger::query()->delete();
         Carbon::setTestNow(Carbon::parse('2026-06-02 14:00:00'));
         try {
             $user = User::factory()->create();


### PR DESCRIPTION
## Summary
Show an ongoing-trip card on the home screen when the logged-in user has a trip starting within 1 hour, is currently traveling, or up to 30 minutes after the estimated arrival.
### Backend
**Cause:** `my-trips` only returns future trips (`trip_date >= now`), so in-progress trips disappear from the client once they start. The home screen had no API to surface the active trip.
**Fix:**
- Add `OngoingTripHelper` with the visibility window (`-60 min` → `+estimated_time +30 min`)
- Add `TripRepository::getOngoingTrip()` for driver and accepted-passenger trips (excludes weekly schedule)
- Expose `GET /api/users/ongoing-trip` (returns `{ data: trip }` or `{ data: null }`)
