### PR TITLE
Changelog

### DIFF
--- a/app/Http/Controllers/Api/Admin/ChangelogController.php
+++ b/app/Http/Controllers/Api/Admin/ChangelogController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+use STS\Http\Controllers\Controller;
+use STS\Models\Changelog;
+
+class ChangelogController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $rows = Changelog::query()
+            ->with([
+                'creator:id,name',
+                'updater:id,name',
+            ])
+            ->orderByDesc('id')
+            ->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (Changelog $c) => $this->serializeChangelog($c))->all(),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'version' => 'required|string|min:1|max:32|unique:changelogs,version',
+            'body_markdown' => 'required|string|min:1',
+        ]);
+
+        $admin = auth()->user();
+        $changelog = Changelog::create([
+            'version' => $validated['version'],
+            'body_markdown' => $validated['body_markdown'],
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $changelog->load(['creator:id,name', 'updater:id,name']);
+
+        return response()->json(['data' => $this->serializeChangelog($changelog)], Response::HTTP_CREATED);
+    }
+
+    public function show(Changelog $changelog): JsonResponse
+    {
+        $changelog->load(['creator:id,name', 'updater:id,name']);
+
+        return response()->json(['data' => $this->serializeChangelog($changelog)]);
+    }
+
+    public function update(Request $request, Changelog $changelog): JsonResponse
+    {
+        $validated = $request->validate([
+            'version' => [
+                'required',
+                'string',
+                'min:1',
+                'max:32',
+                Rule::unique('changelogs', 'version')->ignore($changelog->id),
+            ],
+            'body_markdown' => 'required|string|min:1',
+        ]);
+
+        $admin = auth()->user();
+
+        $changelog->fill([
+            'version' => $validated['version'],
+            'body_markdown' => $validated['body_markdown'],
+            'updated_by' => $admin->id,
+        ]);
+        $changelog->save();
+
+        $changelog->load(['creator:id,name', 'updater:id,name']);
+
+        return response()->json(['data' => $this->serializeChangelog($changelog)]);
+    }
+
+    public function destroy(Changelog $changelog): Response
+    {
+        $changelog->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeChangelog(Changelog $changelog): array
+    {
+        return [
+            'id' => $changelog->id,
+            'version' => $changelog->version,
+            'body_markdown' => $changelog->body_markdown,
+            'created_at' => $changelog->created_at?->toIso8601String(),
+            'updated_at' => $changelog->updated_at?->toIso8601String(),
+            'created_by' => $changelog->created_by,
+            'updated_by' => $changelog->updated_by,
+            'creator' => $changelog->relationLoaded('creator') && $changelog->creator
+                ? ['id' => $changelog->creator->id, 'name' => $changelog->creator->name]
+                : null,
+            'updater' => $changelog->relationLoaded('updater') && $changelog->updater
+                ? ['id' => $changelog->updater->id, 'name' => $changelog->updater->name]
+                : null,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/v1/ChangelogController.php
+++ b/app/Http/Controllers/Api/v1/ChangelogController.php
@@ -10,6 +10,23 @@ use STS\Models\Changelog;
 
 class ChangelogController extends Controller
 {
+    public function index(): JsonResponse
+    {
+        $rows = Changelog::query()->get();
+
+        $sorted = $rows->sort(function (Changelog $left, Changelog $right) {
+            return version_compare($right->version, $left->version);
+        })->values();
+
+        return response()->json([
+            'data' => $sorted->map(fn (Changelog $changelog) => [
+                'id' => $changelog->id,
+                'version' => $changelog->version,
+                'body_markdown' => $changelog->body_markdown,
+            ])->all(),
+        ]);
+    }
+
     public function show(Request $request): JsonResponse
     {
         $validated = $request->validate([

--- a/app/Http/Controllers/Api/v1/ChangelogController.php
+++ b/app/Http/Controllers/Api/v1/ChangelogController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use STS\Http\Controllers\Controller;
+use STS\Models\Changelog;
+
+class ChangelogController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'version' => 'required|string|min:1|max:32',
+        ]);
+
+        $changelog = Changelog::query()
+            ->where('version', $validated['version'])
+            ->first();
+
+        if (! $changelog) {
+            return response()->json(['message' => 'Not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        return response()->json([
+            'data' => [
+                'id' => $changelog->id,
+                'version' => $changelog->version,
+                'body_markdown' => $changelog->body_markdown,
+            ],
+        ]);
+    }
+}

--- a/app/Models/Changelog.php
+++ b/app/Models/Changelog.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Changelog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'version',
+        'body_markdown',
+        'created_by',
+        'updated_by',
+    ];
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function updater(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+}

--- a/database/migrations/2026_06_08_120000_create_changelogs_table.php
+++ b/database/migrations/2026_06_08_120000_create_changelogs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('changelogs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('version')->unique();
+            $table->text('body_markdown');
+            $table->unsignedInteger('created_by')->nullable();
+            $table->unsignedInteger('updated_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('created_by')->references('id')->on('users')->nullOnDelete();
+            $table->foreign('updated_by')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('changelogs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ use STS\Http\Controllers\Api\v1\AuthController;
 use STS\Http\Controllers\Api\v1\CampaignController as ApiCampaignController;
 use STS\Http\Controllers\Api\v1\CampaignRewardController as ApiCampaignRewardController;
 use STS\Http\Controllers\Api\v1\CarController;
+use STS\Http\Controllers\Api\v1\ChangelogController;
 use STS\Http\Controllers\Api\v1\ConversationController;
 use STS\Http\Controllers\Api\v1\DataController;
 use STS\Http\Controllers\Api\v1\DeviceController;
@@ -44,6 +45,7 @@ Route::middleware(['api'])->group(function () {
     Route::post('login', [AuthController::class, 'login']);
     Route::post('retoken', [AuthController::class, 'retoken']);
     Route::get('config', [AuthController::class, 'getConfig']);
+    Route::get('changelog', [ChangelogController::class, 'show']);
 
     Route::post('logout', [AuthController::class, 'logout']);
     Route::post('activate/{activation_token?}', [AuthController::class, 'active']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,7 @@ Route::middleware(['api'])->group(function () {
     Route::post('retoken', [AuthController::class, 'retoken']);
     Route::get('config', [AuthController::class, 'getConfig']);
     Route::get('changelog', [ChangelogController::class, 'show']);
+    Route::get('changelogs', [ChangelogController::class, 'index']);
 
     Route::post('logout', [AuthController::class, 'logout']);
     Route::post('activate/{activation_token?}', [AuthController::class, 'active']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use STS\Http\Controllers\Api\Admin\CampaignDonationController;
 use STS\Http\Controllers\Api\Admin\CampaignMilestoneController;
 use STS\Http\Controllers\Api\Admin\CampaignRewardController;
 use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
+use STS\Http\Controllers\Api\Admin\ChangelogController as AdminChangelogController;
 use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
 use STS\Http\Controllers\Api\Admin\MercadoPagoRejectedValidationController as AdminMercadoPagoRejectedValidationController;
@@ -290,6 +291,7 @@ Route::middleware(['api'])->group(function () {
 
         Route::post('support/reply-templates/{reply_template}/duplicate', [AdminSupportReplyTemplateController::class, 'duplicate']);
         Route::apiResource('support/reply-templates', AdminSupportReplyTemplateController::class)->except(['create', 'edit']);
+        Route::apiResource('changelogs', AdminChangelogController::class)->except(['create', 'edit']);
     });
 
     Route::post('campaigns/{campaign}/rewards/{reward}/purchase', [ApiCampaignRewardController::class, 'purchase'])->middleware('logged.optional');

--- a/tests/Feature/Http/AdminChangelogApiTest.php
+++ b/tests/Feature/Http/AdminChangelogApiTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\Changelog;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminChangelogApiTest extends TestCase
+{
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_admin_lists_changelogs_newest_first(): void
+    {
+        $admin = $this->adminUser();
+        $older = Changelog::create([
+            'version' => '1.0.0',
+            'body_markdown' => 'Old notes',
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+        $newer = Changelog::create([
+            'version' => '2.0.0',
+            'body_markdown' => 'New notes',
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/changelogs')->assertOk();
+        $rows = collect($response->json('data'));
+        $newerIdx = $rows->search(fn (array $r): bool => (int) $r['id'] === $newer->id);
+        $olderIdx = $rows->search(fn (array $r): bool => (int) $r['id'] === $older->id);
+        $this->assertNotFalse($newerIdx);
+        $this->assertNotFalse($olderIdx);
+        $this->assertLessThan($olderIdx, $newerIdx);
+    }
+
+    public function test_admin_stores_changelog_with_audit_fields(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/changelogs', [
+            'version' => '3.2.3',
+            'body_markdown' => '## Cambios',
+        ])->assertCreated();
+
+        $data = $response->json('data');
+        $this->assertSame('3.2.3', $data['version']);
+        $this->assertSame('## Cambios', $data['body_markdown']);
+        $this->assertSame($admin->id, $data['created_by']);
+        $this->assertSame($admin->id, $data['updated_by']);
+
+        $this->assertDatabaseHas('changelogs', [
+            'id' => $data['id'],
+            'version' => '3.2.3',
+            'created_by' => $admin->id,
+        ]);
+    }
+
+    public function test_store_validates_required_fields(): void
+    {
+        $admin = $this->adminUser();
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/changelogs', [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['version', 'body_markdown']);
+    }
+
+    public function test_store_rejects_duplicate_version(): void
+    {
+        $admin = $this->adminUser();
+        Changelog::create([
+            'version' => '1.0.0',
+            'body_markdown' => 'Existing',
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/changelogs', [
+            'version' => '1.0.0',
+            'body_markdown' => 'Duplicate',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['version']);
+    }
+
+    public function test_admin_shows_changelog(): void
+    {
+        $admin = $this->adminUser();
+        $changelog = Changelog::create([
+            'version' => '4.0.0',
+            'body_markdown' => 'Notes',
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/changelogs/'.$changelog->id)->assertOk();
+        $data = $response->json('data');
+        $this->assertSame($changelog->id, $data['id']);
+        $this->assertArrayHasKey('creator', $data);
+        $this->assertSame($admin->id, $data['creator']['id']);
+    }
+
+    public function test_admin_updates_changelog_sets_updated_by(): void
+    {
+        $admin = $this->adminUser();
+        $other = $this->adminUser();
+        $changelog = Changelog::create([
+            'version' => '5.0.0',
+            'body_markdown' => 'A',
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $this->actingAs($other, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->putJson('api/admin/changelogs/'.$changelog->id, [
+            'version' => '5.0.1',
+            'body_markdown' => 'B',
+        ])->assertOk();
+
+        $data = $response->json('data');
+        $this->assertSame('5.0.1', $data['version']);
+        $this->assertSame('B', $data['body_markdown']);
+        $this->assertSame($admin->id, $data['created_by']);
+        $this->assertSame($other->id, $data['updated_by']);
+    }
+
+    public function test_admin_destroys_changelog(): void
+    {
+        $admin = $this->adminUser();
+        $changelog = Changelog::create([
+            'version' => '6.0.0',
+            'body_markdown' => 'Z',
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->deleteJson('api/admin/changelogs/'.$changelog->id)->assertNoContent();
+        $this->assertDatabaseMissing('changelogs', ['id' => $changelog->id]);
+    }
+}

--- a/tests/Feature/Http/ChangelogApiTest.php
+++ b/tests/Feature/Http/ChangelogApiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Models\Changelog;
+use Tests\TestCase;
+
+class ChangelogApiTest extends TestCase
+{
+    public function test_returns_changelog_for_matching_version(): void
+    {
+        Changelog::create([
+            'version' => '3.2.3',
+            'body_markdown' => '## Novedades\n- Mejoras de rendimiento',
+        ]);
+
+        $response = $this->getJson('api/changelog?version=3.2.3')->assertOk();
+
+        $data = $response->json('data');
+        $this->assertSame('3.2.3', $data['version']);
+        $this->assertSame('## Novedades\n- Mejoras de rendimiento', $data['body_markdown']);
+    }
+
+    public function test_returns_404_when_no_changelog_for_version(): void
+    {
+        $this->getJson('api/changelog?version=9.9.9')->assertNotFound();
+    }
+
+    public function test_validates_version_parameter(): void
+    {
+        $this->getJson('api/changelog')->assertUnprocessable()
+            ->assertJsonValidationErrors(['version']);
+    }
+}

--- a/tests/Feature/Http/ChangelogApiTest.php
+++ b/tests/Feature/Http/ChangelogApiTest.php
@@ -31,4 +31,25 @@ class ChangelogApiTest extends TestCase
         $this->getJson('api/changelog')->assertUnprocessable()
             ->assertJsonValidationErrors(['version']);
     }
+
+    public function test_lists_all_changelogs_sorted_by_semver_newest_first(): void
+    {
+        Changelog::create([
+            'version' => '1.0.0',
+            'body_markdown' => 'Primera versión',
+        ]);
+        Changelog::create([
+            'version' => '2.10.0',
+            'body_markdown' => 'Mejoras mayores',
+        ]);
+        Changelog::create([
+            'version' => '2.2.0',
+            'body_markdown' => 'Parches',
+        ]);
+
+        $response = $this->getJson('api/changelogs')->assertOk();
+
+        $versions = array_column($response->json('data'), 'version');
+        $this->assertSame(['2.10.0', '2.2.0', '1.0.0'], $versions);
+    }
 }


### PR DESCRIPTION
## Summary
Adds version-scoped changelogs: admins can publish release notes per semver version; users see them once in a modal on app load (or reopen from the profile menu).

---

## Backend (`carpoolear_backend`)
### Cause
There was no way to store or serve release notes tied to an app version.
### Changes
- New `changelogs` table (`version` unique semver, `body_markdown`, audit fields).
- **Public API:** `GET /api/changelog?version=` — returns changelog for the requested version, or 404.
- **Admin API:** full CRUD at `/api/admin/changelogs` (list, create, read, update, delete).
- Feature tests: `ChangelogApiTest`, `AdminChangelogApiTest` (10 tests).
