### PR TITLE
Advanced filters in search

### DIFF
--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -562,16 +562,7 @@ class TripRepository
         }
 
         if (isset($data['hide_carpooleado']) && parse_boolean($data['hide_carpooleado'])) {
-            $trips->whereRaw(
-                'trips.total_seats > (
-                    SELECT COUNT(*)
-                    FROM trip_passengers
-                    WHERE trip_passengers.trip_id = trips.id
-                    AND trip_passengers.request_state = ?
-                    AND trip_passengers.user_id <> trips.user_id
-                )',
-                [Passenger::STATE_ACCEPTED]
-            );
+            $this->excludeCarpooleadoTrips($trips);
         }
 
         $trips->with([
@@ -618,6 +609,20 @@ class TripRepository
             }
             $q->whereRaw('sin_lat * '.$sin_lat.' + cos_lat * '.$cos_lat.' *  (cos_lng * '.$cos_lng.' + sin_lng * '.$sin_lng.') > '.$dist);
         });
+    }
+
+    private function excludeCarpooleadoTrips($trips): void
+    {
+        $trips->whereRaw(
+            'trips.total_seats > (
+                SELECT COUNT(*)
+                FROM trip_passengers
+                WHERE trip_passengers.trip_id = trips.id
+                AND trip_passengers.request_state = ?
+                AND trip_passengers.user_id <> trips.user_id
+            )',
+            [Passenger::STATE_ACCEPTED]
+        );
     }
 
     private function applyAcceptedPassengerFilter($query, $userId): void

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -561,6 +561,19 @@ class TripRepository
             }
         }
 
+        if (isset($data['hide_carpooleado']) && parse_boolean($data['hide_carpooleado'])) {
+            $trips->whereRaw(
+                'trips.total_seats > (
+                    SELECT COUNT(*)
+                    FROM trip_passengers
+                    WHERE trip_passengers.trip_id = trips.id
+                    AND trip_passengers.request_state = ?
+                    AND trip_passengers.user_id <> trips.user_id
+                )',
+                [Passenger::STATE_ACCEPTED]
+            );
+        }
+
         $trips->with([
             'user',
             'user.accounts',

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -561,6 +561,8 @@ class TripRepository
             }
         }
 
+        $this->applyAllowPreferenceFilters($trips, $data);
+
         if (isset($data['hide_carpooleado']) && parse_boolean($data['hide_carpooleado'])) {
             $this->excludeCarpooleadoTrips($trips);
         }
@@ -609,6 +611,15 @@ class TripRepository
             }
             $q->whereRaw('sin_lat * '.$sin_lat.' + cos_lat * '.$cos_lat.' *  (cos_lng * '.$cos_lng.' + sin_lng * '.$sin_lng.') > '.$dist);
         });
+    }
+
+    private function applyAllowPreferenceFilters($trips, array $data): void
+    {
+        foreach (['allow_animals', 'allow_smoking', 'allow_kids'] as $allowField) {
+            if (isset($data[$allowField])) {
+                $trips->where($allowField, parse_boolean($data[$allowField]) ? 1 : 0);
+            }
+        }
     }
 
     private function excludeCarpooleadoTrips($trips): void

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -4145,4 +4145,64 @@ class TripRepositoryTest extends TestCase
         $this->assertTrue($filteredIds->contains($available->id));
         $this->assertFalse($filteredIds->contains($full->id));
     }
+
+    public function test_search_filters_by_allow_preference_flags_when_set(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+
+        $allowsAnimals = Trip::factory()->create([
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+            'allow_animals' => true,
+            'allow_smoking' => false,
+            'allow_kids' => false,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+        $allowsSmoking = Trip::factory()->create([
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+            'allow_animals' => false,
+            'allow_smoking' => true,
+            'allow_kids' => false,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+        $allowsKids = Trip::factory()->create([
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+            'allow_animals' => false,
+            'allow_smoking' => false,
+            'allow_kids' => true,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+
+        $animalsOnly = collect($this->repo()->search($admin, [
+            'allow_animals' => 'true',
+            'page' => 1,
+            'page_size' => 10,
+        ])->items())->pluck('id');
+        $this->assertTrue($animalsOnly->contains($allowsAnimals->id));
+        $this->assertFalse($animalsOnly->contains($allowsSmoking->id));
+        $this->assertFalse($animalsOnly->contains($allowsKids->id));
+
+        $noSmoking = collect($this->repo()->search($admin, [
+            'allow_smoking' => 'false',
+            'page' => 1,
+            'page_size' => 10,
+        ])->items())->pluck('id');
+        $this->assertTrue($noSmoking->contains($allowsAnimals->id));
+        $this->assertFalse($noSmoking->contains($allowsSmoking->id));
+        $this->assertTrue($noSmoking->contains($allowsKids->id));
+
+        $all = collect($this->repo()->search($admin, [
+            'page' => 1,
+            'page_size' => 10,
+        ])->items())->pluck('id');
+        $this->assertTrue($all->contains($allowsAnimals->id));
+        $this->assertTrue($all->contains($allowsSmoking->id));
+        $this->assertTrue($all->contains($allowsKids->id));
+    }
 }

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -4100,4 +4100,49 @@ class TripRepositoryTest extends TestCase
 
         $this->assertSame(0, (int) DB::table('user_visibility_trip')->where('trip_id', $publicTrip->id)->count());
     }
+
+    public function test_search_hides_carpooleado_trips_when_hide_carpooleado_is_true(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+
+        $available = Trip::factory()->create([
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+            'total_seats' => 2,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+
+        $full = Trip::factory()->create([
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+            'total_seats' => 1,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+        Passenger::factory()->aceptado()->create([
+            'trip_id' => $full->id,
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        $this->assertSame(0, (int) $full->fresh()->seats_available);
+
+        $all = $this->repo()->search($admin, [
+            'page' => 1,
+            'page_size' => 10,
+        ]);
+        $allIds = collect($all->items())->pluck('id');
+        $this->assertTrue($allIds->contains($available->id));
+        $this->assertTrue($allIds->contains($full->id));
+
+        $filtered = $this->repo()->search($admin, [
+            'hide_carpooleado' => 'true',
+            'page' => 1,
+            'page_size' => 10,
+        ]);
+        $filteredIds = collect($filtered->items())->pluck('id');
+        $this->assertTrue($filteredIds->contains($available->id));
+        $this->assertFalse($filteredIds->contains($full->id));
+    }
 }


### PR DESCRIPTION
## Summary

Adds advanced search filters to help users narrow trip results by preferences and availability.

### Backend (`carpoolear_backend`)

**Cause:** Trip search API could not filter by preference flags or exclude full trips server-side.

**Fix:**
- `TripRepository::search()` honors `hide_carpooleado` — excludes trips with no seats left
- Honors `allow_animals`, `allow_smoking`, `allow_kids` when provided (boolean true/false); omitted params mean "any"
- Logic extracted to `excludeCarpooleadoTrips()` and `applyAllowPreferenceFilters()` helpers
