### PR TITLE
Trip create negative contribution

### DIFF
--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -44,7 +44,7 @@ class TripsManager extends BaseManager
                 'car_id' => $this->activeCarIdRule($user_id),
                 'weekly_schedule' => 'required_without:trip_date|nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
-                'seat_price_cents' => 'nullable|integer|gte:-1',
+                'seat_price_cents' => $this->seatPriceCentsRule(),
 
                 'points.*.address' => 'required|string',
                 'points.*.json_address' => 'required|array',
@@ -67,7 +67,7 @@ class TripsManager extends BaseManager
                 'car_id' => $this->activeCarIdRule($user_id),
                 'weekly_schedule' => 'nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
-                'seat_price_cents' => 'nullable|integer|gte:-1',
+                'seat_price_cents' => $this->seatPriceCentsRule(),
 
                 'points.*.address' => 'string',
                 'points.*.json_address' => 'array',
@@ -186,6 +186,11 @@ class TripsManager extends BaseManager
 
             return $trip;
         }
+    }
+
+    private function seatPriceCentsRule(): string
+    {
+        return 'nullable|integer|gte:-1';
     }
 
     private function activeCarIdRule($user_id): array

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -44,6 +44,7 @@ class TripsManager extends BaseManager
                 'car_id' => $this->activeCarIdRule($user_id),
                 'weekly_schedule' => 'required_without:trip_date|nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
+                'seat_price_cents' => 'nullable|integer|gte:-1',
 
                 'points.*.address' => 'required|string',
                 'points.*.json_address' => 'required|array',
@@ -66,6 +67,7 @@ class TripsManager extends BaseManager
                 'car_id' => $this->activeCarIdRule($user_id),
                 'weekly_schedule' => 'nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
+                'seat_price_cents' => 'nullable|integer|gte:-1',
 
                 'points.*.address' => 'string',
                 'points.*.json_address' => 'array',

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -156,6 +156,54 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_validator_create_allows_voluntary_and_non_negative_seat_price_cents(): void
+    {
+        Carbon::setTestNow('2028-01-01 12:00:00');
+        $user = User::factory()->create();
+
+        $voluntary = $this->manager()->validator(
+            $this->minimalCreatePayload(['seat_price_cents' => -1]),
+            $user->id
+        );
+        $this->assertFalse($voluntary->fails());
+
+        $priced = $this->manager()->validator(
+            $this->minimalCreatePayload(['seat_price_cents' => 1500]),
+            $user->id
+        );
+        $this->assertFalse($priced->fails());
+
+        Carbon::setTestNow();
+    }
+
+    public function test_validator_create_rejects_negative_seat_price_cents_below_voluntary_sentinel(): void
+    {
+        Carbon::setTestNow('2028-01-01 12:00:00');
+        $user = User::factory()->create();
+        $v = $this->manager()->validator(
+            $this->minimalCreatePayload(['seat_price_cents' => -500]),
+            $user->id
+        );
+        $this->assertTrue($v->fails());
+        $this->assertTrue($v->errors()->has('seat_price_cents'));
+        Carbon::setTestNow();
+    }
+
+    public function test_validator_update_rejects_negative_seat_price_cents_below_voluntary_sentinel(): void
+    {
+        Carbon::setTestNow('2028-01-01 12:00:00');
+        $user = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $user->id]);
+        $v = $this->manager()->validator(
+            ['seat_price_cents' => -250],
+            $user->id,
+            $trip->id
+        );
+        $this->assertTrue($v->fails());
+        $this->assertTrue($v->errors()->has('seat_price_cents'));
+        Carbon::setTestNow();
+    }
+
     public function test_validator_create_rejects_trip_date_not_after_now(): void
     {
         Carbon::setTestNow('2028-06-01 12:00:00');


### PR DESCRIPTION
## Summary

Prevent negative per-person contribution values during trip creation.

- **Frontend:** Block negative contribution input in the trip creation form with validation on input/submit, `min="0"` on price fields, and a dedicated error message. Negative form values no longer map to negative cents in the API payload.
- **Backend:** Reject `seat_price_cents` values below `-1` (the voluntary contribution sentinel) on trip create/update.

## Cause

The contribution field accepted negative numbers. `seatPriceCentsForApi` converted them to negative cents (e.g. `-5` → `-500`), and the backend had no validation rule for `seat_price_cents`.

## Fix

### Backend (`carpoolear_backend`)
- Added `seat_price_cents` validation in `TripsManager`: `nullable|integer|gte:-1` (allows `-1` voluntary sentinel and non-negative values; rejects e.g. `-500`).
