### PR TITLE
Stop notifying sharers when live location sharing starts.

### DIFF
--- a/app/Services/Logic/TripLiveShareManager.php
+++ b/app/Services/Logic/TripLiveShareManager.php
@@ -39,7 +39,7 @@ class TripLiveShareManager extends BaseManager
         $wasActive = ($existing = $this->liveShareRepo->findByTripAndUser($tripId, $user->id)) && $existing->is_active;
         $share = $this->liveShareRepo->start($tripId, $user->id);
 
-        if (! $wasActive && $this->tripsManager->tripOwner($user, $trip)) {
+        if (! $wasActive && $this->shouldNotifyParticipantsOfSharing($user, $trip)) {
             $this->notifyPassengersOfDriverSharing($trip, $user);
         }
 
@@ -183,13 +183,27 @@ class TripLiveShareManager extends BaseManager
         }
     }
 
+    private function shouldNotifyParticipantsOfSharing(User $user, Trip $trip): bool
+    {
+        return (int) $trip->user_id === (int) $user->id;
+    }
+
     private function notifyPassengersOfDriverSharing(Trip $trip, User $driver): void
     {
         $trip->loadMissing('passengerAccepted.user');
+        $sharerId = (int) $driver->id;
+        $tripOwnerId = (int) $trip->user_id;
+
         foreach ($trip->passengerAccepted as $passenger) {
             if (! $passenger->user) {
                 continue;
             }
+
+            $passengerUserId = (int) $passenger->user_id;
+            if ($passengerUserId === $sharerId || $passengerUserId === $tripOwnerId) {
+                continue;
+            }
+
             $notification = new DriverLiveLocationSharingNotification;
             $notification->setAttribute('trip', $trip);
             $notification->setAttribute('from', $driver);

--- a/tests/Unit/Services/Logic/TripLiveShareManagerTest.php
+++ b/tests/Unit/Services/Logic/TripLiveShareManagerTest.php
@@ -7,7 +7,9 @@ use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\TripLiveShare;
 use STS\Models\User;
+use STS\Notifications\DriverLiveLocationSharingNotification;
 use STS\Services\Logic\TripLiveShareManager;
+use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
 
 class TripLiveShareManagerTest extends TestCase
@@ -383,5 +385,102 @@ class TripLiveShareManagerTest extends TestCase
         $manager = $this->manager();
         $this->assertNull($manager->getTripView($outsider, $trip->id));
         $this->assertSame('access_denied', $manager->getErrors()['error']);
+    }
+
+    public function test_driver_start_notifies_accepted_passengers_only(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 15:30:00'));
+        $driver = User::factory()->create(['name' => 'Driver']);
+        $passenger = User::factory()->create();
+        $trip = $this->ongoingTripFor($driver);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+        ]);
+
+        $notifiedUserIds = [];
+        $mock = $this->mock(NotificationServices::class);
+        $mock->shouldReceive('send')
+            ->andReturnUsing(function ($notification, $users) use (&$notifiedUserIds) {
+                if ($notification instanceof DriverLiveLocationSharingNotification && $users instanceof User) {
+                    $notifiedUserIds[] = $users->id;
+                }
+            });
+
+        $this->manager()->start($driver, $trip->id);
+
+        $this->assertSame([$passenger->id], array_values(array_unique($notifiedUserIds)));
+    }
+
+    public function test_driver_start_does_not_notify_driver_even_with_accepted_passenger_row(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 15:30:00'));
+        $driver = User::factory()->create(['name' => 'Driver']);
+        $passenger = User::factory()->create();
+        $trip = $this->ongoingTripFor($driver);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $driver->id,
+        ]);
+
+        $notifiedUserIds = [];
+        $mock = $this->mock(NotificationServices::class);
+        $mock->shouldReceive('send')
+            ->andReturnUsing(function ($notification, $users) use (&$notifiedUserIds) {
+                if ($notification instanceof DriverLiveLocationSharingNotification && $users instanceof User) {
+                    $notifiedUserIds[] = $users->id;
+                }
+            });
+
+        $this->manager()->start($driver, $trip->id);
+
+        $this->assertSame([$passenger->id], array_values(array_unique($notifiedUserIds)));
+        $this->assertNotContains($driver->id, $notifiedUserIds);
+    }
+
+    public function test_passenger_start_does_not_notify_anyone(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 15:30:00'));
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = $this->ongoingTripFor($driver);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+        ]);
+
+        $mock = $this->mock(NotificationServices::class);
+        $mock->shouldReceive('send')
+            ->never()
+            ->withArgs(function ($notification) {
+                return $notification instanceof DriverLiveLocationSharingNotification;
+            });
+
+        $this->manager()->start($passenger, $trip->id);
+    }
+
+    public function test_admin_passenger_start_does_not_notify_anyone(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-02 15:30:00'));
+        $driver = User::factory()->create();
+        $adminPassenger = User::factory()->create(['is_admin' => true]);
+        $trip = $this->ongoingTripFor($driver);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $adminPassenger->id,
+        ]);
+
+        $mock = $this->mock(NotificationServices::class);
+        $mock->shouldReceive('send')
+            ->never()
+            ->withArgs(function ($notification) {
+                return $notification instanceof DriverLiveLocationSharingNotification;
+            });
+
+        $this->manager()->start($adminPassenger, $trip->id);
     }
 }


### PR DESCRIPTION
## Summary
Fixes live location sharing on iOS and corrects push notifications when a passenger (or admin passenger) starts sharing.

### Backend (`carpoolear_backend`)
**Cause**
- Starting live location sharing notified passengers using logic that treated admins as trip owners (`tripOwner()` includes `is_admin`).
- When a passenger who is also an admin started sharing, they triggered `DriverLiveLocationSharingNotification` and received their own push (“{name} está compartiendo… para tu viaje a…”).
**Fix**
- Only the actual trip owner (`trip.user_id === user.id`) triggers passenger notifications via `shouldNotifyParticipantsOfSharing()`.
- `notifyPassengersOfDriverSharing()` explicitly skips the sharer and trip owner.
- Passenger/admin sharing no longer sends driver-sharing notifications to anyone.
- Unit tests cover driver → passengers only, driver never notified, passenger start notifies nobody, admin passenger start notifies nobody.
