### PR TITLE
Rate accepted passengers

### DIFF
--- a/app/Listeners/Ratings/CreateRatingDeleteTrip.php
+++ b/app/Listeners/Ratings/CreateRatingDeleteTrip.php
@@ -32,18 +32,37 @@ class CreateRatingDeleteTrip
     {
         $trip = $event->trip;
 
-        $passengers = $trip->passengerAccepted;
-        if ($passengers->isNotEmpty()) {
-            foreach ($passengers as $passenger) {
-                $passenger_hash = Str::random(40);
-                $rate = $this->ratingRepository->create($passenger->user_id, $trip->user_id, $trip->id, Passenger::TYPE_CONDUCTOR, Passenger::STATE_ACCEPTED, $passenger_hash);
+        $passengerUserIdsNotified = [];
 
-                $notification = new DeleteTripNotification;
-                $notification->setAttribute('trip', $trip);
-                $notification->setAttribute('from', $trip->user);
-                $notification->setAttribute('hash', $passenger_hash);
-                $notification->notify($passenger->user);
+        foreach ($trip->passenger()->orderBy('created_at', 'desc')->get() as $passenger) {
+            $requestState = (int) $passenger->request_state;
+            $inRatingState = $requestState === Passenger::STATE_ACCEPTED || $requestState === Passenger::STATE_CANCELED;
+
+            $canceledButAccepted = true;
+            if ($requestState === Passenger::STATE_CANCELED) {
+                if (isset($passenger->canceled_state) && (int) $passenger->canceled_state === Passenger::CANCELED_REQUEST) {
+                    $canceledButAccepted = false;
+                }
             }
+
+            if (! $inRatingState || ! $canceledButAccepted) {
+                continue;
+            }
+
+            if (in_array($passenger->user_id, $passengerUserIdsNotified, true)) {
+                continue;
+            }
+
+            $passenger_hash = Str::random(40);
+            $this->ratingRepository->create($passenger->user_id, $trip->user_id, $trip->id, Passenger::TYPE_CONDUCTOR, Passenger::STATE_ACCEPTED, $passenger_hash);
+
+            $notification = new DeleteTripNotification;
+            $notification->setAttribute('trip', $trip);
+            $notification->setAttribute('from', $trip->user);
+            $notification->setAttribute('hash', $passenger_hash);
+            $notification->notify($passenger->user);
+
+            $passengerUserIdsNotified[] = $passenger->user_id;
         }
     }
 }

--- a/app/Listeners/Ratings/CreateRatingDeleteTrip.php
+++ b/app/Listeners/Ratings/CreateRatingDeleteTrip.php
@@ -53,6 +53,10 @@ class CreateRatingDeleteTrip
                 continue;
             }
 
+            if ($this->ratingRepository->getRating($passenger->user_id, $trip->user_id, $trip->id)) {
+                continue;
+            }
+
             $passenger_hash = Str::random(40);
             $this->ratingRepository->create($passenger->user_id, $trip->user_id, $trip->id, Passenger::TYPE_CONDUCTOR, Passenger::STATE_ACCEPTED, $passenger_hash);
 

--- a/app/Listeners/Ratings/CreateRatingDeleteTrip.php
+++ b/app/Listeners/Ratings/CreateRatingDeleteTrip.php
@@ -35,17 +35,7 @@ class CreateRatingDeleteTrip
         $passengerUserIdsNotified = [];
 
         foreach ($trip->passenger()->orderBy('created_at', 'desc')->get() as $passenger) {
-            $requestState = (int) $passenger->request_state;
-            $inRatingState = $requestState === Passenger::STATE_ACCEPTED || $requestState === Passenger::STATE_CANCELED;
-
-            $canceledButAccepted = true;
-            if ($requestState === Passenger::STATE_CANCELED) {
-                if (isset($passenger->canceled_state) && (int) $passenger->canceled_state === Passenger::CANCELED_REQUEST) {
-                    $canceledButAccepted = false;
-                }
-            }
-
-            if (! $inRatingState || ! $canceledButAccepted) {
+            if (! $passenger->isEligibleForRating()) {
                 continue;
             }
 

--- a/app/Models/Passenger.php
+++ b/app/Models/Passenger.php
@@ -86,6 +86,22 @@ class Passenger extends Model
         return $this->belongsTo('STS\Models\Trip', 'trip_id');
     }
 
+    public function isEligibleForRating(): bool
+    {
+        $requestState = (int) $this->request_state;
+        $inRatingState = $requestState === self::STATE_ACCEPTED || $requestState === self::STATE_CANCELED;
+
+        if (! $inRatingState) {
+            return false;
+        }
+
+        if ($requestState === self::STATE_CANCELED) {
+            return ! isset($this->canceled_state) || (int) $this->canceled_state !== self::CANCELED_REQUEST;
+        }
+
+        return true;
+    }
+
     /**
      * Ratings this passenger's user gave on this trip (FK columns reference users.id).
      */

--- a/app/Services/Logic/RatingManager.php
+++ b/app/Services/Logic/RatingManager.php
@@ -140,17 +140,7 @@ class RatingManager extends BaseManager
             $passenger_ids_rates_created = [];
 
             foreach ($passengers as $passenger) {
-                $requestState = (int) $passenger->request_state;
-                $inRatingState = $requestState === Passenger::STATE_ACCEPTED || $requestState === Passenger::STATE_CANCELED;
-
-                $canceledButAccepted = true;
-                if ($requestState === Passenger::STATE_CANCELED) {
-                    if (isset($passenger->canceled_state) && (int) $passenger->canceled_state === Passenger::CANCELED_REQUEST) {
-                        $canceledButAccepted = false;
-                    }
-                }
-
-                if ($inRatingState && $canceledButAccepted) {
+                if ($passenger->isEligibleForRating()) {
                     // the passenger could be make more than one trip request
                     if (! in_array($passenger->user->id, $passenger_ids_rates_created)) {
                         $passenger_hash = Str::random(40);

--- a/tests/Unit/Listeners/Ratings/CreateRatingDeleteTripListenerTest.php
+++ b/tests/Unit/Listeners/Ratings/CreateRatingDeleteTripListenerTest.php
@@ -192,4 +192,84 @@ class CreateRatingDeleteTripListenerTest extends TestCase
 
         (new CreateRatingDeleteTrip($ratingRepository))->handle(new TripDeleted($trip));
     }
+
+    public function test_handle_skips_passenger_who_withdrew_pending_request(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => User::factory(),
+            'request_state' => Passenger::STATE_CANCELED,
+            'canceled_state' => Passenger::CANCELED_REQUEST,
+        ]);
+
+        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository->shouldNotReceive('create');
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        (new CreateRatingDeleteTrip($ratingRepository))->handle(new TripDeleted($trip->fresh()));
+    }
+
+    public function test_handle_skips_when_pending_rating_already_exists(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $passengerUser = User::factory()->create();
+
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+        ]);
+
+        $trip = $trip->fresh();
+
+        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository->shouldReceive('getRating')
+            ->once()
+            ->with($passengerUser->id, $driver->id, $trip->id)
+            ->andReturn((object) ['id' => 99, 'voted' => false]);
+        $ratingRepository->shouldNotReceive('create');
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        (new CreateRatingDeleteTrip($ratingRepository))->handle(new TripDeleted($trip));
+    }
+
+    public function test_handle_deduplicates_rating_per_passenger_user(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $passengerUser = User::factory()->create();
+
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+            'request_state' => Passenger::STATE_CANCELED,
+            'canceled_state' => Passenger::CANCELED_DRIVER,
+        ]);
+
+        $trip = $trip->fresh();
+
+        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository->shouldReceive('getRating')
+            ->once()
+            ->with($passengerUser->id, $driver->id, $trip->id)
+            ->andReturn(null);
+        $ratingRepository->shouldReceive('create')
+            ->once()
+            ->andReturn((object) ['id' => 1]);
+
+        $this->mock(NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(3);
+
+        (new CreateRatingDeleteTrip($ratingRepository))->handle(new TripDeleted($trip));
+    }
 }

--- a/tests/Unit/Listeners/Ratings/CreateRatingDeleteTripListenerTest.php
+++ b/tests/Unit/Listeners/Ratings/CreateRatingDeleteTripListenerTest.php
@@ -15,6 +15,14 @@ use Tests\TestCase;
 
 class CreateRatingDeleteTripListenerTest extends TestCase
 {
+    private function mockRatingRepository(): RatingRepository
+    {
+        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository->shouldReceive('getRating')->andReturn(null);
+
+        return $ratingRepository;
+    }
+
     public function test_handle_does_nothing_when_trip_has_no_accepted_passengers(): void
     {
         $driver = User::factory()->create();
@@ -47,7 +55,7 @@ class CreateRatingDeleteTripListenerTest extends TestCase
 
         $trip = $trip->fresh();
 
-        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository = $this->mockRatingRepository();
         $ratingRepository->shouldReceive('create')
             ->once()
             ->withArgs(function ($userFromId, $userToId, $tripId, $userToType, $userToState, $hash) use ($passengerUser, $driver, $trip) {
@@ -101,7 +109,7 @@ class CreateRatingDeleteTripListenerTest extends TestCase
 
         $trip = $trip->fresh();
 
-        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository = $this->mockRatingRepository();
         $ratingRepository->shouldReceive('create')
             ->twice()
             ->withArgs(function ($userFromId, $userToId, $tripId, $userToType, $userToState, $hash) use ($first, $second, $driver, $trip) {
@@ -157,7 +165,7 @@ class CreateRatingDeleteTripListenerTest extends TestCase
 
         $trip = $trip->fresh();
 
-        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository = $this->mockRatingRepository();
         $ratingRepository->shouldReceive('create')
             ->once()
             ->withArgs(function ($userFromId, $userToId, $tripId, $userToType, $userToState, $hash) use ($passengerUser, $driver, $trip) {
@@ -257,11 +265,7 @@ class CreateRatingDeleteTripListenerTest extends TestCase
 
         $trip = $trip->fresh();
 
-        $ratingRepository = Mockery::mock(RatingRepository::class);
-        $ratingRepository->shouldReceive('getRating')
-            ->once()
-            ->with($passengerUser->id, $driver->id, $trip->id)
-            ->andReturn(null);
+        $ratingRepository = $this->mockRatingRepository();
         $ratingRepository->shouldReceive('create')
             ->once()
             ->andReturn((object) ['id' => 1]);

--- a/tests/Unit/Listeners/Ratings/CreateRatingDeleteTripListenerTest.php
+++ b/tests/Unit/Listeners/Ratings/CreateRatingDeleteTripListenerTest.php
@@ -141,4 +141,55 @@ class CreateRatingDeleteTripListenerTest extends TestCase
 
         (new CreateRatingDeleteTrip($ratingRepository))->handle(new TripDeleted($trip));
     }
+
+    public function test_handle_creates_pending_rating_for_passenger_removed_by_driver(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $passengerUser = User::factory()->create();
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+            'request_state' => Passenger::STATE_CANCELED,
+            'canceled_state' => Passenger::CANCELED_DRIVER,
+        ]);
+
+        $trip = $trip->fresh();
+
+        $ratingRepository = Mockery::mock(RatingRepository::class);
+        $ratingRepository->shouldReceive('create')
+            ->once()
+            ->withArgs(function ($userFromId, $userToId, $tripId, $userToType, $userToState, $hash) use ($passengerUser, $driver, $trip) {
+                return $userFromId === $passengerUser->id
+                    && $userToId === $driver->id
+                    && $tripId === $trip->id
+                    && $userToType === Passenger::TYPE_CONDUCTOR
+                    && $userToState === Passenger::STATE_ACCEPTED
+                    && is_string($hash)
+                    && strlen($hash) === 40;
+            })
+            ->andReturn((object) ['id' => 1]);
+
+        $this->mock(NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(3)
+            ->withArgs(function ($notification, $users, $channel) use ($trip, $driver, $passengerUser) {
+                if (! $notification instanceof DeleteTripNotification) {
+                    return false;
+                }
+
+                $hash = $notification->getAttribute('hash');
+
+                return $notification->getAttribute('trip')->is($trip)
+                    && $notification->getAttribute('from')->is($driver)
+                    && is_string($hash)
+                    && strlen($hash) === 40
+                    && $users instanceof User
+                    && $users->is($passengerUser)
+                    && is_string($channel);
+            });
+
+        (new CreateRatingDeleteTrip($ratingRepository))->handle(new TripDeleted($trip));
+    }
 }

--- a/tests/Unit/Models/PassengerTest.php
+++ b/tests/Unit/Models/PassengerTest.php
@@ -214,6 +214,27 @@ class PassengerTest extends TestCase
         $this->assertSame(2, Passenger::TYPE_CONDUCTORRECURRENTE);
     }
 
+    public function test_is_eligible_for_rating(): void
+    {
+        $accepted = Passenger::factory()->make(['request_state' => Passenger::STATE_ACCEPTED]);
+        $this->assertTrue($accepted->isEligibleForRating());
+
+        $canceledByDriver = Passenger::factory()->make([
+            'request_state' => Passenger::STATE_CANCELED,
+            'canceled_state' => Passenger::CANCELED_DRIVER,
+        ]);
+        $this->assertTrue($canceledByDriver->isEligibleForRating());
+
+        $canceledRequest = Passenger::factory()->make([
+            'request_state' => Passenger::STATE_CANCELED,
+            'canceled_state' => Passenger::CANCELED_REQUEST,
+        ]);
+        $this->assertFalse($canceledRequest->isEligibleForRating());
+
+        $pending = Passenger::factory()->make(['request_state' => Passenger::STATE_PENDING]);
+        $this->assertFalse($pending->isEligibleForRating());
+    }
+
     public function test_table_name_is_trip_passengers(): void
     {
         $this->assertSame('trip_passengers', (new Passenger)->getTable());


### PR DESCRIPTION
## Summary

Fix a loophole where drivers could accept passengers, remove them, delete the trip, and avoid receiving ratings from those passengers.

## Cause

When a trip is deleted, `CreateRatingDeleteTrip` only considered `passengerAccepted` (`STATE_ACCEPTED`). Passengers removed by the driver are `STATE_CANCELED` with `canceled_state = CANCELED_DRIVER`, so they were skipped. Because the trip is soft-deleted, the `rate:create` cron (`activeRatings`) never runs for it either — leaving removed passengers with no way to rate the driver.

## Fix (backend only)

- **`CreateRatingDeleteTrip`**: Evaluate all trip passengers using the same eligibility rules as `activeRatings` (accepted or canceled, excluding never-accepted `CANCELED_REQUEST`).
- **Idempotency**: Skip creating a rating if a pending one already exists for that passenger → driver on the trip.
- **Deduplication**: One rating per passenger user when multiple request rows exist.
- **`Passenger::isEligibleForRating()`**: Shared helper used by both trip-delete ratings and `RatingManager::activeRatings` to keep rules in sync.