### PR TITLE
Friend changes

### DIFF
--- a/app/Http/Controllers/Api/v1/FriendsController.php
+++ b/app/Http/Controllers/Api/v1/FriendsController.php
@@ -99,4 +99,18 @@ class FriendsController extends Controller
 
         return $this->collection($users, new ProfileTransformer($this->user));
     }
+
+    public function toggleTripAlerts(Request $request, $id)
+    {
+        $this->user = auth()->user();
+        $friend = $this->users->find($id);
+        if ($friend) {
+            $enabled = $this->friends->toggleTripAlerts($this->user, $friend);
+            if ($enabled !== null) {
+                return response()->json(['friend_trip_alerts_enabled' => $enabled]);
+            }
+        }
+
+        throw new ExceptionWithErrors('Bad request exceptions', $this->friends->getErrors());
+    }
 }

--- a/app/Http/Controllers/Api/v1/FriendsController.php
+++ b/app/Http/Controllers/Api/v1/FriendsController.php
@@ -100,6 +100,28 @@ class FriendsController extends Controller
         return $this->collection($users, new ProfileTransformer($this->user));
     }
 
+    public function sentPendings(Request $request)
+    {
+        $this->user = auth()->user();
+        $users = $this->friends->getSentPendings($this->user);
+
+        return $this->collection($users, new ProfileTransformer($this->user));
+    }
+
+    public function cancelRequest(Request $request, $id)
+    {
+        $this->user = auth()->user();
+        $friend = $this->users->find($id);
+        if ($friend) {
+            $ret = $this->friends->cancelRequest($this->user, $friend);
+            if ($ret) {
+                return response()->json('OK');
+            }
+        }
+
+        throw new ExceptionWithErrors('Bad request exceptions', $this->friends->getErrors());
+    }
+
     public function toggleTripAlerts(Request $request, $id)
     {
         $this->user = auth()->user();

--- a/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
@@ -12,6 +12,7 @@ use STS\Models\CampaignDonation;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\PaymentAttempt;
 use STS\Models\Trip;
+use STS\Services\FriendTripAlertService;
 use STS\Services\Logic\ConversationsManager;
 use STS\Services\Logic\TripsManager;
 
@@ -291,6 +292,7 @@ class MercadoPagoWebhookController extends Controller
     {
         if ($paymentStatus === PaymentAttempt::STATUS_COMPLETED) {
             $trip->setStateReady()->save();
+            app(FriendTripAlertService::class)->notifyIfVisible($trip->fresh());
         } elseif ($paymentStatus === PaymentAttempt::STATUS_FAILED) {
             $trip->setStatePaymentFailed()->save();
         } elseif ($paymentStatus === PaymentAttempt::STATUS_PENDING) {

--- a/app/Http/Controllers/Api/v1/TripController.php
+++ b/app/Http/Controllers/Api/v1/TripController.php
@@ -85,6 +85,18 @@ class TripController extends Controller
         return response()->json(['data' => 'ok']);
     }
 
+    public function inviteFriends($id, Request $request)
+    {
+        $this->user = auth()->user();
+        $friendIds = $request->get('friend_ids', []);
+        $count = $this->tripsLogic->inviteFriends($this->user, $id, $friendIds);
+        if ($count === null) {
+            throw new ExceptionWithErrors('Could not invite friends.', $this->tripsLogic->getErrors());
+        }
+
+        return response()->json(['invited_count' => $count]);
+    }
+
     public function show($id, Request $request)
     {
         if (OldCordovaAppHelper::isOldCordovaApp()) {

--- a/app/Models/FriendTripAlertSubscription.php
+++ b/app/Models/FriendTripAlertSubscription.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FriendTripAlertSubscription extends Model
+{
+    protected $table = 'friend_trip_alert_subscriptions';
+
+    protected $fillable = [
+        'user_id',
+        'friend_id',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function friend(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'friend_id');
+    }
+}

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -99,6 +99,7 @@ class Trip extends Model
             'state',
             'payment_id',
             'needs_sellado',
+            'autoaccept_friends_requests',
         ];
     }
 

--- a/app/Notifications/FriendCreatedTripNotification.php
+++ b/app/Notifications/FriendCreatedTripNotification.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace STS\Notifications;
+
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\MailChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+
+class FriendCreatedTripNotification extends BaseNotification
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->via = [
+            DatabaseChannel::class,
+            MailChannel::class,
+            PushChannel::class,
+        ];
+    }
+
+    public function toEmail($user)
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+        $driverName = $driver ? $driver->name : __('notifications.someone');
+        $destination = $trip ? $trip->to_town : __('notifications.destination_unknown');
+        $date = $this->tripDate($trip);
+        $time = $this->tripTime($trip);
+
+        return [
+            'title' => __('notifications.friend_created_trip.title', [
+                'name' => $driverName,
+                'destination' => $destination,
+            ]),
+            'email_view' => 'subscription_match',
+            'url' => config('app.url').'/app/trips/'.($trip ? $trip->id : ''),
+            'name_app' => config('carpoolear.name_app'),
+            'domain' => config('app.url'),
+            'message' => __('notifications.friend_created_trip.message', [
+                'name' => $driverName,
+                'destination' => $destination,
+                'date' => $date,
+                'time' => $time,
+            ]),
+        ];
+    }
+
+    public function toString()
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+        $driverName = $driver ? $driver->name : __('notifications.someone');
+        $destination = $trip ? $trip->to_town : __('notifications.destination_unknown');
+
+        return __('notifications.friend_created_trip.message', [
+            'name' => $driverName,
+            'destination' => $destination,
+            'date' => $this->tripDate($trip),
+            'time' => $this->tripTime($trip),
+        ]);
+    }
+
+    public function getExtras()
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+
+        return [
+            'type' => 'friend_trip',
+            'trip_id' => $trip ? $trip->id : null,
+            'user_id' => $driver ? $driver->id : null,
+        ];
+    }
+
+    public function toPush($user, $device)
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+        $driverName = $driver ? $driver->name : __('notifications.someone');
+        $destination = $trip ? $trip->to_town : __('notifications.destination_unknown');
+
+        return [
+            'message' => __('notifications.friend_created_trip.message', [
+                'name' => $driverName,
+                'destination' => $destination,
+                'date' => $this->tripDate($trip),
+                'time' => $this->tripTime($trip),
+            ]),
+            'url' => '/trips/'.($trip ? $trip->id : ''),
+            'extras' => [
+                'id' => $trip ? $trip->id : null,
+            ],
+            'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
+        ];
+    }
+
+    private function tripDate($trip): string
+    {
+        if (! $trip || ! $trip->trip_date) {
+            return __('notifications.date_not_available');
+        }
+
+        return $trip->trip_date->format('d/m/Y');
+    }
+
+    private function tripTime($trip): string
+    {
+        if (! $trip || ! $trip->trip_date) {
+            return __('notifications.date_not_available');
+        }
+
+        return $trip->trip_date->format('H:i');
+    }
+}

--- a/app/Notifications/FriendTripInviteNotification.php
+++ b/app/Notifications/FriendTripInviteNotification.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace STS\Notifications;
+
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\MailChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+
+class FriendTripInviteNotification extends BaseNotification
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->via = [
+            DatabaseChannel::class,
+            MailChannel::class,
+            PushChannel::class,
+        ];
+    }
+
+    public function toEmail($user)
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+        $driverName = $driver ? $driver->name : __('notifications.someone');
+        $destination = $trip ? $trip->to_town : __('notifications.destination_unknown');
+
+        return [
+            'title' => __('notifications.friend_trip_invite.title', [
+                'name' => $driverName,
+                'destination' => $destination,
+            ]),
+            'email_view' => 'subscription_match',
+            'url' => config('app.url').'/app/trips/'.($trip ? $trip->id : ''),
+            'name_app' => config('carpoolear.name_app'),
+            'domain' => config('app.url'),
+            'message' => __('notifications.friend_trip_invite.message', [
+                'name' => $driverName,
+                'destination' => $destination,
+                'date' => $this->tripDate($trip),
+                'time' => $this->tripTime($trip),
+            ]),
+        ];
+    }
+
+    public function toString()
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+        $driverName = $driver ? $driver->name : __('notifications.someone');
+        $destination = $trip ? $trip->to_town : __('notifications.destination_unknown');
+
+        return __('notifications.friend_trip_invite.message', [
+            'name' => $driverName,
+            'destination' => $destination,
+            'date' => $this->tripDate($trip),
+            'time' => $this->tripTime($trip),
+        ]);
+    }
+
+    public function getExtras()
+    {
+        $trip = $this->getAttribute('trip');
+
+        return [
+            'type' => 'friend_trip_invite',
+            'trip_id' => $trip ? $trip->id : null,
+        ];
+    }
+
+    public function toPush($user, $device)
+    {
+        $trip = $this->getAttribute('trip');
+        $driver = $this->getAttribute('driver');
+        $driverName = $driver ? $driver->name : __('notifications.someone');
+        $destination = $trip ? $trip->to_town : __('notifications.destination_unknown');
+
+        return [
+            'message' => __('notifications.friend_trip_invite.message', [
+                'name' => $driverName,
+                'destination' => $destination,
+                'date' => $this->tripDate($trip),
+                'time' => $this->tripTime($trip),
+            ]),
+            'url' => '/trips/'.($trip ? $trip->id : ''),
+            'extras' => [
+                'id' => $trip ? $trip->id : null,
+            ],
+            'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
+        ];
+    }
+
+    private function tripDate($trip): string
+    {
+        if (! $trip || ! $trip->trip_date) {
+            return __('notifications.date_not_available');
+        }
+
+        return $trip->trip_date->format('d/m/Y');
+    }
+
+    private function tripTime($trip): string
+    {
+        if (! $trip || ! $trip->trip_date) {
+            return __('notifications.date_not_available');
+        }
+
+        return $trip->trip_date->format('H:i');
+    }
+}

--- a/app/Repository/FriendTripAlertRepository.php
+++ b/app/Repository/FriendTripAlertRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace STS\Repository;
+
+use STS\Models\FriendTripAlertSubscription;
+use STS\Models\User as UserModel;
+
+class FriendTripAlertRepository
+{
+    public function subscribe(UserModel $user, UserModel $friend): void
+    {
+        FriendTripAlertSubscription::firstOrCreate([
+            'user_id' => $user->id,
+            'friend_id' => $friend->id,
+        ]);
+    }
+
+    public function unsubscribe(UserModel $user, UserModel $friend): void
+    {
+        FriendTripAlertSubscription::where('user_id', $user->id)
+            ->where('friend_id', $friend->id)
+            ->delete();
+    }
+
+    public function toggle(UserModel $user, UserModel $friend): bool
+    {
+        if ($this->isSubscribed($user, $friend)) {
+            $this->unsubscribe($user, $friend);
+
+            return false;
+        }
+
+        $this->subscribe($user, $friend);
+
+        return true;
+    }
+
+    public function isSubscribed(UserModel $user, UserModel $friend): bool
+    {
+        return FriendTripAlertSubscription::where('user_id', $user->id)
+            ->where('friend_id', $friend->id)
+            ->exists();
+    }
+
+    public function getSubscribersForDriver(UserModel $driver)
+    {
+        return UserModel::whereIn('id', function ($query) use ($driver) {
+            $query->select('user_id')
+                ->from('friend_trip_alert_subscriptions')
+                ->where('friend_id', $driver->id);
+        })->get();
+    }
+
+    public function deleteForUsers(UserModel $user1, UserModel $user2): void
+    {
+        FriendTripAlertSubscription::where(function ($query) use ($user1, $user2) {
+            $query->where('user_id', $user1->id)->where('friend_id', $user2->id);
+        })->orWhere(function ($query) use ($user1, $user2) {
+            $query->where('user_id', $user2->id)->where('friend_id', $user1->id);
+        })->delete();
+    }
+}

--- a/app/Repository/FriendsRepository.php
+++ b/app/Repository/FriendsRepository.php
@@ -2,12 +2,10 @@
 
 namespace STS\Repository;
 
-use STS\Models\User as UserModel;
+use DB;
 use STS\Models\Trip as TripModel;
 use STS\Models\TripVisibility as TripVisibilityModel;
-
-use DB;
-
+use STS\Models\User as UserModel;
 
 class FriendsRepository
 {
@@ -25,7 +23,7 @@ class FriendsRepository
         $this->undoFriendTripVisibility($user1, $user2);
     }
 
-    public function get(UserModel $user1, UserModel $user2 = null, $state = null, $data = [])
+    public function get(UserModel $user1, ?UserModel $user2 = null, $state = null, $data = [])
     {
         $pageNumber = isset($data['page']) ? $data['page'] : null;
         $pageSize = isset($data['page_size']) ? $data['page_size'] : null;
@@ -57,19 +55,25 @@ class FriendsRepository
         return $users->get();
     }
 
-    public function closestFriend(UserModel $user1, UserModel $user2 = null)
+    public function getSentPending(UserModel $user)
+    {
+        return $user->allFriends(UserModel::FRIEND_REQUEST)->get();
+    }
+
+    public function closestFriend(UserModel $user1, ?UserModel $user2 = null)
     {
         $friends = $user1->friends()
-                         ->whereHas('friends',
-                            function ($q) use ($user2) {
-                                $q->whereId($user2->id);
-                            }
-                         )->count();
+            ->whereHas('friends',
+                function ($q) use ($user2) {
+                    $q->whereId($user2->id);
+                }
+            )->count();
 
         return $friends > 0;
     }
 
-    public function generateFriendTripVisibility ($requestedUser, $userAccepted) {
+    public function generateFriendTripVisibility($requestedUser, $userAccepted)
+    {
         // somos amigos
         // ahora deberia ver todos los viajes que publicaste como only friends
         // tambien deberia ver los viajes de amigos de amigos publicados como FoF
@@ -80,19 +84,18 @@ class FriendsRepository
         $ownTrips->each(function ($t) use (&$data, $requestedUser) {
             $data[] = [
                 'user_id' => $requestedUser->id,
-                'trip_id' => $t->id
+                'trip_id' => $t->id,
             ];
         });
 
-
         $friendsTrips = $userAccepted->friends()->each(function ($f) use (&$data, $requestedUser) {
-            
+
             $friendTrips = $f->trips(TripModel::ACTIVO)->where('friendship_type_id', TripModel::PRIVACY_FOF);
             // \Log::info($f->name . ': ' . $friendTrips->count());
             $friendTrips->each(function ($t) use (&$data, $requestedUser) {
                 $data[] = [
                     'user_id' => $requestedUser->id,
-                    'trip_id' => $t->id
+                    'trip_id' => $t->id,
                 ];
             });
         });
@@ -102,21 +105,22 @@ class FriendsRepository
         }
     }
 
-    public function undoFriendTripVisibility ($requestedUser, $userRejected) {
+    public function undoFriendTripVisibility($requestedUser, $userRejected)
+    {
         $ownTrips = $userRejected->trips(TripModel::ACTIVO)->where('friendship_type_id', '<', TripModel::PRIVACY_PUBLIC);
 
         $data = [];
         // \Log::info($userRejected->name . ': ' . $ownTrips->count());
 
         $ownTrips->each(function ($t) use (&$data, $requestedUser) {
-            $data[] = [ $requestedUser->id, $t->id ];
+            $data[] = [$requestedUser->id, $t->id];
         });
 
         $userRejected->friends()->each(function ($f) use (&$data, $requestedUser) {
             $friendTrips = $f->trips(TripModel::ACTIVO)->where('friendship_type_id', TripModel::PRIVACY_FOF);
             // \Log::info($f->name . ': ' . $friendTrips->count());
             $friendTrips->each(function ($t) use (&$data, $requestedUser) {
-                $data[] = [ $requestedUser->id, $t->id ];
+                $data[] = [$requestedUser->id, $t->id];
             });
         });
 
@@ -125,7 +129,6 @@ class FriendsRepository
         foreach ($data as $row) {
             DB::delete('DELETE FROM user_visibility_trip WHERE user_id = ? AND trip_id = ?', $row);
         }
-
 
     }
 }

--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -118,17 +118,14 @@ class UserRepository
         $users->orderBy('name');
         $users = $users->get();
 
-        $users = $users->map(function ($item, $key) use ($user) {
-            $u = $user->allFriends()->withPivot('state')->where('id', $item->id)->first();
-            if ($u) {
-                if ($u->pivot->state == User::FRIEND_REQUEST) {
-                    $item->state = 'request';
-                } else {
-                    $item->state = 'friend';
-                }
-            } else {
-                $item->state = 'none';
-            }
+        $friendsManager = app(\STS\Services\Logic\FriendsManager::class);
+        $users = $users->map(function ($item) use ($user, $friendsManager) {
+            $friendshipState = $friendsManager->getFriendshipState($user, $item);
+            $item->state = match ($friendshipState) {
+                'friend' => 'friend',
+                'pending_sent', 'pending_received' => 'request',
+                default => 'none',
+            };
 
             return $item;
         });

--- a/app/Services/FriendTripAlertService.php
+++ b/app/Services/FriendTripAlertService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace STS\Services;
+
+use Carbon\Carbon;
+use STS\Models\Trip;
+use STS\Notifications\FriendCreatedTripNotification;
+use STS\Repository\FriendTripAlertRepository;
+use STS\Services\Logic\TripsManager;
+
+class FriendTripAlertService
+{
+    protected FriendTripAlertRepository $alertRepo;
+
+    protected TripsManager $tripsManager;
+
+    public function __construct(FriendTripAlertRepository $alertRepo, TripsManager $tripsManager)
+    {
+        $this->alertRepo = $alertRepo;
+        $this->tripsManager = $tripsManager;
+    }
+
+    public function notifyIfVisible(Trip $trip): void
+    {
+        if ($trip->friend_trip_alert_sent_at) {
+            return;
+        }
+
+        $driver = $trip->user;
+        $subscribers = $this->alertRepo->getSubscribersForDriver($driver);
+
+        if ($subscribers->isEmpty()) {
+            return;
+        }
+
+        $notified = false;
+
+        foreach ($subscribers as $subscriber) {
+            if (! $this->tripsManager->userCanSeeTrip($subscriber, $trip)) {
+                continue;
+            }
+
+            $notification = new FriendCreatedTripNotification;
+            $notification->setAttribute('trip', $trip);
+            $notification->setAttribute('driver', $driver);
+            $notification->notify($subscriber);
+            $notified = true;
+        }
+
+        if ($notified) {
+            $trip->friend_trip_alert_sent_at = Carbon::now();
+            $trip->save();
+        }
+    }
+
+    public function isImmediatelyVisible(Trip $trip): bool
+    {
+        if ($trip->needs_sellado && $trip->state !== Trip::STATE_READY) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Services/Logic/FriendsManager.php
+++ b/app/Services/Logic/FriendsManager.php
@@ -2,12 +2,12 @@
 
 namespace STS\Services\Logic;
 
-use STS\Repository\FriendsRepository;
-use STS\Models\User as UserModel;
+use STS\Events\Friend\Accept as AcceptEvent;
 use STS\Events\Friend\Cancel as CancelEvent;
-use STS\Events\Friend\Accept  as AcceptEvent;
-use STS\Events\Friend\Reject  as RejectEvent;
-use STS\Events\Friend\Request as RequestEvent; 
+use STS\Events\Friend\Reject as RejectEvent;
+use STS\Events\Friend\Request as RequestEvent;
+use STS\Models\User as UserModel;
+use STS\Repository\FriendsRepository;
 
 class FriendsManager extends BaseManager
 {
@@ -54,7 +54,8 @@ class FriendsManager extends BaseManager
             $this->friendsRepo->add($who, $user, UserModel::FRIEND_ACCEPTED);
             $this->friendsRepo->add($user, $who, UserModel::FRIEND_ACCEPTED);
             event(new AcceptEvent($who, $user));
-            // tengo que 
+
+            // tengo que
             return true;
         } else {
             $this->setErrors(['error' => 'Operación inválida']);
@@ -67,7 +68,7 @@ class FriendsManager extends BaseManager
     {
         if ($this->friendsRepo->get($user, $who, UserModel::FRIEND_REQUEST)->count() > 0) {
             $this->friendsRepo->delete($user, $who);
-            //$this->friendsRepo->add($who, $user, UserModel::FRIEND_REJECT );
+            // $this->friendsRepo->add($who, $user, UserModel::FRIEND_REJECT );
             event(new RejectEvent($who, $user));
 
             return true;
@@ -111,5 +112,22 @@ class FriendsManager extends BaseManager
     public function getPendings(UserModel $who)
     {
         return $this->friendsRepo->getPending($who);
+    }
+
+    public function getFriendshipState(UserModel $viewer, UserModel $profileUser): string
+    {
+        if ($this->areFriend($viewer, $profileUser)) {
+            return 'friend';
+        }
+
+        if ($this->friendsRepo->get($viewer, $profileUser, UserModel::FRIEND_REQUEST)->count() > 0) {
+            return 'pending_sent';
+        }
+
+        if ($this->friendsRepo->get($profileUser, $viewer, UserModel::FRIEND_REQUEST)->count() > 0) {
+            return 'pending_received';
+        }
+
+        return 'none';
     }
 }

--- a/app/Services/Logic/FriendsManager.php
+++ b/app/Services/Logic/FriendsManager.php
@@ -8,14 +8,18 @@ use STS\Events\Friend\Reject as RejectEvent;
 use STS\Events\Friend\Request as RequestEvent;
 use STS\Models\User as UserModel;
 use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
 
 class FriendsManager extends BaseManager
 {
     protected $friendsRepo;
 
-    public function __construct(FriendsRepository $friends)
+    protected $friendTripAlertRepo;
+
+    public function __construct(FriendsRepository $friends, FriendTripAlertRepository $friendTripAlertRepo)
     {
         $this->friendsRepo = $friends;
+        $this->friendTripAlertRepo = $friendTripAlertRepo;
     }
 
     public function areFriend(UserModel $who, UserModel $user, $friendOfFriends = false)
@@ -84,6 +88,7 @@ class FriendsManager extends BaseManager
         if ($this->friendsRepo->get($who, $user, UserModel::FRIEND_ACCEPTED)->count() > 0) {
             $this->friendsRepo->delete($who, $user);
             $this->friendsRepo->delete($user, $who);
+            $this->friendTripAlertRepo->deleteForUsers($who, $user);
             event(new CancelEvent($who, $user));
 
             return true;
@@ -129,5 +134,16 @@ class FriendsManager extends BaseManager
         }
 
         return 'none';
+    }
+
+    public function toggleTripAlerts(UserModel $who, UserModel $friend)
+    {
+        if (! $this->areFriend($who, $friend)) {
+            $this->setErrors(['error' => 'Operación inválida']);
+
+            return;
+        }
+
+        return $this->friendTripAlertRepo->toggle($who, $friend);
     }
 }

--- a/app/Services/Logic/FriendsManager.php
+++ b/app/Services/Logic/FriendsManager.php
@@ -119,6 +119,23 @@ class FriendsManager extends BaseManager
         return $this->friendsRepo->getPending($who);
     }
 
+    public function getSentPendings(UserModel $who)
+    {
+        return $this->friendsRepo->getSentPending($who);
+    }
+
+    public function cancelRequest(UserModel $who, UserModel $user)
+    {
+        if ($this->friendsRepo->get($who, $user, UserModel::FRIEND_REQUEST)->count() > 0) {
+            $this->friendsRepo->delete($who, $user);
+
+            return true;
+        }
+
+        $this->setErrors(['error' => 'Operación inválida']);
+
+    }
+
     public function getFriendshipState(UserModel $viewer, UserModel $profileUser): string
     {
         if ($this->areFriend($viewer, $profileUser)) {

--- a/app/Services/Logic/PassengersManager.php
+++ b/app/Services/Logic/PassengersManager.php
@@ -136,7 +136,10 @@ class PassengersManager extends BaseManager
             }
 
             if ($result = $this->passengerRepository->newRequest($tripId, $user, $data)) {
-                if ($trip->user->autoaccept_requests) {
+                $friendsManager = app(FriendsManager::class);
+                $shouldAutoAccept = $trip->user->autoaccept_requests
+                    || ($trip->autoaccept_friends_requests && $friendsManager->areFriend($user, $trip->user));
+                if ($shouldAutoAccept) {
                     // $result = $this->passengerRepository->acceptRequest($tripId, $user->id, $trip->user, $data);
                     if (! config('carpoolear.module_trip_seats_payment', false)) {
                         if ($result = $this->passengerRepository->acceptRequest($tripId, $user->id, $trip->user, $data)) {

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -46,6 +46,7 @@ class TripsManager extends BaseManager
                 'weekly_schedule' => 'required_without:trip_date|nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
                 'seat_price_cents' => $this->seatPriceCentsRule(),
+                'autoaccept_friends_requests' => 'boolean',
 
                 'points.*.address' => 'required|string',
                 'points.*.json_address' => 'required|array',
@@ -69,6 +70,7 @@ class TripsManager extends BaseManager
                 'weekly_schedule' => 'nullable|integer|min:0|max:127',
                 'weekly_schedule_time' => 'nullable|date_format:H:i:s',
                 'seat_price_cents' => $this->seatPriceCentsRule(),
+                'autoaccept_friends_requests' => 'boolean',
 
                 'points.*.address' => 'string',
                 'points.*.json_address' => 'array',

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -596,6 +596,12 @@ class TripsManager extends BaseManager
             return;
         }
 
+        if ($trip->expired()) {
+            $this->setErrors(['error' => 'trip_expired']);
+
+            return;
+        }
+
         $friendsManager = app(FriendsManager::class);
         $invited = 0;
 

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -10,6 +10,8 @@ use STS\Events\Trip\Create as CreateEvent;
 use STS\Events\Trip\Delete as DeleteEvent;
 use STS\Events\Trip\Update as UpdateEvent;
 use STS\Models\Trip;
+use STS\Models\User;
+use STS\Notifications\FriendTripInviteNotification;
 use STS\Repository\TripRepository;
 use STS\Services\FriendTripAlertService;
 use Validator;
@@ -583,6 +585,34 @@ class TripsManager extends BaseManager
         // [TODO] Faltaría saber si sos pasajero
 
         return false;
+    }
+
+    public function inviteFriends($user, $tripId, $friendIds)
+    {
+        $trip = $this->tripRepo->show($user, $tripId);
+        if (! $trip || $trip->user_id != $user->id) {
+            $this->setErrors(['error' => 'access_denied']);
+
+            return;
+        }
+
+        $friendsManager = app(FriendsManager::class);
+        $invited = 0;
+
+        foreach ((array) $friendIds as $friendId) {
+            $friend = User::find($friendId);
+            if (! $friend || ! $friendsManager->areFriend($user, $friend)) {
+                continue;
+            }
+
+            $notification = new FriendTripInviteNotification;
+            $notification->setAttribute('trip', $trip);
+            $notification->setAttribute('driver', $user);
+            $notification->notify($friend);
+            $invited++;
+        }
+
+        return $invited;
     }
 
     public function shareTrip($me, $user)

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -11,6 +11,7 @@ use STS\Events\Trip\Delete as DeleteEvent;
 use STS\Events\Trip\Update as UpdateEvent;
 use STS\Models\Trip;
 use STS\Repository\TripRepository;
+use STS\Services\FriendTripAlertService;
 use Validator;
 
 class TripsManager extends BaseManager
@@ -183,6 +184,11 @@ class TripsManager extends BaseManager
                 }
             }
             event(new CreateEvent($trip));
+
+            $friendTripAlertService = app(FriendTripAlertService::class);
+            if ($friendTripAlertService->isImmediatelyVisible($trip)) {
+                $friendTripAlertService->notifyIfVisible($trip);
+            }
 
             return $trip;
         }

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -605,7 +605,11 @@ class UsersManager extends BaseManager
     {
         $profile = $this->repo->show($profile_id);
         if ($profile) {
-            // $profile->donations = $profile->donations->get();
+            if ($user && $profile->id !== $user->id) {
+                $friendsManager = app(FriendsManager::class);
+                $profile->friendship_state = $friendsManager->getFriendshipState($user, $profile);
+            }
+
             return $profile;
         }
         $this->setErrors(['error' => 'profile not found']);

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -251,6 +251,12 @@ class UsersManager extends BaseManager
 
     public function update($user, array $data, $is_driver = false, $is_admin = false)
     {
+        foreach (['friendship_state', 'friend_trip_alerts_enabled', 'state'] as $virtualKey) {
+            if ($user->offsetExists($virtualKey)) {
+                $user->offsetUnset($virtualKey);
+            }
+        }
+
         if (! $this->isFacebookProfileUrlModuleEnabled()) {
             unset($data['facebook_profile_url']);
         } else {

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -608,6 +608,10 @@ class UsersManager extends BaseManager
             if ($user && $profile->id !== $user->id) {
                 $friendsManager = app(FriendsManager::class);
                 $profile->friendship_state = $friendsManager->getFriendshipState($user, $profile);
+                if ($profile->friendship_state === 'friend') {
+                    $alertRepo = app(\STS\Repository\FriendTripAlertRepository::class);
+                    $profile->friend_trip_alerts_enabled = $alertRepo->isSubscribed($user, $profile);
+                }
             }
 
             return $profile;

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -157,6 +157,10 @@ class ProfileTransformer extends TransformerAbstract
             $data['friendship_state'] = $user->friendship_state;
         }
 
+        if (isset($user->friend_trip_alerts_enabled)) {
+            $data['friend_trip_alerts_enabled'] = (bool) $user->friend_trip_alerts_enabled;
+        }
+
         return $data;
     }
 

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -153,6 +153,10 @@ class ProfileTransformer extends TransformerAbstract
             $data['state'] = $user->state;
         }
 
+        if (isset($user->friendship_state)) {
+            $data['friendship_state'] = $user->friendship_state;
+        }
+
         return $data;
     }
 

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -149,7 +149,7 @@ class ProfileTransformer extends TransformerAbstract
                 break;
         }
 
-        if ($user->state) {
+        if (isset($user->state)) {
             $data['state'] = $user->state;
         }
 

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -4,6 +4,7 @@ namespace STS\Transformers;
 
 use League\Fractal\TransformerAbstract;
 use STS\Models\Trip;
+use STS\Services\Logic\FriendsManager;
 
 class TripTransformer extends TransformerAbstract
 {
@@ -67,6 +68,9 @@ class TripTransformer extends TransformerAbstract
         $data['request'] = '';
         $data['passenger'] = [];
         if ($this->user) {
+            $friendsManager = app(FriendsManager::class);
+            $data['driver_is_friend'] = $friendsManager->areFriend($this->user, $trip->user);
+
             $userTranforms = new TripUserTransformer($this->user);
             $data['user'] = $userTranforms->transform($trip->user);
             if ($trip->isPassenger($this->user) || $trip->user_id == $this->user->id || $this->user->is_admin) {

--- a/database/migrations/2026_06_09_120000_create_friend_trip_alert_subscriptions_table.php
+++ b/database/migrations/2026_06_09_120000_create_friend_trip_alert_subscriptions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('friend_trip_alert_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('friend_id');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('friend_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['user_id', 'friend_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('friend_trip_alert_subscriptions');
+    }
+};

--- a/database/migrations/2026_06_09_120001_add_friend_trip_alert_sent_at_to_trips_table.php
+++ b/database/migrations/2026_06_09_120001_add_friend_trip_alert_sent_at_to_trips_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->timestamp('friend_trip_alert_sent_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn('friend_trip_alert_sent_at');
+        });
+    }
+};

--- a/database/migrations/2026_06_09_130000_add_autoaccept_friends_requests_to_trips_table.php
+++ b/database/migrations/2026_06_09_130000_add_autoaccept_friends_requests_to_trips_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->boolean('autoaccept_friends_requests')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn('autoaccept_friends_requests');
+        });
+    }
+};

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -51,6 +51,10 @@ return [
     'friend_request.title' => 'Nueva solicitud de amistad',
     'friend_request.message' => ':name te ha enviado una solicitud de amistad.',
 
+    // FriendCreatedTripNotification
+    'friend_created_trip.title' => ':name publicó un nuevo viaje a :destination',
+    'friend_created_trip.message' => ':name publicó un viaje a :destination el :date a las :time',
+
     // HourLeftNotification
     'hour_left.title' => 'Recordatorio de viaje hacia :destination?',
     'hour_left.message' => 'Recuerda que en poco más de una hora viajas hacia :destination',

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -55,6 +55,10 @@ return [
     'friend_created_trip.title' => ':name publicó un nuevo viaje a :destination',
     'friend_created_trip.message' => ':name publicó un viaje a :destination el :date a las :time',
 
+    // FriendTripInviteNotification
+    'friend_trip_invite.title' => ':name te invitó a un viaje a :destination',
+    'friend_trip_invite.message' => ':name te invitó a un viaje a :destination el :date a las :time',
+
     // HourLeftNotification
     'hour_left.title' => 'Recordatorio de viaje hacia :destination?',
     'hour_left.message' => 'Recuerda que en poco más de una hora viajas hacia :destination',

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -51,6 +51,10 @@ return [
     'friend_request.title' => 'Nueva solicitud de amistad',
     'friend_request.message' => ':name te ha enviado una solicitud de amistad.',
 
+    // FriendCreatedTripNotification
+    'friend_created_trip.title' => ':name publicó un nuevo viaje a :destination',
+    'friend_created_trip.message' => ':name publicó un viaje a :destination el :date a las :time',
+
     // HourLeftNotification
     'hour_left.title' => 'Recordatorio de viaje hacia :destination?',
     'hour_left.message' => 'Recuerda que en poco más de una hora viajas hacia :destination',

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -55,6 +55,10 @@ return [
     'friend_created_trip.title' => ':name publicó un nuevo viaje a :destination',
     'friend_created_trip.message' => ':name publicó un viaje a :destination el :date a las :time',
 
+    // FriendTripInviteNotification
+    'friend_trip_invite.title' => ':name te invitó a un viaje a :destination',
+    'friend_trip_invite.message' => ':name te invitó a un viaje a :destination el :date a las :time',
+
     // HourLeftNotification
     'hour_left.title' => 'Recordatorio de viaje hacia :destination?',
     'hour_left.message' => 'Recuerda que en poco más de una hora viajas hacia :destination',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -55,6 +55,10 @@ return [
     'friend_created_trip.title' => ':name published a new trip to :destination',
     'friend_created_trip.message' => ':name published a trip to :destination on :date at :time',
 
+    // FriendTripInviteNotification
+    'friend_trip_invite.title' => ':name invited you to a trip to :destination',
+    'friend_trip_invite.message' => ':name invited you to a trip to :destination on :date at :time',
+
     // HourLeftNotification
     'hour_left.title' => 'Trip reminder to :destination',
     'hour_left.message' => 'Remember that in just over an hour you are traveling to :destination',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -51,6 +51,10 @@ return [
     'friend_request.title' => 'New friend request',
     'friend_request.message' => ':name has sent you a friend request.',
 
+    // FriendCreatedTripNotification
+    'friend_created_trip.title' => ':name published a new trip to :destination',
+    'friend_created_trip.message' => ':name published a trip to :destination on :date at :time',
+
     // HourLeftNotification
     'hour_left.title' => 'Trip reminder to :destination',
     'hour_left.message' => 'Remember that in just over an hour you are traveling to :destination',

--- a/routes/api.php
+++ b/routes/api.php
@@ -149,6 +149,7 @@ Route::middleware(['api'])->group(function () {
         Route::delete('/{id?}', [TripController::class, 'delete']);
         Route::get('/{id?}', [TripController::class, 'show']);
         Route::post('/{id?}/changeSeats', [TripController::class, 'changeTripSeats']);
+        Route::post('/{id}/invite-friends', [TripController::class, 'inviteFriends'])->middleware('throttle:trip-invite-friends');
         Route::post('/{id}/change-visibility', [TripController::class, 'changeVisibility']);
         Route::post('/price', [TripController::class, 'price']);
         Route::post('/trip-info', [TripController::class, 'getTripInfo']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -123,10 +123,12 @@ Route::middleware(['api'])->group(function () {
         Route::post('/request/{id?}', [FriendsController::class, 'request']);
         Route::post('/delete/{id?}', [FriendsController::class, 'delete']);
         Route::post('/reject/{id?}', [FriendsController::class, 'reject']);
+        Route::post('/cancel-request/{id?}', [FriendsController::class, 'cancelRequest']);
         Route::post('/trip-alerts/{id?}', [FriendsController::class, 'toggleTripAlerts']);
 
         Route::get('/', [FriendsController::class, 'index']);
         Route::get('/pedings', [FriendsController::class, 'pedings']);
+        Route::get('/sent-pendings', [FriendsController::class, 'sentPendings']);
     });
 
     Route::prefix('social')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -123,6 +123,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('/request/{id?}', [FriendsController::class, 'request']);
         Route::post('/delete/{id?}', [FriendsController::class, 'delete']);
         Route::post('/reject/{id?}', [FriendsController::class, 'reject']);
+        Route::post('/trip-alerts/{id?}', [FriendsController::class, 'toggleTripAlerts']);
 
         Route::get('/', [FriendsController::class, 'index']);
         Route::get('/pedings', [FriendsController::class, 'pedings']);

--- a/routes/rate_limits.php
+++ b/routes/rate_limits.php
@@ -173,3 +173,12 @@ RateLimiter::for('support-ticket-admin-reply', function (Request $request) {
 
     return Limit::perHour(config('carpoolear.support_ticket_rate_limit_admin_reply_per_hour', 120))->by($user->id.':support-admin-reply');
 });
+
+RateLimiter::for('trip-invite-friends', function (Request $request) {
+    $user = $request->user();
+    if (! $user) {
+        return Limit::perHour(20)->by($request->ip().':trip-invite-friends');
+    }
+
+    return Limit::perHour(20)->by($user->id.':trip-invite-friends');
+});

--- a/tests/Feature/Http/FriendSentPendingTest.php
+++ b/tests/Feature/Http/FriendSentPendingTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Models\User;
+use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
+use STS\Services\Logic\FriendsManager;
+use Tests\TestCase;
+
+class FriendSentPendingTest extends TestCase
+{
+    private function makeFriends(User $a, User $b): void
+    {
+        (new FriendsManager(new FriendsRepository, new FriendTripAlertRepository))->request($a, $b);
+    }
+
+    public function test_sent_pendings_lists_outgoing_friend_requests(): void
+    {
+        $actor = User::factory()->create();
+        $sentTo = User::factory()->create();
+        $incomingFrom = User::factory()->create();
+        $this->makeFriends($actor, $sentTo);
+        $this->makeFriends($incomingFrom, $actor);
+
+        $this->actingAs($actor, 'api')
+            ->getJson('/api/friends/sent-pendings')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $sentTo->id);
+    }
+
+    public function test_cancel_request_removes_outgoing_friend_request(): void
+    {
+        $actor = User::factory()->create();
+        $target = User::factory()->create();
+        $this->makeFriends($actor, $target);
+
+        $this->actingAs($actor, 'api')
+            ->postJson("/api/friends/cancel-request/{$target->id}")
+            ->assertOk();
+
+        $this->actingAs($actor, 'api')
+            ->getJson('/api/friends/sent-pendings')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+}

--- a/tests/Feature/Http/TripInviteFriendsTest.php
+++ b/tests/Feature/Http/TripInviteFriendsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Carbon\Carbon;
+use Mockery;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Notifications\FriendTripInviteNotification;
+use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
+use STS\Services\Logic\FriendsManager;
+use STS\Services\Notifications\NotificationServices;
+use Tests\TestCase;
+
+class TripInviteFriendsTest extends TestCase
+{
+    private function makeFriends(User $a, User $b): void
+    {
+        (new FriendsManager(new FriendsRepository, new FriendTripAlertRepository))->make($a, $b);
+    }
+
+    public function test_invite_friends_notifies_accepted_friends_only(): void
+    {
+        $driver = User::factory()->create();
+        $friend = User::factory()->create();
+        $stranger = User::factory()->create();
+        $this->makeFriends($driver, $friend);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'from_town' => 'Rosario',
+            'to_town' => 'Buenos Aires',
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+
+        $this->mock(NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(3)
+            ->withArgs(function ($notification, $users, $channel) use ($trip, $friend, $driver) {
+                if (! $notification instanceof FriendTripInviteNotification) {
+                    return false;
+                }
+
+                return $notification->getAttribute('trip')->is($trip)
+                    && $notification->getAttribute('driver')->is($driver)
+                    && $users instanceof User
+                    && $users->is($friend)
+                    && is_string($channel);
+            });
+
+        $this->actingAs($driver, 'api')
+            ->postJson("/api/trips/{$trip->id}/invite-friends", [
+                'friend_ids' => [$friend->id, $stranger->id],
+            ])
+            ->assertOk()
+            ->assertJsonPath('invited_count', 1);
+    }
+
+    public function test_invite_friends_denies_non_owner(): void
+    {
+        $driver = User::factory()->create();
+        $other = User::factory()->create();
+        $friend = User::factory()->create();
+        $this->makeFriends($driver, $friend);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        $this->actingAs($other, 'api')
+            ->postJson("/api/trips/{$trip->id}/invite-friends", [
+                'friend_ids' => [$friend->id],
+            ])
+            ->assertStatus(400);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Feature/Http/TripInviteFriendsTest.php
+++ b/tests/Feature/Http/TripInviteFriendsTest.php
@@ -76,7 +76,7 @@ class TripInviteFriendsTest extends TestCase
             ->postJson("/api/trips/{$trip->id}/invite-friends", [
                 'friend_ids' => [$friend->id],
             ])
-            ->assertStatus(400);
+            ->assertStatus(422);
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Http/TripInviteFriendsTest.php
+++ b/tests/Feature/Http/TripInviteFriendsTest.php
@@ -58,6 +58,26 @@ class TripInviteFriendsTest extends TestCase
             ->assertJsonPath('invited_count', 1);
     }
 
+    public function test_invite_friends_denies_expired_trip(): void
+    {
+        $driver = User::factory()->create();
+        $friend = User::factory()->create();
+        $this->makeFriends($driver, $friend);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => Carbon::now()->subDay(),
+        ]);
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        $this->actingAs($driver, 'api')
+            ->postJson("/api/trips/{$trip->id}/invite-friends", [
+                'friend_ids' => [$friend->id],
+            ])
+            ->assertStatus(422);
+    }
+
     public function test_invite_friends_denies_non_owner(): void
     {
         $driver = User::factory()->create();

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -563,6 +563,23 @@ class UserControllerApiTest extends TestCase
             ->assertJsonPath('data.0.title', 'Me slug');
     }
 
+    public function test_user_index_search_includes_friendship_state_for_results(): void
+    {
+        $needle = 'LilNeedle'.uniqid('', false);
+        $actor = User::factory()->create(['active' => true, 'banned' => false, 'name' => 'Actor']);
+        $match = User::factory()->create([
+            'active' => true,
+            'banned' => false,
+            'name' => 'Lilliana '.$needle,
+        ]);
+
+        $this->actingAs($actor, 'api')
+            ->getJson('api/users/list?value='.urlencode('Lilliana'))
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $match->id)
+            ->assertJsonPath('data.0.state', 'none');
+    }
+
     public function test_user_index_search_value_narrows_results_relative_to_open_list(): void
     {
         $needle = 'ZzNeedle'.uniqid('', false);

--- a/tests/Unit/Models/TripTest.php
+++ b/tests/Unit/Models/TripTest.php
@@ -66,6 +66,7 @@ class TripTest extends TestCase
             'state',
             'payment_id',
             'needs_sellado',
+            'autoaccept_friends_requests',
         ];
 
         $this->assertSame($expected, (new Trip)->getFillable());

--- a/tests/Unit/Repository/FriendTripAlertRepositoryTest.php
+++ b/tests/Unit/Repository/FriendTripAlertRepositoryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Repository;
+
+use STS\Models\User;
+use STS\Repository\FriendTripAlertRepository;
+use Tests\TestCase;
+
+class FriendTripAlertRepositoryTest extends TestCase
+{
+    private function repo(): FriendTripAlertRepository
+    {
+        return new FriendTripAlertRepository;
+    }
+
+    public function test_subscribe_creates_subscription_row(): void
+    {
+        $subscriber = User::factory()->create();
+        $driver = User::factory()->create();
+
+        $this->repo()->subscribe($subscriber, $driver);
+
+        $this->assertDatabaseHas('friend_trip_alert_subscriptions', [
+            'user_id' => $subscriber->id,
+            'friend_id' => $driver->id,
+        ]);
+    }
+
+    public function test_unsubscribe_removes_subscription_row(): void
+    {
+        $subscriber = User::factory()->create();
+        $driver = User::factory()->create();
+        $this->repo()->subscribe($subscriber, $driver);
+
+        $this->repo()->unsubscribe($subscriber, $driver);
+
+        $this->assertDatabaseMissing('friend_trip_alert_subscriptions', [
+            'user_id' => $subscriber->id,
+            'friend_id' => $driver->id,
+        ]);
+    }
+
+    public function test_is_subscribed_returns_true_when_subscribed(): void
+    {
+        $subscriber = User::factory()->create();
+        $driver = User::factory()->create();
+        $this->repo()->subscribe($subscriber, $driver);
+
+        $this->assertTrue($this->repo()->isSubscribed($subscriber, $driver));
+    }
+
+    public function test_is_subscribed_returns_false_when_not_subscribed(): void
+    {
+        $subscriber = User::factory()->create();
+        $driver = User::factory()->create();
+
+        $this->assertFalse($this->repo()->isSubscribed($subscriber, $driver));
+    }
+
+    public function test_toggle_subscribes_when_not_subscribed(): void
+    {
+        $subscriber = User::factory()->create();
+        $driver = User::factory()->create();
+
+        $enabled = $this->repo()->toggle($subscriber, $driver);
+
+        $this->assertTrue($enabled);
+        $this->assertTrue($this->repo()->isSubscribed($subscriber, $driver));
+    }
+
+    public function test_toggle_unsubscribes_when_subscribed(): void
+    {
+        $subscriber = User::factory()->create();
+        $driver = User::factory()->create();
+        $this->repo()->subscribe($subscriber, $driver);
+
+        $enabled = $this->repo()->toggle($subscriber, $driver);
+
+        $this->assertFalse($enabled);
+        $this->assertFalse($this->repo()->isSubscribed($subscriber, $driver));
+    }
+
+    public function test_get_subscribers_for_driver_returns_subscribed_users(): void
+    {
+        $driver = User::factory()->create();
+        $subscriber1 = User::factory()->create();
+        $subscriber2 = User::factory()->create();
+        $other = User::factory()->create();
+
+        $this->repo()->subscribe($subscriber1, $driver);
+        $this->repo()->subscribe($subscriber2, $driver);
+        $this->repo()->subscribe($other, User::factory()->create());
+
+        $subscribers = $this->repo()->getSubscribersForDriver($driver);
+
+        $this->assertCount(2, $subscribers);
+        $this->assertTrue($subscribers->contains(fn ($u) => $u->id === $subscriber1->id));
+        $this->assertTrue($subscribers->contains(fn ($u) => $u->id === $subscriber2->id));
+    }
+
+    public function test_delete_for_users_removes_both_directions(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $this->repo()->subscribe($user1, $user2);
+        $this->repo()->subscribe($user2, $user1);
+
+        $this->repo()->deleteForUsers($user1, $user2);
+
+        $this->assertDatabaseMissing('friend_trip_alert_subscriptions', [
+            'user_id' => $user1->id,
+            'friend_id' => $user2->id,
+        ]);
+        $this->assertDatabaseMissing('friend_trip_alert_subscriptions', [
+            'user_id' => $user2->id,
+            'friend_id' => $user1->id,
+        ]);
+    }
+}

--- a/tests/Unit/Services/FriendTripAlertServiceTest.php
+++ b/tests/Unit/Services/FriendTripAlertServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Carbon\Carbon;
+use Mockery;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Notifications\FriendCreatedTripNotification;
+use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
+use STS\Services\FriendTripAlertService;
+use STS\Services\Logic\TripsManager;
+use STS\Services\Notifications\NotificationServices;
+use Tests\TestCase;
+
+class FriendTripAlertServiceTest extends TestCase
+{
+    private function friendsRepo(): FriendsRepository
+    {
+        return new FriendsRepository;
+    }
+
+    private function service(?FriendTripAlertRepository $alertRepo = null, ?TripsManager $tripsManager = null): FriendTripAlertService
+    {
+        return new FriendTripAlertService(
+            $alertRepo ?? new FriendTripAlertRepository,
+            $tripsManager ?? app(TripsManager::class)
+        );
+    }
+
+    public function test_notify_if_visible_skips_when_alert_already_sent(): void
+    {
+        $driver = User::factory()->create();
+        $subscriber = User::factory()->create();
+        $this->friendsRepo()->add($driver, $subscriber, User::FRIEND_ACCEPTED);
+        $this->friendsRepo()->add($subscriber, $driver, User::FRIEND_ACCEPTED);
+
+        $alertRepo = new FriendTripAlertRepository;
+        $alertRepo->subscribe($subscriber, $driver);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::now()->addDay(),
+            'friend_trip_alert_sent_at' => Carbon::now(),
+        ]);
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        $this->service($alertRepo)->notifyIfVisible($trip->fresh());
+    }
+
+    public function test_notify_if_visible_skips_subscriber_who_cannot_see_trip(): void
+    {
+        $driver = User::factory()->create();
+        $subscriber = User::factory()->create();
+        $this->friendsRepo()->add($driver, $subscriber, User::FRIEND_ACCEPTED);
+        $this->friendsRepo()->add($subscriber, $driver, User::FRIEND_ACCEPTED);
+
+        $alertRepo = new FriendTripAlertRepository;
+        $alertRepo->subscribe($subscriber, $driver);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'friendship_type_id' => Trip::PRIVACY_FRIENDS,
+            'trip_date' => Carbon::now()->addDay(),
+            'needs_sellado' => true,
+            'state' => Trip::STATE_AWAITING_PAYMENT,
+        ]);
+
+        $tripsManager = Mockery::mock(TripsManager::class);
+        $tripsManager->shouldReceive('userCanSeeTrip')
+            ->once()
+            ->with(
+                Mockery::on(fn (User $u) => $u->id === $subscriber->id),
+                Mockery::on(fn (Trip $t) => $t->id === $trip->id)
+            )
+            ->andReturn(false);
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        $this->service($alertRepo, $tripsManager)->notifyIfVisible($trip->fresh());
+
+        $this->assertNull($trip->fresh()->friend_trip_alert_sent_at);
+    }
+
+    public function test_notify_if_visible_notifies_subscribers_and_marks_trip_sent(): void
+    {
+        $driver = User::factory()->create(['name' => 'Driver Name']);
+        $subscriber = User::factory()->create();
+        $this->friendsRepo()->add($driver, $subscriber, User::FRIEND_ACCEPTED);
+        $this->friendsRepo()->add($subscriber, $driver, User::FRIEND_ACCEPTED);
+
+        $alertRepo = new FriendTripAlertRepository;
+        $alertRepo->subscribe($subscriber, $driver);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'from_town' => 'Rosario',
+            'to_town' => 'Buenos Aires',
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+
+        $this->mock(NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(3)
+            ->withArgs(function ($notification, $users, $channel) use ($trip, $subscriber, $driver) {
+                if (! $notification instanceof FriendCreatedTripNotification) {
+                    return false;
+                }
+
+                return $notification->getAttribute('trip')->is($trip)
+                    && $notification->getAttribute('driver')->is($driver)
+                    && $users instanceof User
+                    && $users->is($subscriber)
+                    && is_string($channel);
+            });
+
+        $this->service($alertRepo)->notifyIfVisible($trip->fresh());
+
+        $this->assertNotNull($trip->fresh()->friend_trip_alert_sent_at);
+    }
+
+    public function test_notify_if_visible_skips_when_no_subscribers(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::now()->addDay(),
+        ]);
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        $this->service()->notifyIfVisible($trip->fresh());
+
+        $this->assertNull($trip->fresh()->friend_trip_alert_sent_at);
+    }
+}

--- a/tests/Unit/Services/Logic/FriendsManagerTest.php
+++ b/tests/Unit/Services/Logic/FriendsManagerTest.php
@@ -281,4 +281,41 @@ class FriendsManagerTest extends TestCase
 
         $this->assertSame('pending_received', $this->manager()->getFriendshipState($viewer, $profile));
     }
+
+    public function test_get_sent_pendings_returns_users_viewer_requested(): void
+    {
+        $viewer = User::factory()->create();
+        $requested = User::factory()->create();
+        $incomingOnly = User::factory()->create();
+        $unrelated = User::factory()->create();
+
+        $this->manager()->request($viewer, $requested);
+        $this->manager()->request($incomingOnly, $viewer);
+        $this->manager()->request($viewer, $unrelated);
+
+        $sent = $this->manager()->getSentPendings($viewer)->pluck('id')->all();
+
+        $this->assertContains($requested->id, $sent);
+        $this->assertContains($unrelated->id, $sent);
+        $this->assertNotContains($incomingOnly->id, $sent);
+    }
+
+    public function test_cancel_request_removes_outgoing_pending_edge(): void
+    {
+        $viewer = User::factory()->create();
+        $target = User::factory()->create();
+        $this->manager()->request($viewer, $target);
+
+        $this->assertTrue($this->manager()->cancelRequest($viewer, $target));
+        $this->assertSame('none', $this->manager()->getFriendshipState($viewer, $target));
+        $this->assertEmpty($this->manager()->getSentPendings($viewer));
+    }
+
+    public function test_cancel_request_fails_without_outgoing_request(): void
+    {
+        $viewer = User::factory()->create();
+        $target = User::factory()->create();
+
+        $this->assertNull($this->manager()->cancelRequest($viewer, $target));
+    }
 }

--- a/tests/Unit/Services/Logic/FriendsManagerTest.php
+++ b/tests/Unit/Services/Logic/FriendsManagerTest.php
@@ -9,6 +9,7 @@ use STS\Events\Friend\Reject as RejectEvent;
 use STS\Events\Friend\Request as RequestEvent;
 use STS\Models\User;
 use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
 use STS\Services\Logic\FriendsManager;
 use Tests\TestCase;
 
@@ -16,7 +17,7 @@ class FriendsManagerTest extends TestCase
 {
     private function manager(): FriendsManager
     {
-        return new FriendsManager(new FriendsRepository);
+        return new FriendsManager(new FriendsRepository, new FriendTripAlertRepository);
     }
 
     public function test_are_friend_false_without_edge(): void

--- a/tests/Unit/Services/Logic/FriendsManagerTest.php
+++ b/tests/Unit/Services/Logic/FriendsManagerTest.php
@@ -245,4 +245,39 @@ class FriendsManagerTest extends TestCase
         $this->assertContains($p2->id, $pendings);
         $this->assertNotContains($otherTarget->id, $pendings);
     }
+
+    public function test_get_friendship_state_none_without_edge(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create();
+
+        $this->assertSame('none', $this->manager()->getFriendshipState($viewer, $profile));
+    }
+
+    public function test_get_friendship_state_friend_when_accepted(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create();
+        $this->manager()->make($viewer, $profile);
+
+        $this->assertSame('friend', $this->manager()->getFriendshipState($viewer, $profile));
+    }
+
+    public function test_get_friendship_state_pending_sent_when_viewer_requested(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create();
+        $this->manager()->request($viewer, $profile);
+
+        $this->assertSame('pending_sent', $this->manager()->getFriendshipState($viewer, $profile));
+    }
+
+    public function test_get_friendship_state_pending_received_when_profile_requested(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create();
+        $this->manager()->request($profile, $viewer);
+
+        $this->assertSame('pending_received', $this->manager()->getFriendshipState($viewer, $profile));
+    }
 }

--- a/tests/Unit/Services/Logic/PassengersManagerTest.php
+++ b/tests/Unit/Services/Logic/PassengersManagerTest.php
@@ -16,6 +16,9 @@ use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\User;
 use STS\Notifications\CancelPassengerNotification;
+use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
+use STS\Services\Logic\FriendsManager;
 use STS\Services\Logic\PassengersManager;
 use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
@@ -240,6 +243,51 @@ class PassengersManagerTest extends TestCase
         Event::assertNotDispatched(RequestEvent::class);
         Event::assertNotDispatched(AcceptEvent::class);
         Event::assertNotDispatched(AutoRequestEvent::class);
+    }
+
+    public function test_new_request_autoaccept_friends_dispatches_auto_and_accept_events(): void
+    {
+        Event::fake([RequestEvent::class, AcceptEvent::class, AutoRequestEvent::class]);
+        $driver = User::factory()->create(['autoaccept_requests' => false]);
+        $requester = User::factory()->create();
+        (new FriendsManager(new FriendsRepository, new FriendTripAlertRepository))->make($driver, $requester);
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::now()->addDay(),
+            'total_seats' => 4,
+            'autoaccept_friends_requests' => true,
+        ]);
+
+        $row = $this->manager()->newRequest($trip->id, $requester, []);
+
+        $this->assertNotNull($row);
+        $this->assertSame(Passenger::STATE_ACCEPTED, (int) $row->fresh()->request_state);
+        Event::assertNotDispatched(RequestEvent::class);
+        Event::assertDispatched(AutoRequestEvent::class);
+        Event::assertDispatched(AcceptEvent::class);
+    }
+
+    public function test_new_request_autoaccept_friends_skips_non_friends(): void
+    {
+        Event::fake([RequestEvent::class, AcceptEvent::class, AutoRequestEvent::class]);
+        $driver = User::factory()->create(['autoaccept_requests' => false]);
+        $requester = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::now()->addDay(),
+            'total_seats' => 4,
+            'autoaccept_friends_requests' => true,
+        ]);
+
+        $row = $this->manager()->newRequest($trip->id, $requester, []);
+
+        $this->assertNotNull($row);
+        $this->assertSame(Passenger::STATE_PENDING, (int) $row->fresh()->request_state);
+        Event::assertDispatched(RequestEvent::class);
+        Event::assertNotDispatched(AutoRequestEvent::class);
+        Event::assertNotDispatched(AcceptEvent::class);
     }
 
     public function test_new_request_autoaccept_dispatches_auto_and_accept_events(): void

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -354,7 +354,7 @@ class TripsManagerTest extends TestCase
 
         $this->assertFalse($this->manager()->userCanSeeTrip($stranger, $trip));
 
-        (new FriendsManager(new FriendsRepository))->make($driver, $friend);
+        (new FriendsManager(new FriendsRepository, new \STS\Repository\FriendTripAlertRepository))->make($driver, $friend);
 
         $this->assertTrue($this->manager()->userCanSeeTrip($friend->fresh(), $trip));
     }
@@ -930,7 +930,7 @@ class TripsManagerTest extends TestCase
         $a = User::factory()->create();
         $b = User::factory()->create();
         $c = User::factory()->create();
-        $friends = new FriendsManager(new FriendsRepository);
+        $friends = new FriendsManager(new FriendsRepository, new \STS\Repository\FriendTripAlertRepository);
         $friends->make($a, $b);
         $friends->make($b, $c);
 

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -7,6 +7,9 @@ use STS\Models\Car;
 use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\User;
+use STS\Repository\FriendsRepository;
+use STS\Repository\FriendTripAlertRepository;
+use STS\Services\Logic\FriendsManager;
 use STS\Transformers\TripTransformer;
 use Tests\TestCase;
 
@@ -343,5 +346,36 @@ class TripTransformerTest extends TestCase
 
         $this->assertSame('send', $payload['request']);
         $this->assertArrayHasKey('allPassengerRequest', $payload);
+    }
+
+    public function test_transform_includes_driver_is_friend_when_viewer_is_friend(): void
+    {
+        $driver = User::factory()->create();
+        $viewer = User::factory()->create();
+        (new FriendsManager(new FriendsRepository, new FriendTripAlertRepository))->make($driver, $viewer);
+
+        $trip = $this->makeTrip(['user_id' => $driver->id]);
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh());
+
+        $this->assertTrue($payload['driver_is_friend']);
+    }
+
+    public function test_transform_includes_driver_is_friend_false_for_stranger(): void
+    {
+        $driver = User::factory()->create();
+        $viewer = User::factory()->create();
+        $trip = $this->makeTrip(['user_id' => $driver->id]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh());
+
+        $this->assertFalse($payload['driver_is_friend']);
+    }
+
+    public function test_transform_omits_driver_is_friend_without_logged_viewer(): void
+    {
+        $trip = $this->makeTrip();
+        $payload = (new TripTransformer(null))->transform($trip->fresh());
+
+        $this->assertArrayNotHasKey('driver_is_friend', $payload);
     }
 }


### PR DESCRIPTION
## Summary

Friends overhaul: discover friends on profiles and home, trip alerts, friend-first trip list, trip invites, and settings polish — with regression tests on both repos.

---

## Backend (`carpoolear_backend`)

### Friendship & profiles
- **Cause:** No consistent friendship state on profiles; virtual fields could leak into user updates.
- **Fix:** Expose `friendship_state` on profiles; unify friendship derivation in user lists; strip virtual keys (`friendship_state`, `friend_trip_alerts_enabled`) on update.

### Friend trip alerts
- **Cause:** No way to subscribe/unsubscribe to a friend’s new trips or notify subscribers.
- **Fix:** `FriendTripAlertRepository` + migrations, `FriendTripAlertService`, `FriendCreatedTripNotification` (`type: friend_trip`), toggle endpoint on friends API, and `friend_trip_alerts_enabled` on profile responses.

### Trip creation & invites
- **Cause:** No auto-accept for friend seat requests; no API to invite friends to a trip; invites allowed on expired trips.
- **Fix:** `autoaccept_friends_requests` on trips; `POST /api/trips/{id}/invite-friends`; reject invites when the trip is expired.

### Trip list sorting signal
- **Cause:** Frontend couldn’t prioritize friends’ trips without an explicit flag.
- **Fix:** `driver_is_friend` on `TripTransformer`.

### Outgoing friend requests
- **Cause:** Users couldn’t cancel sent pending requests from settings.
- **Fix:** Cancel-request endpoint and friends manager support.
