### PR TITLE
chore: ignore local git worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ storage/logs/*
 tests/coverage/*
 cert
 storage/framework/phpunit-mysql-testing.lock
+
+# Git worktrees (local isolated checkouts)
+.worktrees/
+worktrees/


### PR DESCRIPTION
Prevent project-local worktrees from appearing as untracked files.