### PR TITLE
Rate after trip

### DIFF
--- a/app/Console/Commands/CreateRates.php
+++ b/app/Console/Commands/CreateRates.php
@@ -4,7 +4,7 @@ namespace STS\Console\Commands;
 
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use STS\Services\Logic\RatingManager; 
+use STS\Services\Logic\RatingManager;
 
 class CreateRates extends Command
 {
@@ -42,8 +42,9 @@ class CreateRates extends Command
      */
     public function handle()
     {
-        \Log::info("COMMAND CreateRates");
+        \Log::info('COMMAND CreateRates');
+        $this->rateLogic->createEligibleRatings();
         $date = Carbon::now()->subDay()->toDateTimeString();
-        $this->rateLogic->activeRatings($date);
+        $this->rateLogic->sendRatingNotifications($date);
     }
 }

--- a/app/Helpers/RatingHelper.php
+++ b/app/Helpers/RatingHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace STS\Helpers;
+
+use Carbon\Carbon;
+
+class RatingHelper
+{
+    public const AVAILABLE_DURATION_FACTOR = 0.8;
+
+    public static function getRatingAvailableAt(Carbon $tripStart, ?string $estimatedTime): Carbon
+    {
+        $durationMinutes = OngoingTripHelper::estimatedTimeToMinutes($estimatedTime);
+        $availableAfterMinutes = (int) round($durationMinutes * self::AVAILABLE_DURATION_FACTOR);
+
+        return $tripStart->copy()->addMinutes($availableAfterMinutes);
+    }
+
+    public static function isRatingAvailable(
+        Carbon $now,
+        Carbon $tripStart,
+        ?string $estimatedTime
+    ): bool {
+        return $now->greaterThanOrEqualTo(self::getRatingAvailableAt($tripStart, $estimatedTime));
+    }
+}

--- a/app/Services/Logic/RatingManager.php
+++ b/app/Services/Logic/RatingManager.php
@@ -150,13 +150,10 @@ class RatingManager extends BaseManager
 
     public function sendRatingNotifications($when): void
     {
-        $criterias = [
+        $trips = $this->tripRepo->index($this->driverTripCriteria([
             ['key' => 'trip_date', 'value' => $when, 'op' => '<'],
             ['key' => 'mail_send', 'value' => false],
-            ['key' => 'is_passenger', 'value' => false],
-        ];
-
-        $trips = $this->tripRepo->index($criterias, ['user', 'passenger']);
+        ]), ['user', 'passenger']);
 
         foreach ($trips as $trip) {
             if (! Rating::query()->where('trip_id', $trip->id)->exists()) {
@@ -213,5 +210,16 @@ class RatingManager extends BaseManager
             event(new PendingEvent($rate->from, $trip, $rate->voted_hash));
             $notifiedUserIds[] = $rate->user_id_from;
         }
+    }
+
+    /**
+     * @param  list<array{key: string, value: mixed, op?: string}>  $extra
+     * @return list<array{key: string, value: mixed, op?: string}>
+     */
+    private function driverTripCriteria(array $extra = []): array
+    {
+        return array_merge([
+            ['key' => 'is_passenger', 'value' => false],
+        ], $extra);
     }
 }

--- a/app/Services/Logic/RatingManager.php
+++ b/app/Services/Logic/RatingManager.php
@@ -6,8 +6,10 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 use STS\Events\Rating\PendingRate as PendingEvent;
+use STS\Helpers\RatingHelper;
 use STS\Models\Passenger;
 use STS\Models\Rating;
+use STS\Models\Trip;
 use STS\Models\User;
 use STS\Repository\RatingRepository;
 use STS\Repository\TripRepository;
@@ -122,6 +124,32 @@ class RatingManager extends BaseManager
 
     public function activeRatings($when)
     {
+        $this->createEligibleRatings();
+        $this->sendRatingNotifications($when);
+    }
+
+    public function createEligibleRatings(): void
+    {
+        $now = Carbon::now();
+        $trips = Trip::query()
+            ->where('is_passenger', false)
+            ->where('mail_send', false)
+            ->where('trip_date', '<', $now)
+            ->whereDoesntHave('ratings')
+            ->with(['user', 'passenger'])
+            ->get();
+
+        foreach ($trips as $trip) {
+            if (! RatingHelper::isRatingAvailable($now, Carbon::parse($trip->trip_date), $trip->estimated_time)) {
+                continue;
+            }
+
+            $this->createRatingsForTrip($trip);
+        }
+    }
+
+    public function sendRatingNotifications($when): void
+    {
         $criterias = [
             ['key' => 'trip_date', 'value' => $when, 'op' => '<'],
             ['key' => 'mail_send', 'value' => false],
@@ -131,33 +159,59 @@ class RatingManager extends BaseManager
         $trips = $this->tripRepo->index($criterias, ['user', 'passenger']);
 
         foreach ($trips as $trip) {
-            $driver = $trip->user;
-            $driver_hash = Str::random(40);
-            $has_passenger = false;
-
-            $passengers = $trip->passenger()->orderBy('created_at', 'desc')->get();
-
-            $passenger_ids_rates_created = [];
-
-            foreach ($passengers as $passenger) {
-                if ($passenger->isEligibleForRating()) {
-                    // the passenger could be make more than one trip request
-                    if (! in_array($passenger->user->id, $passenger_ids_rates_created)) {
-                        $passenger_hash = Str::random(40);
-                        $rate = $this->ratingRepository->create($driver->id, $passenger->user_id, $trip->id, Passenger::TYPE_PASAJERO, $passenger->request_state, $driver_hash);
-
-                        $rate = $this->ratingRepository->create($passenger->user_id, $driver->id, $trip->id, Passenger::TYPE_CONDUCTOR, Passenger::STATE_ACCEPTED, $passenger_hash);
-                        $has_passenger = true;
-                        event(new PendingEvent($passenger->user, $trip, $passenger_hash));
-
-                        $passenger_ids_rates_created[] = $passenger->user->id;
-                    }
-                }
+            if (! Rating::query()->where('trip_id', $trip->id)->exists()) {
+                continue;
             }
-            if ($has_passenger) {
-                event(new PendingEvent($driver, $trip, $driver_hash));
-            }
+
+            $this->dispatchRatingNotificationsForTrip($trip);
             $this->tripRepo->update($trip, ['mail_send' => true]);
+        }
+    }
+
+    private function createRatingsForTrip(Trip $trip): bool
+    {
+        $driver = $trip->user;
+        $driver_hash = Str::random(40);
+        $has_passenger = false;
+        $passengers = $trip->passenger()->orderBy('created_at', 'desc')->get();
+        $passenger_ids_rates_created = [];
+
+        foreach ($passengers as $passenger) {
+            if (! $passenger->isEligibleForRating()) {
+                continue;
+            }
+
+            if (in_array($passenger->user->id, $passenger_ids_rates_created)) {
+                continue;
+            }
+
+            $passenger_hash = Str::random(40);
+            $this->ratingRepository->create($driver->id, $passenger->user_id, $trip->id, Passenger::TYPE_PASAJERO, $passenger->request_state, $driver_hash);
+            $this->ratingRepository->create($passenger->user_id, $driver->id, $trip->id, Passenger::TYPE_CONDUCTOR, Passenger::STATE_ACCEPTED, $passenger_hash);
+            $has_passenger = true;
+            $passenger_ids_rates_created[] = $passenger->user->id;
+        }
+
+        return $has_passenger;
+    }
+
+    private function dispatchRatingNotificationsForTrip(Trip $trip): void
+    {
+        $notifiedUserIds = [];
+
+        $pendingRatings = Rating::query()
+            ->where('trip_id', $trip->id)
+            ->where('voted', false)
+            ->with('from')
+            ->get();
+
+        foreach ($pendingRatings as $rate) {
+            if (in_array($rate->user_id_from, $notifiedUserIds)) {
+                continue;
+            }
+
+            event(new PendingEvent($rate->from, $trip, $rate->voted_hash));
+            $notifiedUserIds[] = $rate->user_id_from;
         }
     }
 }

--- a/tests/Unit/Console/Commands/CreateRatesTest.php
+++ b/tests/Unit/Console/Commands/CreateRatesTest.php
@@ -25,7 +25,8 @@ class CreateRatesTest extends TestCase
         Event::fake([MessageLogged::class]);
 
         $ratingManager = Mockery::mock(RatingManager::class);
-        $ratingManager->shouldReceive('activeRatings')
+        $ratingManager->shouldReceive('createEligibleRatings')->once();
+        $ratingManager->shouldReceive('sendRatingNotifications')
             ->once()
             ->with('2026-04-27 09:00:00');
 

--- a/tests/Unit/Helpers/RatingHelperTest.php
+++ b/tests/Unit/Helpers/RatingHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use Carbon\Carbon;
+use STS\Helpers\RatingHelper;
+use Tests\TestCase;
+
+class RatingHelperTest extends TestCase
+{
+    public function test_get_rating_available_at_is_trip_start_plus_eighty_percent_of_estimated_time(): void
+    {
+        $tripStart = Carbon::parse('2026-06-01 10:00:00');
+
+        $availableAt = RatingHelper::getRatingAvailableAt($tripStart, '02:00');
+
+        $this->assertSame('2026-06-01 11:36:00', $availableAt->format('Y-m-d H:i:s'));
+    }
+
+    public function test_get_rating_available_at_returns_trip_start_when_estimated_time_is_missing(): void
+    {
+        $tripStart = Carbon::parse('2026-06-01 10:00:00');
+
+        $this->assertSame(
+            '2026-06-01 10:00:00',
+            RatingHelper::getRatingAvailableAt($tripStart, null)->format('Y-m-d H:i:s')
+        );
+        $this->assertSame(
+            '2026-06-01 10:00:00',
+            RatingHelper::getRatingAvailableAt($tripStart, '')->format('Y-m-d H:i:s')
+        );
+    }
+
+    public function test_is_rating_available_returns_true_when_now_is_after_available_at(): void
+    {
+        $tripStart = Carbon::parse('2026-06-01 10:00:00');
+        $now = Carbon::parse('2026-06-01 11:36:00');
+
+        $this->assertTrue(RatingHelper::isRatingAvailable($now, $tripStart, '02:00'));
+    }
+
+    public function test_is_rating_available_returns_false_before_eighty_percent_of_estimated_time(): void
+    {
+        $tripStart = Carbon::parse('2026-06-01 10:00:00');
+        $now = Carbon::parse('2026-06-01 11:35:00');
+
+        $this->assertFalse(RatingHelper::isRatingAvailable($now, $tripStart, '02:00'));
+    }
+}

--- a/tests/Unit/Services/Logic/RatingManagerTest.php
+++ b/tests/Unit/Services/Logic/RatingManagerTest.php
@@ -535,7 +535,7 @@ class RatingManagerTest extends TestCase
         $repo->create($driver->id, $passengerUser->id, $trip->id, 0, 0, 'drv-'.uniqid('', true));
         $repo->create($passengerUser->id, $driver->id, $trip->id, 0, 0, 'psg-'.uniqid('', true));
 
-        $this->manager()->sendRatingNotifications('2026-06-01 10:00:00');
+        $this->manager()->sendRatingNotifications('2026-06-01 11:00:00');
 
         $this->assertSame(2, Rating::query()->where('trip_id', $trip->id)->count());
         $this->assertSame(1, (int) $trip->fresh()->mail_send);

--- a/tests/Unit/Services/Logic/RatingManagerTest.php
+++ b/tests/Unit/Services/Logic/RatingManagerTest.php
@@ -453,4 +453,94 @@ class RatingManagerTest extends TestCase
 
         Carbon::setTestNow();
     }
+
+    public function test_create_eligible_ratings_creates_pending_rows_after_eighty_percent_of_estimated_time_without_notification(): void
+    {
+        Event::fake([PendingRateEvent::class]);
+        Carbon::setTestNow('2026-06-01 14:00:00');
+
+        $driver = User::factory()->create();
+        $passengerUser = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => '2026-06-01 10:00:00',
+            'estimated_time' => '04:00',
+            'mail_send' => false,
+            'is_passenger' => false,
+        ]);
+
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+        ]);
+
+        $this->manager()->createEligibleRatings();
+
+        $this->assertSame(2, Rating::query()->where('trip_id', $trip->id)->count());
+        $this->assertSame(0, (int) $trip->fresh()->mail_send);
+        Event::assertNotDispatched(PendingRateEvent::class);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_create_eligible_ratings_skips_trips_before_eighty_percent_of_estimated_time(): void
+    {
+        Event::fake([PendingRateEvent::class]);
+        Carbon::setTestNow('2026-06-01 12:00:00');
+
+        $driver = User::factory()->create();
+        $passengerUser = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => '2026-06-01 10:00:00',
+            'estimated_time' => '04:00',
+            'mail_send' => false,
+            'is_passenger' => false,
+        ]);
+
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+        ]);
+
+        $this->manager()->createEligibleRatings();
+
+        $this->assertSame(0, Rating::query()->where('trip_id', $trip->id)->count());
+        Event::assertNotDispatched(PendingRateEvent::class);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_send_rating_notifications_dispatches_events_after_twenty_four_hours_without_recreating_ratings(): void
+    {
+        Event::fake([PendingRateEvent::class]);
+        Carbon::setTestNow('2026-06-02 11:00:00');
+
+        $driver = User::factory()->create();
+        $passengerUser = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => '2026-06-01 10:00:00',
+            'estimated_time' => '04:00',
+            'mail_send' => false,
+            'is_passenger' => false,
+        ]);
+
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerUser->id,
+        ]);
+
+        $repo = new RatingRepository;
+        $repo->create($driver->id, $passengerUser->id, $trip->id, 0, 0, 'drv-'.uniqid('', true));
+        $repo->create($passengerUser->id, $driver->id, $trip->id, 0, 0, 'psg-'.uniqid('', true));
+
+        $this->manager()->sendRatingNotifications('2026-06-01 10:00:00');
+
+        $this->assertSame(2, Rating::query()->where('trip_id', $trip->id)->count());
+        $this->assertSame(1, (int) $trip->fresh()->mail_send);
+        Event::assertDispatched(PendingRateEvent::class, 2);
+
+        Carbon::setTestNow();
+    }
 }


### PR DESCRIPTION
## Summary

Users can now rate a trip earlier — once 80% of the estimated trip duration has elapsed — while push notifications still go out 24 hours after trip start.

## Cause

Rating eligibility was tied to the same 24-hour cron job that creates rating records and sends notifications. Users had to wait a full day before they could rate, even if the trip had clearly ended much earlier.

## Fix

### Backend (`carpoolear_backend`)

- Added `RatingHelper` to compute when rating becomes available: `trip_date + (estimated_time × 80%)`.
- Split `RatingManager::activeRatings()` into two responsibilities:
  - **`createEligibleRatings()`** — creates pending rating rows when 80% of estimated time has passed (no notification).
  - **`sendRatingNotifications()`** — dispatches `PendingRate` events and sets `mail_send` when 24 hours have passed since trip start.
- Updated `rate:create` command to run both steps on each hourly execution.
