### PR TITLE
Remove devices: fix logs

### DIFF
--- a/app/Services/Notifications/Channels/PushChannel.php
+++ b/app/Services/Notifications/Channels/PushChannel.php
@@ -46,7 +46,7 @@ class PushChannel
                         $this->sendBrowser($device, $data);
                     }
                 } catch (\Exception $e) {
-                    if (FirebaseService::isStaleRegistrationTokenError($e) || self::isApnsUnregisteredError($e)) {
+                    if (FirebaseService::isStaleRegistrationTokenError($e) || self::isApnsUnregisteredError($e) || self::isApnsBadDeviceTokenError($e)) {
                         $this->deactivateDeviceAfterStaleToken($device, $user, $e);
                     } else {
                         \Log::error('PushChannel: Error sending push notification', [
@@ -182,7 +182,7 @@ class PushChannel
 
             return $result;
         } catch (\Exception $e) {
-            if (! self::isApnsUnregisteredError($e)) {
+            if (! self::isApnsUnregisteredError($e) && ! self::isApnsBadDeviceTokenError($e)) {
                 \Log::error('PushChannel: sendIOS error', [
                     'device_id' => $device->id,
                     'device_token' => $device->device_id,
@@ -206,6 +206,25 @@ class PushChannel
         }
 
         if (preg_match('/"reason"\s*:\s*"Unregistered"/', $message) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function isApnsBadDeviceTokenError(\Throwable $e): bool
+    {
+        $message = $e->getMessage();
+
+        if (strpos($message, 'HTTP 400') === false) {
+            return false;
+        }
+
+        if (stripos($message, 'BadDeviceToken') !== false) {
+            return true;
+        }
+
+        if (preg_match('/"reason"\s*:\s*"BadDeviceToken"/', $message) === 1) {
             return true;
         }
 

--- a/app/Services/Notifications/Channels/PushChannel.php
+++ b/app/Services/Notifications/Channels/PushChannel.php
@@ -46,7 +46,7 @@ class PushChannel
                         $this->sendBrowser($device, $data);
                     }
                 } catch (\Exception $e) {
-                    if (FirebaseService::isStaleRegistrationTokenError($e) || self::isApnsUnregisteredError($e) || self::isApnsBadDeviceTokenError($e)) {
+                    if (FirebaseService::isStaleRegistrationTokenError($e) || self::isApnsStaleTokenError($e)) {
                         $this->deactivateDeviceAfterStaleToken($device, $user, $e);
                     } else {
                         \Log::error('PushChannel: Error sending push notification', [
@@ -182,7 +182,7 @@ class PushChannel
 
             return $result;
         } catch (\Exception $e) {
-            if (! self::isApnsUnregisteredError($e) && ! self::isApnsBadDeviceTokenError($e)) {
+            if (! self::isApnsStaleTokenError($e)) {
                 \Log::error('PushChannel: sendIOS error', [
                     'device_id' => $device->id,
                     'device_token' => $device->device_id,
@@ -210,6 +210,11 @@ class PushChannel
         }
 
         return false;
+    }
+
+    public static function isApnsStaleTokenError(\Throwable $e): bool
+    {
+        return self::isApnsUnregisteredError($e) || self::isApnsBadDeviceTokenError($e);
     }
 
     public static function isApnsBadDeviceTokenError(\Throwable $e): bool

--- a/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
+++ b/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
@@ -645,6 +645,66 @@ class PushChannelTest extends TestCase
         $this->assertFalse(PushChannel::isApnsUnregisteredError(new \RuntimeException('network down')));
     }
 
+    public function test_is_apns_bad_device_token_error_detects_http_400_bad_device_token(): void
+    {
+        $exception = new \RuntimeException(
+            'APNs returned HTTP 400: {"reason":"BadDeviceToken"}'
+        );
+
+        $this->assertTrue(PushChannel::isApnsBadDeviceTokenError($exception));
+    }
+
+    public function test_is_apns_bad_device_token_error_returns_false_for_other_apns_errors(): void
+    {
+        $exception = new \RuntimeException('APNs returned HTTP 410: {"reason":"Unregistered"}');
+
+        $this->assertFalse(PushChannel::isApnsBadDeviceTokenError($exception));
+        $this->assertFalse(PushChannel::isApnsBadDeviceTokenError(new \RuntimeException('network down')));
+    }
+
+    public function test_send_deactivates_ios_device_when_apns_returns_bad_device_token(): void
+    {
+        Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
+
+        $logged = [];
+        Log::shouldReceive('error')->zeroOrMoreTimes();
+        Log::shouldReceive('warning')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
+                $logged[] = ['message' => $message, 'context' => $context];
+            });
+
+        $channel = new class extends PushChannel
+        {
+            public function sendIOS($device, $data)
+            {
+                throw new \Exception('APNs returned HTTP 400: {"reason":"BadDeviceToken"}');
+            }
+        };
+
+        $user = User::factory()->create();
+        $device = Device::query()->create([
+            'user_id' => $user->id,
+            'device_id' => str_repeat('c', 64),
+            'device_type' => 'iOS',
+            'session_id' => 's-bad-ios-token',
+            'notifications' => true,
+            'last_activity' => now()->toDateTimeString(),
+        ]);
+
+        $user->load('devices');
+
+        $notification = new AnnouncementNotification;
+        $notification->setAttribute('message', 'Hello ios');
+        $notification->setAttribute('title', 'TI');
+
+        $channel->send($notification, $user);
+
+        $device->refresh();
+        $this->assertFalse($device->notifications);
+        $this->assertSame([], $logged);
+    }
+
     public function test_send_deactivates_ios_device_when_apns_returns_unregistered(): void
     {
         Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);


### PR DESCRIPTION
## Summary
- Deactivate iOS devices when APNs returns HTTP 400 `BadDeviceToken`, matching the existing behavior for HTTP 410 `Unregistered` and stale FCM tokens
- Stop logging repeated errors for permanently invalid APNs tokens
- Consolidate APNs stale-token detection into `isApnsStaleTokenError()`
## Cause
Production logs showed push failures like:
APNs returned HTTP 400: {"reason":"BadDeviceToken"}

These tokens are permanently invalid (wrong APNs environment, token from another app/bundle, malformed or expired token). The backend already deactivated devices for `Unregistered` (410) and stale FCM tokens, but `BadDeviceToken` (400) still went through the error-logging path on every notification attempt.
## Fix (backend)
In `PushChannel`:
- Added `isApnsBadDeviceTokenError()` to detect HTTP 400 + `BadDeviceToken`
- Added `isApnsStaleTokenError()` as a single entry point for APNs stale/invalid tokens
- Reused existing `deactivateDeviceAfterStaleToken()` to set `notifications = false` silently (no error logs)
