### PR TITLE
Car changes

### DIFF
--- a/app/Console/Commands/SyncArgautosCarCatalog.php
+++ b/app/Console/Commands/SyncArgautosCarCatalog.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use STS\Services\Argautos\CarCatalogSyncService;
+
+class SyncArgautosCarCatalog extends Command
+{
+    protected $signature = 'car-catalog:sync-argautos {--mode=incremental : initial or incremental} {--dry-run : Report changes without writing}';
+
+    protected $description = 'Sync car brands and models from Argautos API';
+
+    public function handle(CarCatalogSyncService $service): int
+    {
+        $lock = Cache::lock(CarCatalogSyncService::LOCK_KEY, 7200);
+
+        if (! $lock->get()) {
+            $this->error('Another car catalog sync is already running.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $mode = (string) $this->option('mode');
+            $dryRun = (bool) $this->option('dry-run');
+            $service->storeStatus(['mode' => $mode, 'dry_run' => $dryRun], true);
+
+            $summary = $service->sync($mode, $dryRun);
+            $service->storeStatus($summary, false);
+
+            $this->info(json_encode($summary, JSON_PRETTY_PRINT));
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $service->storeStatus(['mode' => $this->option('mode')], false, $e->getMessage());
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        } finally {
+            optional($lock)->release();
+        }
+    }
+}

--- a/app/Http/Controllers/Api/Admin/CarBrandController.php
+++ b/app/Http/Controllers/Api/Admin/CarBrandController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use STS\Http\Controllers\Controller;
+use STS\Models\CarBrand;
+
+class CarBrandController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $rows = CarBrand::query()->orderBy('name')->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (CarBrand $brand) => $this->serialize($brand))->all(),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:100',
+            'is_active' => 'sometimes|boolean',
+            'argautos_id' => 'nullable|integer|unique:car_brands,argautos_id',
+        ]);
+
+        $brand = CarBrand::create([
+            'name' => $validated['name'],
+            'slug' => $this->uniqueSlug($validated['name']),
+            'argautos_id' => $validated['argautos_id'] ?? null,
+            'is_active' => $validated['is_active'] ?? true,
+        ]);
+
+        return response()->json(['data' => $this->serialize($brand)], Response::HTTP_CREATED);
+    }
+
+    public function show(CarBrand $carBrand): JsonResponse
+    {
+        return response()->json(['data' => $this->serialize($carBrand)]);
+    }
+
+    public function update(Request $request, CarBrand $carBrand): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:100',
+            'is_active' => 'sometimes|boolean',
+            'argautos_id' => 'nullable|integer|unique:car_brands,argautos_id,'.$carBrand->id,
+        ]);
+
+        $carBrand->fill([
+            'name' => $validated['name'],
+            'slug' => $this->uniqueSlug($validated['name'], $carBrand->id),
+            'argautos_id' => $validated['argautos_id'] ?? $carBrand->argautos_id,
+            'is_active' => $validated['is_active'] ?? $carBrand->is_active,
+        ]);
+        $carBrand->save();
+
+        return response()->json(['data' => $this->serialize($carBrand)]);
+    }
+
+    public function destroy(CarBrand $carBrand): JsonResponse
+    {
+        if ($carBrand->cars()->exists()) {
+            $carBrand->is_active = false;
+            $carBrand->save();
+
+            return response()->json(['data' => $this->serialize($carBrand)]);
+        }
+
+        $carBrand->delete();
+
+        return response()->json(['data' => 'ok']);
+    }
+
+    private function uniqueSlug(string $name, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($name) ?: 'brand';
+        $slug = $base;
+        $suffix = 1;
+
+        while (CarBrand::query()
+            ->when($ignoreId, fn ($q) => $q->where('id', '!=', $ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(CarBrand $brand): array
+    {
+        return [
+            'id' => $brand->id,
+            'name' => $brand->name,
+            'slug' => $brand->slug,
+            'argautos_id' => $brand->argautos_id,
+            'is_active' => $brand->is_active,
+            'created_at' => $brand->created_at?->toIso8601String(),
+            'updated_at' => $brand->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Admin/CarCatalogSyncController.php
+++ b/app/Http/Controllers/Api/Admin/CarCatalogSyncController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use STS\Http\Controllers\Controller;
+use STS\Jobs\SyncArgautosCarCatalogJob;
+use STS\Services\Argautos\CarCatalogSyncService;
+
+class CarCatalogSyncController extends Controller
+{
+    public function store(CarCatalogSyncService $service): JsonResponse
+    {
+        $status = $service->currentStatus();
+        if ($status['running'] ?? false) {
+            return response()->json([
+                'message' => 'sync_already_running',
+            ], Response::HTTP_CONFLICT);
+        }
+
+        SyncArgautosCarCatalogJob::dispatch();
+
+        return response()->json(['data' => ['queued' => true]], Response::HTTP_ACCEPTED);
+    }
+
+    public function status(CarCatalogSyncService $service): JsonResponse
+    {
+        return response()->json(['data' => $service->currentStatus()]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/CarColorController.php
+++ b/app/Http/Controllers/Api/Admin/CarColorController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use STS\Http\Controllers\Controller;
+use STS\Models\CarColor;
+
+class CarColorController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $rows = CarColor::query()
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (CarColor $color) => $this->serialize($color))->all(),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $this->validatePayload($request);
+
+        $color = CarColor::create([
+            'name' => $validated['name'],
+            'slug' => $this->uniqueSlug($validated['name']),
+            'hex' => $validated['hex'] ?? null,
+            'is_active' => $validated['is_active'] ?? true,
+            'sort_order' => $validated['sort_order'] ?? 0,
+        ]);
+
+        return response()->json(['data' => $this->serialize($color)], Response::HTTP_CREATED);
+    }
+
+    public function show(CarColor $carColor): JsonResponse
+    {
+        return response()->json(['data' => $this->serialize($carColor)]);
+    }
+
+    public function update(Request $request, CarColor $carColor): JsonResponse
+    {
+        $validated = $this->validatePayload($request, $carColor->id);
+
+        $carColor->fill([
+            'name' => $validated['name'],
+            'slug' => $this->uniqueSlug($validated['name'], $carColor->id),
+            'hex' => $validated['hex'] ?? null,
+            'is_active' => $validated['is_active'] ?? true,
+            'sort_order' => $validated['sort_order'] ?? 0,
+        ]);
+        $carColor->save();
+
+        return response()->json(['data' => $this->serialize($carColor)]);
+    }
+
+    public function destroy(CarColor $carColor): JsonResponse
+    {
+        if ($carColor->cars()->exists()) {
+            $carColor->is_active = false;
+            $carColor->save();
+
+            return response()->json(['data' => $this->serialize($carColor)]);
+        }
+
+        $carColor->delete();
+
+        return response()->json(['data' => 'ok']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validatePayload(Request $request, ?int $ignoreId = null): array
+    {
+        return $request->validate([
+            'name' => ['required', 'string', 'max:80'],
+            'hex' => ['nullable', 'string', 'regex:/^#[0-9A-Fa-f]{6}$/'],
+            'is_active' => ['sometimes', 'boolean'],
+            'sort_order' => ['sometimes', 'integer', 'min:0', 'max:65535'],
+        ]);
+    }
+
+    private function uniqueSlug(string $name, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($name) ?: 'color';
+        $slug = $base;
+        $suffix = 1;
+
+        while (CarColor::query()
+            ->when($ignoreId, fn ($q) => $q->where('id', '!=', $ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(CarColor $color): array
+    {
+        return [
+            'id' => $color->id,
+            'name' => $color->name,
+            'slug' => $color->slug,
+            'hex' => $color->hex,
+            'is_active' => $color->is_active,
+            'sort_order' => $color->sort_order,
+            'created_at' => $color->created_at?->toIso8601String(),
+            'updated_at' => $color->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Admin/CarModelController.php
+++ b/app/Http/Controllers/Api/Admin/CarModelController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use STS\Http\Controllers\Controller;
+use STS\Models\CarBrand;
+use STS\Models\CarModel;
+
+class CarModelController extends Controller
+{
+    public function index(CarBrand $carBrand): JsonResponse
+    {
+        $rows = $carBrand->models()->orderBy('name')->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (CarModel $model) => $this->serialize($model))->all(),
+        ]);
+    }
+
+    public function store(Request $request, CarBrand $carBrand): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:150',
+            'is_active' => 'sometimes|boolean',
+            'argautos_id' => 'nullable|integer',
+        ]);
+
+        $model = CarModel::create([
+            'car_brand_id' => $carBrand->id,
+            'name' => $validated['name'],
+            'slug' => $this->uniqueSlug($carBrand->id, $validated['name']),
+            'argautos_id' => $validated['argautos_id'] ?? null,
+            'is_active' => $validated['is_active'] ?? true,
+        ]);
+
+        return response()->json(['data' => $this->serialize($model)], Response::HTTP_CREATED);
+    }
+
+    public function show(CarBrand $carBrand, CarModel $carModel): JsonResponse
+    {
+        $this->assertModelBelongsToBrand($carBrand, $carModel);
+
+        return response()->json(['data' => $this->serialize($carModel)]);
+    }
+
+    public function update(Request $request, CarBrand $carBrand, CarModel $carModel): JsonResponse
+    {
+        $this->assertModelBelongsToBrand($carBrand, $carModel);
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:150',
+            'is_active' => 'sometimes|boolean',
+            'argautos_id' => 'nullable|integer',
+        ]);
+
+        $carModel->fill([
+            'name' => $validated['name'],
+            'slug' => $this->uniqueSlug($carBrand->id, $validated['name'], $carModel->id),
+            'argautos_id' => $validated['argautos_id'] ?? $carModel->argautos_id,
+            'is_active' => $validated['is_active'] ?? $carModel->is_active,
+        ]);
+        $carModel->save();
+
+        return response()->json(['data' => $this->serialize($carModel)]);
+    }
+
+    public function destroy(CarBrand $carBrand, CarModel $carModel): JsonResponse
+    {
+        $this->assertModelBelongsToBrand($carBrand, $carModel);
+
+        if ($carModel->cars()->exists()) {
+            $carModel->is_active = false;
+            $carModel->save();
+
+            return response()->json(['data' => $this->serialize($carModel)]);
+        }
+
+        $carModel->delete();
+
+        return response()->json(['data' => 'ok']);
+    }
+
+    private function assertModelBelongsToBrand(CarBrand $carBrand, CarModel $carModel): void
+    {
+        abort_if((int) $carModel->car_brand_id !== (int) $carBrand->id, 404);
+    }
+
+    private function uniqueSlug(int $brandId, string $name, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($name) ?: 'model';
+        $slug = $base;
+        $suffix = 1;
+
+        while (CarModel::query()
+            ->where('car_brand_id', $brandId)
+            ->when($ignoreId, fn ($q) => $q->where('id', '!=', $ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(CarModel $model): array
+    {
+        return [
+            'id' => $model->id,
+            'car_brand_id' => $model->car_brand_id,
+            'name' => $model->name,
+            'slug' => $model->slug,
+            'argautos_id' => $model->argautos_id,
+            'is_active' => $model->is_active,
+            'created_at' => $model->created_at?->toIso8601String(),
+            'updated_at' => $model->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/v1/CarCatalogController.php
+++ b/app/Http/Controllers/Api/v1/CarCatalogController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\JsonResponse;
+use STS\Http\Controllers\Controller;
+use STS\Models\CarBrand;
+use STS\Models\CarColor;
+use STS\Models\CarModel;
+
+class CarCatalogController extends Controller
+{
+    public function brands(): JsonResponse
+    {
+        $rows = CarBrand::query()->active()->orderBy('name')->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (CarBrand $brand) => [
+                'id' => $brand->id,
+                'name' => $brand->name,
+                'slug' => $brand->slug,
+            ])->all(),
+        ]);
+    }
+
+    public function models(CarBrand $carBrand): JsonResponse
+    {
+        $rows = $carBrand->models()->active()->orderBy('name')->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (CarModel $model) => [
+                'id' => $model->id,
+                'car_brand_id' => $model->car_brand_id,
+                'name' => $model->name,
+                'slug' => $model->slug,
+            ])->all(),
+        ]);
+    }
+
+    public function colors(): JsonResponse
+    {
+        $rows = CarColor::query()->active()->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (CarColor $color) => [
+                'id' => $color->id,
+                'name' => $color->name,
+                'slug' => $color->slug,
+            ])->all(),
+        ]);
+    }
+}

--- a/app/Jobs/SyncArgautosCarCatalogJob.php
+++ b/app/Jobs/SyncArgautosCarCatalogJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace STS\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use STS\Services\Argautos\CarCatalogSyncService;
+
+class SyncArgautosCarCatalogJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function handle(CarCatalogSyncService $service): void
+    {
+        $lock = Cache::lock(CarCatalogSyncService::LOCK_KEY, 7200);
+
+        if (! $lock->get()) {
+            return;
+        }
+
+        try {
+            $service->storeStatus(['mode' => 'incremental'], true);
+            $summary = $service->sync('incremental', false);
+            $service->storeStatus($summary, false);
+        } catch (\Throwable $e) {
+            $service->storeStatus(['mode' => 'incremental'], false, $e->getMessage());
+            throw $e;
+        } finally {
+            optional($lock)->release();
+        }
+    }
+}

--- a/app/Models/Car.php
+++ b/app/Models/Car.php
@@ -110,6 +110,10 @@ class Car extends Model
             return true;
         }
 
+        if ($this->car_brand_id && $this->hasValue($this->model_other)) {
+            return true;
+        }
+
         return $this->hasValue($this->brand_other) && $this->hasValue($this->model_other);
     }
 

--- a/app/Models/Car.php
+++ b/app/Models/Car.php
@@ -4,6 +4,7 @@ namespace STS\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Car extends Model
@@ -18,24 +19,66 @@ class Car extends Model
 
     protected $table = 'cars';
 
-    protected $fillable = ['patente', 'description', 'user_id'];
+    protected $fillable = [
+        'patente',
+        'description',
+        'user_id',
+        'car_brand_id',
+        'car_model_id',
+        'brand_other',
+        'model_other',
+        'car_color_id',
+    ];
 
     protected $hidden = ['created_at', 'updated_at'];
 
     protected $appends = ['trips_count'];
 
-    public function user()
+    public function user(): BelongsTo
     {
-        return $this->belongsTo('STS\Models\User', 'user_id');
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     public function trips()
     {
-        return $this->hasMany('STS\Models\Trip', 'car_id');
+        return $this->hasMany(Trip::class, 'car_id');
+    }
+
+    public function brand(): BelongsTo
+    {
+        return $this->belongsTo(CarBrand::class, 'car_brand_id');
+    }
+
+    public function carModel(): BelongsTo
+    {
+        return $this->belongsTo(CarModel::class, 'car_model_id');
+    }
+
+    public function color(): BelongsTo
+    {
+        return $this->belongsTo(CarColor::class, 'car_color_id');
     }
 
     public function getTripsCountAttribute()
     {
         return $this->trips()->count();
+    }
+
+    public function isComplete(): bool
+    {
+        if (! $this->hasValue($this->patente)) {
+            return false;
+        }
+
+        if ($this->car_brand_id && $this->car_model_id) {
+            return true;
+        }
+
+        return $this->hasValue($this->brand_other) && $this->hasValue($this->model_other);
+    }
+
+    private function hasValue($value): bool
+    {
+        return $value !== null && trim((string) $value) !== '';
     }
 }

--- a/app/Models/Car.php
+++ b/app/Models/Car.php
@@ -32,7 +32,7 @@ class Car extends Model
 
     protected $hidden = ['created_at', 'updated_at'];
 
-    protected $appends = ['trips_count'];
+    protected $appends = ['trips_count', 'brand_name', 'model_name', 'color_name'];
 
     public function user(): BelongsTo
     {
@@ -62,6 +62,33 @@ class Car extends Model
     public function getTripsCountAttribute()
     {
         return $this->trips()->count();
+    }
+
+    public function getBrandNameAttribute(): ?string
+    {
+        if ($this->relationLoaded('brand') && $this->brand) {
+            return $this->brand->name;
+        }
+
+        return $this->brand_other;
+    }
+
+    public function getModelNameAttribute(): ?string
+    {
+        if ($this->relationLoaded('carModel') && $this->carModel) {
+            return $this->carModel->name;
+        }
+
+        return $this->model_other;
+    }
+
+    public function getColorNameAttribute(): ?string
+    {
+        if ($this->relationLoaded('color') && $this->color) {
+            return $this->color->name;
+        }
+
+        return null;
     }
 
     public function isComplete(): bool

--- a/app/Models/Car.php
+++ b/app/Models/Car.php
@@ -102,6 +102,10 @@ class Car extends Model
             return false;
         }
 
+        if (! $this->car_color_id) {
+            return false;
+        }
+
         if ($this->car_brand_id && $this->car_model_id) {
             return true;
         }

--- a/app/Models/Car.php
+++ b/app/Models/Car.php
@@ -28,6 +28,7 @@ class Car extends Model
         'brand_other',
         'model_other',
         'car_color_id',
+        'year',
     ];
 
     protected $hidden = ['created_at', 'updated_at'];
@@ -97,11 +98,26 @@ class Car extends Model
             return false;
         }
 
+        if (! $this->hasValidYear()) {
+            return false;
+        }
+
         if ($this->car_brand_id && $this->car_model_id) {
             return true;
         }
 
         return $this->hasValue($this->brand_other) && $this->hasValue($this->model_other);
+    }
+
+    private function hasValidYear(): bool
+    {
+        if ($this->year === null) {
+            return false;
+        }
+
+        $year = (int) $this->year;
+
+        return $year >= 1900 && $year <= (int) date('Y');
     }
 
     private function hasValue($value): bool

--- a/app/Models/CarBrand.php
+++ b/app/Models/CarBrand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace STS\Models;
+
+use Database\Factories\CarBrandFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class CarBrand extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'argautos_id',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'argautos_id' => 'integer',
+    ];
+
+    protected static function newFactory()
+    {
+        return CarBrandFactory::new();
+    }
+
+    public function models(): HasMany
+    {
+        return $this->hasMany(CarModel::class, 'car_brand_id');
+    }
+
+    public function cars(): HasMany
+    {
+        return $this->hasMany(Car::class, 'car_brand_id');
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/app/Models/CarColor.php
+++ b/app/Models/CarColor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace STS\Models;
+
+use Database\Factories\CarColorFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class CarColor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'hex',
+        'is_active',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    protected static function newFactory()
+    {
+        return CarColorFactory::new();
+    }
+
+    public function cars(): HasMany
+    {
+        return $this->hasMany(Car::class, 'car_color_id');
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query
+            ->where('is_active', true)
+            ->orderBy('sort_order')
+            ->orderBy('name');
+    }
+}

--- a/app/Models/CarModel.php
+++ b/app/Models/CarModel.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace STS\Models;
+
+use Database\Factories\CarModelFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class CarModel extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'car_brand_id',
+        'name',
+        'slug',
+        'argautos_id',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'argautos_id' => 'integer',
+        'car_brand_id' => 'integer',
+    ];
+
+    protected static function newFactory()
+    {
+        return CarModelFactory::new();
+    }
+
+    public function brand(): BelongsTo
+    {
+        return $this->belongsTo(CarBrand::class, 'car_brand_id');
+    }
+
+    public function cars(): HasMany
+    {
+        return $this->hasMany(Car::class, 'car_model_id');
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/app/Services/Argautos/ArgautosClient.php
+++ b/app/Services/Argautos/ArgautosClient.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace STS\Services\Argautos;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+class ArgautosClient
+{
+    public function __construct(
+        private readonly string $baseUrl,
+        private readonly ?string $apiKey = null,
+        private readonly int $requestDelayMs = 21000,
+    ) {}
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function fetchBrands(): array
+    {
+        return $this->fetchPaginated($this->baseUrl.'/brands');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function fetchModelsForBrand(int $argautosBrandId): array
+    {
+        if ($this->requestDelayMs > 0) {
+            usleep($this->requestDelayMs * 1000);
+        }
+
+        return $this->fetchPaginated($this->baseUrl.'/brands/'.$argautosBrandId.'/models');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchPaginated(string $url): array
+    {
+        $items = [];
+        $nextUrl = $url;
+
+        while ($nextUrl) {
+            $response = $this->request()->get($nextUrl);
+
+            if ($response->status() === 429) {
+                $retryAfter = (int) ($response->header('Retry-After') ?: 60);
+                sleep(max(1, $retryAfter));
+
+                continue;
+            }
+
+            $response->throw();
+            $payload = $response->json();
+            $items = array_merge($items, $payload['data'] ?? []);
+            $nextUrl = $payload['links']['next'] ?? null;
+        }
+
+        return $items;
+    }
+
+    private function request(): PendingRequest
+    {
+        $request = Http::acceptJson()->timeout(30);
+
+        if ($this->apiKey) {
+            $request = $request->withToken($this->apiKey);
+        }
+
+        return $request;
+    }
+}

--- a/app/Services/Argautos/CarCatalogSyncService.php
+++ b/app/Services/Argautos/CarCatalogSyncService.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace STS\Services\Argautos;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use STS\Models\CarBrand;
+use STS\Models\CarModel;
+
+class CarCatalogSyncService
+{
+    public const LOCK_KEY = 'car-catalog-sync';
+
+    public const STATUS_CACHE_KEY = 'car-catalog-sync-status';
+
+    public function __construct(
+        private readonly ?string $baseUrl = null,
+        private readonly ?string $apiKey = null,
+        private readonly ?int $requestDelayMs = null,
+    ) {}
+
+    public function shouldImportModelName(string $name): bool
+    {
+        if (preg_match('/^\d+P\s/', $name)) {
+            return false;
+        }
+
+        if (preg_match('/\b(TDCI|AT|CVT)\b/i', $name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    public function sync(string $mode = 'incremental', bool $dryRun = false): array
+    {
+        $client = $this->client();
+        $summary = [
+            'mode' => $mode,
+            'dry_run' => $dryRun,
+            'brands_created' => 0,
+            'brands_updated' => 0,
+            'models_created' => 0,
+            'models_skipped' => 0,
+            'errors' => 0,
+        ];
+
+        $brands = $client->fetchBrands();
+
+        foreach ($brands as $brandData) {
+            $brand = $this->upsertBrand($brandData, $mode, $dryRun, $summary);
+            if (! $brand && ! $dryRun) {
+                $brand = CarBrand::query()->where('argautos_id', $brandData['id'])->first();
+            }
+
+            if (! $brand && $dryRun) {
+                continue;
+            }
+
+            if (! $brand) {
+                $summary['errors']++;
+
+                continue;
+            }
+
+            $models = $client->fetchModelsForBrand((int) $brandData['id']);
+
+            foreach ($models as $modelData) {
+                if (! $this->shouldImportModelName((string) ($modelData['name'] ?? ''))) {
+                    $summary['models_skipped']++;
+
+                    continue;
+                }
+
+                $this->upsertModel($brand, $modelData, $mode, $dryRun, $summary);
+            }
+        }
+
+        return $summary;
+    }
+
+    public function storeStatus(array $summary, bool $running = false, ?string $error = null): void
+    {
+        Cache::put(self::STATUS_CACHE_KEY, [
+            'running' => $running,
+            'last_run' => array_merge($summary, [
+                'finished_at' => now()->toIso8601String(),
+                'error' => $error,
+            ]),
+        ], now()->addDays(7));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function currentStatus(): array
+    {
+        return Cache::get(self::STATUS_CACHE_KEY, [
+            'running' => false,
+            'last_run' => null,
+        ]);
+    }
+
+    private function client(): ArgautosClient
+    {
+        return new ArgautosClient(
+            rtrim($this->baseUrl ?? (string) config('carpoolear.argautos_api_base_url'), '/'),
+            $this->apiKey ?? config('carpoolear.argautos_api_key'),
+            $this->requestDelayMs ?? (int) config('carpoolear.argautos_request_delay_ms', 21000),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $brandData
+     * @param  array<string, int|string|null>  $summary
+     */
+    private function upsertBrand(array $brandData, string $mode, bool $dryRun, array &$summary): ?CarBrand
+    {
+        $existing = CarBrand::query()->where('argautos_id', $brandData['id'])->first();
+
+        if ($existing) {
+            if ($mode === 'initial' && ! $dryRun) {
+                $existing->fill([
+                    'name' => $brandData['name'],
+                    'slug' => $brandData['slug'] ?? Str::slug((string) $brandData['name']),
+                    'is_active' => true,
+                ]);
+                $existing->save();
+                $summary['brands_updated']++;
+            }
+
+            return $existing;
+        }
+
+        if ($dryRun) {
+            $summary['brands_created']++;
+
+            return null;
+        }
+
+        $brand = CarBrand::create([
+            'name' => $brandData['name'],
+            'slug' => $this->uniqueBrandSlug($brandData['slug'] ?? Str::slug((string) $brandData['name'])),
+            'argautos_id' => $brandData['id'],
+            'is_active' => true,
+        ]);
+        $summary['brands_created']++;
+
+        return $brand;
+    }
+
+    /**
+     * @param  array<string, mixed>  $modelData
+     * @param  array<string, int|string|null>  $summary
+     */
+    private function upsertModel(CarBrand $brand, array $modelData, string $mode, bool $dryRun, array &$summary): void
+    {
+        $existing = CarModel::query()
+            ->where('car_brand_id', $brand->id)
+            ->where('argautos_id', $modelData['id'])
+            ->first();
+
+        if ($existing) {
+            if ($mode === 'initial' && ! $dryRun) {
+                $existing->fill([
+                    'name' => $modelData['name'],
+                    'slug' => $modelData['slug'] ?? Str::slug((string) $modelData['name']),
+                    'is_active' => true,
+                ]);
+                $existing->save();
+            }
+
+            return;
+        }
+
+        if ($dryRun) {
+            $summary['models_created']++;
+
+            return;
+        }
+
+        CarModel::create([
+            'car_brand_id' => $brand->id,
+            'name' => $modelData['name'],
+            'slug' => $this->uniqueModelSlug($brand->id, $modelData['slug'] ?? Str::slug((string) $modelData['name'])),
+            'argautos_id' => $modelData['id'],
+            'is_active' => true,
+        ]);
+        $summary['models_created']++;
+    }
+
+    private function uniqueBrandSlug(string $slug): string
+    {
+        $base = $slug ?: 'brand';
+        $candidate = $base;
+        $suffix = 1;
+
+        while (CarBrand::query()->where('slug', $candidate)->exists()) {
+            $candidate = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+
+    private function uniqueModelSlug(int $brandId, string $slug): string
+    {
+        $base = $slug ?: 'model';
+        $candidate = $base;
+        $suffix = 1;
+
+        while (CarModel::query()->where('car_brand_id', $brandId)->where('slug', $candidate)->exists()) {
+            $candidate = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+}

--- a/app/Services/Logic/CarsManager.php
+++ b/app/Services/Logic/CarsManager.php
@@ -159,18 +159,11 @@ class CarsManager extends BaseManager
             $validator->errors()->add('model_other', 'Cannot set both car_model_id and model_other.');
         }
 
-        if ($hasBrandId xor $hasModelId) {
-            $validator->errors()->add('car_model_id', 'Both car_brand_id and car_model_id are required together.');
-        }
-
-        if ($hasBrandOther xor $hasModelOther) {
-            $validator->errors()->add('model_other', 'Both brand_other and model_other are required together.');
-        }
-
         $hasCatalogIds = $hasBrandId && $hasModelId;
         $hasCatalogOther = $hasBrandOther && $hasModelOther;
+        $hasCatalogBrandWithOtherModel = $hasBrandId && $hasModelOther && ! $hasModelId;
 
-        if ($isCreate && ! $hasCatalogIds && ! $hasCatalogOther) {
+        if ($isCreate && ! $hasCatalogIds && ! $hasCatalogOther && ! $hasCatalogBrandWithOtherModel) {
             $validator->errors()->add('car_brand_id', 'A brand and model or custom values are required.');
         }
 
@@ -204,7 +197,9 @@ class CarsManager extends BaseManager
 
         if ($payload['car_model_id']) {
             $payload['model_other'] = null;
-        } elseif (! $payload['brand_other']) {
+        } elseif ($this->hasValue($payload['model_other'] ?? null)) {
+            $payload['car_model_id'] = null;
+        } else {
             $payload['model_other'] = null;
         }
 

--- a/app/Services/Logic/CarsManager.php
+++ b/app/Services/Logic/CarsManager.php
@@ -28,10 +28,12 @@ class CarsManager extends BaseManager
             'brand_other' => ['nullable', 'string', 'max:100'],
             'model_other' => ['nullable', 'string', 'max:100'],
             'car_color_id' => ['nullable', 'integer', Rule::exists('car_colors', 'id')->where('is_active', true)],
+            'year' => ['nullable', 'integer', 'min:1900', 'max:'.(int) date('Y')],
         ];
 
         if ($isCreate) {
             $rules['car_color_id'][] = 'required';
+            $rules['year'][] = 'required';
         }
 
         if ($userId) {
@@ -190,6 +192,7 @@ class CarsManager extends BaseManager
             'brand_other' => $this->hasValue($data['brand_other'] ?? null) ? trim($data['brand_other']) : null,
             'model_other' => $this->hasValue($data['model_other'] ?? null) ? trim($data['model_other']) : null,
             'car_color_id' => $data['car_color_id'] ?? null,
+            'year' => isset($data['year']) ? (int) $data['year'] : null,
         ];
 
         if ($payload['car_brand_id']) {

--- a/app/Services/Logic/CarsManager.php
+++ b/app/Services/Logic/CarsManager.php
@@ -2,11 +2,12 @@
 
 namespace STS\Services\Logic;
 
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use STS\Models\Car as CarModel;
+use STS\Models\CarModel as CatalogCarModel;
 use STS\Models\User as UserModel;
 use STS\Repository\CarsRepository;
-use Validator;
 
 class CarsManager extends BaseManager
 {
@@ -17,12 +18,21 @@ class CarsManager extends BaseManager
         $this->repo = $carsRepo;
     }
 
-    public function validator(array $data, $userId = null, $carId = null)
+    public function validator(array $data, $userId = null, $carId = null, bool $isCreate = false)
     {
         $rules = [
             'patente' => ['required', 'string', 'max:10'],
-            'description' => 'required|string|max:255',
+            'description' => 'nullable|string|max:255',
+            'car_brand_id' => ['nullable', 'integer', Rule::exists('car_brands', 'id')->where('is_active', true)],
+            'car_model_id' => ['nullable', 'integer', Rule::exists('car_models', 'id')->where('is_active', true)],
+            'brand_other' => ['nullable', 'string', 'max:100'],
+            'model_other' => ['nullable', 'string', 'max:100'],
+            'car_color_id' => ['nullable', 'integer', Rule::exists('car_colors', 'id')->where('is_active', true)],
         ];
+
+        if ($isCreate) {
+            $rules['car_color_id'][] = 'required';
+        }
 
         if ($userId) {
             $uniquePatente = Rule::unique('cars', 'patente')
@@ -35,73 +45,76 @@ class CarsManager extends BaseManager
             $rules['patente'][] = $uniquePatente;
         }
 
-        return Validator::make($data, $rules);
+        $validator = Validator::make($data, $rules);
+        $validator->after(function ($v) use ($data, $isCreate) {
+            $this->validateCatalogFields($v, $data, $isCreate);
+        });
+
+        return $validator;
     }
 
     public function create(UserModel $user, $data)
     {
-        $v = $this->validator($data, $user->id);
+        $v = $this->validator($data, $user->id, null, true);
         if ($v->fails()) {
             $this->setErrors($v->errors());
 
             return;
-        } else {
-            $existing = $this->repo->findByUserAndPatenteIncludingTrashed(
-                $user->id,
-                $data['patente']
-            );
-
-            if ($existing && $existing->trashed()) {
-                $existing->restore();
-                $existing->description = $data['description'];
-                $this->repo->update($existing);
-
-                return $existing;
-            }
-
-            $car = new CarModel;
-            $car->description = $data['description'];
-            $car->patente = $data['patente'];
-            $car->user_id = $user->id;
-            $this->repo->create($car);
-
-            return $car;
         }
+
+        $payload = $this->normalizePayload($data);
+
+        $existing = $this->repo->findByUserAndPatenteIncludingTrashed(
+            $user->id,
+            $payload['patente']
+        );
+
+        if ($existing && $existing->trashed()) {
+            $existing->restore();
+            $existing->fill($payload);
+            $this->repo->update($existing);
+
+            return $existing->fresh(['brand', 'carModel', 'color']);
+        }
+
+        $car = new CarModel;
+        $car->fill($payload);
+        $car->user_id = $user->id;
+        $this->repo->create($car);
+
+        return $car->fresh(['brand', 'carModel', 'color']);
     }
 
     public function update(UserModel $user, $id, $data)
     {
         $car = $this->show($user, $id);
         if ($car) {
-            $v = $this->validator($data, $user->id, $id);
+            $v = $this->validator($data, $user->id, $id, false);
             if ($v->fails()) {
                 $this->setErrors($v->errors());
 
                 return;
-            } else {
-                $car->description = $data['description'];
-                $car->patente = $data['patente'];
-                $this->repo->update($car);
-
-                return $car;
             }
-        } else {
-            $this->setErrors(['error' => 'car_not_found']);
 
-            return;
+            $car->fill($this->normalizePayload($data));
+            $this->repo->update($car);
+
+            return $car->fresh(['brand', 'carModel', 'color']);
         }
+
+        $this->setErrors(['error' => 'car_not_found']);
+
     }
 
     public function show(UserModel $user, $id)
     {
         $car = $this->repo->show($id);
         if ($car && $car->user_id == $user->id) {
-            return $car;
-        } else {
-            $this->setErrors(['error' => 'car_not_found']);
-
-            return;
+            return $car->load(['brand', 'carModel', 'color']);
         }
+
+        $this->setErrors(['error' => 'car_not_found']);
+
     }
 
     public function delete(UserModel $user, $id)
@@ -110,20 +123,93 @@ class CarsManager extends BaseManager
         if ($car) {
             if ($this->repo->delete($car)) {
                 return true;
-            } else {
-                $this->setErrors(['error' => 'can_delete_car']);
-
-                return;
             }
-        } else {
-            $this->setErrors(['error' => 'car_not_found']);
+
+            $this->setErrors(['error' => 'can_delete_car']);
 
             return;
         }
+
+        $this->setErrors(['error' => 'car_not_found']);
+
     }
 
     public function index(UserModel $user)
     {
-        return $this->repo->index($user);
+        return $this->repo->index($user)->load(['brand', 'carModel', 'color']);
+    }
+
+    /**
+     * @param  \Illuminate\Validation\Validator  $validator
+     */
+    private function validateCatalogFields($validator, array $data, bool $isCreate): void
+    {
+        $hasBrandId = ! empty($data['car_brand_id']);
+        $hasModelId = ! empty($data['car_model_id']);
+        $hasBrandOther = $this->hasValue($data['brand_other'] ?? null);
+        $hasModelOther = $this->hasValue($data['model_other'] ?? null);
+
+        if ($hasBrandId && $hasBrandOther) {
+            $validator->errors()->add('brand_other', 'Cannot set both car_brand_id and brand_other.');
+        }
+
+        if ($hasModelId && $hasModelOther) {
+            $validator->errors()->add('model_other', 'Cannot set both car_model_id and model_other.');
+        }
+
+        if ($hasBrandId xor $hasModelId) {
+            $validator->errors()->add('car_model_id', 'Both car_brand_id and car_model_id are required together.');
+        }
+
+        if ($hasBrandOther xor $hasModelOther) {
+            $validator->errors()->add('model_other', 'Both brand_other and model_other are required together.');
+        }
+
+        $hasCatalogIds = $hasBrandId && $hasModelId;
+        $hasCatalogOther = $hasBrandOther && $hasModelOther;
+
+        if ($isCreate && ! $hasCatalogIds && ! $hasCatalogOther) {
+            $validator->errors()->add('car_brand_id', 'A brand and model or custom values are required.');
+        }
+
+        if ($hasBrandId && $hasModelId) {
+            $model = CatalogCarModel::query()->find($data['car_model_id']);
+            if (! $model || (int) $model->car_brand_id !== (int) $data['car_brand_id']) {
+                $validator->errors()->add('car_model_id', 'The selected model does not belong to the selected brand.');
+            }
+        }
+    }
+
+    private function normalizePayload(array $data): array
+    {
+        $payload = [
+            'patente' => $data['patente'],
+            'description' => $data['description'] ?? '',
+            'car_brand_id' => $data['car_brand_id'] ?? null,
+            'car_model_id' => $data['car_model_id'] ?? null,
+            'brand_other' => $this->hasValue($data['brand_other'] ?? null) ? trim($data['brand_other']) : null,
+            'model_other' => $this->hasValue($data['model_other'] ?? null) ? trim($data['model_other']) : null,
+            'car_color_id' => $data['car_color_id'] ?? null,
+        ];
+
+        if ($payload['car_brand_id']) {
+            $payload['brand_other'] = null;
+        } else {
+            $payload['car_brand_id'] = null;
+            $payload['car_model_id'] = null;
+        }
+
+        if ($payload['car_model_id']) {
+            $payload['model_other'] = null;
+        } elseif (! $payload['brand_other']) {
+            $payload['model_other'] = null;
+        }
+
+        return $payload;
+    }
+
+    private function hasValue($value): bool
+    {
+        return $value !== null && trim((string) $value) !== '';
     }
 }

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -9,6 +9,7 @@ use Illuminate\Validation\Rule;
 use STS\Events\Trip\Create as CreateEvent;
 use STS\Events\Trip\Delete as DeleteEvent;
 use STS\Events\Trip\Update as UpdateEvent;
+use STS\Models\Car as CarModel;
 use STS\Models\Trip;
 use STS\Models\User;
 use STS\Notifications\FriendTripInviteNotification;
@@ -102,6 +103,14 @@ class TripsManager extends BaseManager
             if ($this->isDriverTrip($data) && ! $this->driverTripHasPlate($user, $data)) {
                 $messageBag = new MessageBag;
                 $messageBag->add('car_id', 'The driver must have a car with a plate.');
+                $this->setErrors($messageBag);
+
+                return;
+            }
+
+            if ($this->isDriverTrip($data) && ! $this->driverTripHasCompleteCar($user, $data)) {
+                $messageBag = new MessageBag;
+                $messageBag->add('car_incomplete', 'The driver car must have brand and model.');
                 $this->setErrors($messageBag);
 
                 return;
@@ -285,6 +294,31 @@ class TripsManager extends BaseManager
         return $this->activeCarsWithPlate($user)->count() === 1;
     }
 
+    private function driverTripHasCompleteCar($user, array $data, ?Trip $existingTrip = null): bool
+    {
+        $car = $this->resolveDriverCarForCompleteness($user, $data, $existingTrip);
+
+        return $car && $car->isComplete();
+    }
+
+    private function resolveDriverCarForCompleteness($user, array $data, ?Trip $existingTrip = null): ?CarModel
+    {
+        if (! empty($data['car_id'])) {
+            return $user->cars()->whereKey($data['car_id'])->first();
+        }
+
+        $cars = $this->activeCarsWithPlate($user);
+        if ($cars->count() === 1) {
+            return $cars->first();
+        }
+
+        if ($existingTrip && $existingTrip->car_id) {
+            return $user->cars()->whereKey($existingTrip->car_id)->first();
+        }
+
+        return null;
+    }
+
     private function activeCarsWithPlate($user)
     {
         return $user->cars()
@@ -320,6 +354,17 @@ class TripsManager extends BaseManager
                     ) {
                         $messageBag = new MessageBag;
                         $messageBag->add('car_id', 'The driver must have a car with a plate.');
+                        $this->setErrors($messageBag);
+
+                        return;
+                    }
+
+                    if (
+                        $this->isDriverTrip($data, $trip) &&
+                        ! $this->driverTripHasCompleteCar($user, $data, $trip)
+                    ) {
+                        $messageBag = new MessageBag;
+                        $messageBag->add('car_incomplete', 'The driver car must have brand and model.');
                         $this->setErrors($messageBag);
 
                         return;

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -361,6 +361,7 @@ class TripsManager extends BaseManager
 
                     if (
                         $this->isDriverTrip($data, $trip) &&
+                        $carIdWasInRequest &&
                         ! $this->driverTripHasCompleteCar($user, $data, $trip)
                     ) {
                         $messageBag = new MessageBag;

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -42,6 +42,8 @@ class ProfileTransformer extends TransformerAbstract
      */
     public function transform(User $user)
     {
+        $user->loadMissing(['cars.brand', 'cars.carModel', 'cars.color']);
+
         $lastConnection = $user->last_connection;
         $lastConnectionSerialized = ($lastConnection instanceof Carbon && $lastConnection->year > 0)
             ? $lastConnection->toDateTimeString()

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -110,6 +110,7 @@ class TripTransformer extends TransformerAbstract
             return null;
         }
 
+        $car->loadMissing(['brand', 'carModel', 'color']);
         $payload = $car->toArray();
         if (method_exists($car, 'trashed') && $car->trashed()) {
             $payload['deleted'] = true;

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -180,4 +180,8 @@ return [
             'validate_by_date',
         ],
     ],
+
+    'argautos_api_base_url' => env('ARGAUTOS_API_BASE_URL', 'https://argautos.com/api/v1'),
+    'argautos_api_key' => env('ARGAUTOS_API_KEY'),
+    'argautos_request_delay_ms' => (int) env('ARGAUTOS_REQUEST_DELAY_MS', 21000),
 ];

--- a/database/factories/CarBrandFactory.php
+++ b/database/factories/CarBrandFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use STS\Models\CarBrand;
+
+/**
+ * @extends Factory<CarBrand>
+ */
+class CarBrandFactory extends Factory
+{
+    protected $model = CarBrand::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->company();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'argautos_id' => fake()->unique()->numberBetween(1, 99999),
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/CarColorFactory.php
+++ b/database/factories/CarColorFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use STS\Models\CarColor;
+
+/**
+ * @extends Factory<CarColor>
+ */
+class CarColorFactory extends Factory
+{
+    protected $model = CarColor::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->colorName();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'hex' => fake()->hexColor(),
+            'is_active' => true,
+            'sort_order' => fake()->numberBetween(0, 20),
+        ];
+    }
+}

--- a/database/factories/CarFactory.php
+++ b/database/factories/CarFactory.php
@@ -4,24 +4,37 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use STS\Models\Car;
+use STS\Models\CarBrand;
+use STS\Models\CarColor;
+use STS\Models\CarModel;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\STS\Models\Car>
+ * @extends Factory<Car>
  */
 class CarFactory extends Factory
 {
-    protected $model = \STS\Models\Car::class;
+    protected $model = Car::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [
-            'patente'     => 'ASD 123',
+            'patente' => 'ASD 123',
             'description' => 'sandero',
         ];
+    }
+
+    public function withCatalog(): static
+    {
+        return $this->state(function () {
+            $brand = CarBrand::factory()->create();
+            $model = CarModel::factory()->create(['car_brand_id' => $brand->id]);
+            $color = CarColor::factory()->create();
+
+            return [
+                'car_brand_id' => $brand->id,
+                'car_model_id' => $model->id,
+                'car_color_id' => $color->id,
+            ];
+        });
     }
 }

--- a/database/factories/CarFactory.php
+++ b/database/factories/CarFactory.php
@@ -34,6 +34,7 @@ class CarFactory extends Factory
                 'car_brand_id' => $brand->id,
                 'car_model_id' => $model->id,
                 'car_color_id' => $color->id,
+                'year' => (int) date('Y') - 3,
             ];
         });
     }

--- a/database/factories/CarModelFactory.php
+++ b/database/factories/CarModelFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use STS\Models\CarBrand;
+use STS\Models\CarModel;
+
+/**
+ * @extends Factory<CarModel>
+ */
+class CarModelFactory extends Factory
+{
+    protected $model = CarModel::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->word();
+
+        return [
+            'car_brand_id' => CarBrand::factory(),
+            'name' => strtoupper($name),
+            'slug' => Str::slug($name),
+            'argautos_id' => fake()->unique()->numberBetween(1, 99999),
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/migrations/2026_06_10_000001_create_car_brands_table.php
+++ b/database/migrations/2026_06_10_000001_create_car_brands_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('car_brands', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('name', 100);
+            $table->string('slug', 120)->unique();
+            $table->unsignedInteger('argautos_id')->nullable()->unique();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('car_brands');
+    }
+};

--- a/database/migrations/2026_06_10_000002_create_car_models_table.php
+++ b/database/migrations/2026_06_10_000002_create_car_models_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('car_models', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->unsignedInteger('car_brand_id');
+            $table->string('name', 150);
+            $table->string('slug', 170);
+            $table->unsignedInteger('argautos_id')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->foreign('car_brand_id')->references('id')->on('car_brands')
+                ->onDelete('cascade')->onUpdate('cascade');
+            $table->unique(['car_brand_id', 'slug']);
+            $table->unique(['car_brand_id', 'argautos_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('car_models');
+    }
+};

--- a/database/migrations/2026_06_10_000003_create_car_colors_table.php
+++ b/database/migrations/2026_06_10_000003_create_car_colors_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('car_colors', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('name', 80);
+            $table->string('slug', 100)->unique();
+            $table->string('hex', 7)->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('car_colors');
+    }
+};

--- a/database/migrations/2026_06_10_000004_add_catalog_fields_to_cars_table.php
+++ b/database/migrations/2026_06_10_000004_add_catalog_fields_to_cars_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->unsignedInteger('car_brand_id')->nullable()->after('description');
+            $table->unsignedInteger('car_model_id')->nullable()->after('car_brand_id');
+            $table->string('brand_other', 100)->nullable()->after('car_model_id');
+            $table->string('model_other', 100)->nullable()->after('brand_other');
+            $table->unsignedInteger('car_color_id')->nullable()->after('model_other');
+
+            $table->foreign('car_brand_id')->references('id')->on('car_brands')
+                ->nullOnDelete()->cascadeOnUpdate();
+            $table->foreign('car_model_id')->references('id')->on('car_models')
+                ->nullOnDelete()->cascadeOnUpdate();
+            $table->foreign('car_color_id')->references('id')->on('car_colors')
+                ->nullOnDelete()->cascadeOnUpdate();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->dropForeign(['car_brand_id']);
+            $table->dropForeign(['car_model_id']);
+            $table->dropForeign(['car_color_id']);
+            $table->dropColumn([
+                'car_brand_id',
+                'car_model_id',
+                'brand_other',
+                'model_other',
+                'car_color_id',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_06_10_000005_add_year_to_cars_table.php
+++ b/database/migrations/2026_06_10_000005_add_year_to_cars_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->unsignedSmallInteger('year')->nullable()->after('car_color_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cars', function (Blueprint $table) {
+            $table->dropColumn('year');
+        });
+    }
+};

--- a/database/seeders/CarColorSeeder.php
+++ b/database/seeders/CarColorSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+use STS\Models\CarColor;
+
+class CarColorSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $colors = [
+            ['name' => 'Blanco', 'hex' => '#FFFFFF', 'sort_order' => 1],
+            ['name' => 'Negro', 'hex' => '#000000', 'sort_order' => 2],
+            ['name' => 'Gris', 'hex' => '#808080', 'sort_order' => 3],
+            ['name' => 'Plata', 'hex' => '#C0C0C0', 'sort_order' => 4],
+            ['name' => 'Rojo', 'hex' => '#FF0000', 'sort_order' => 5],
+            ['name' => 'Azul', 'hex' => '#0000FF', 'sort_order' => 6],
+            ['name' => 'Verde', 'hex' => '#008000', 'sort_order' => 7],
+            ['name' => 'Amarillo', 'hex' => '#FFFF00', 'sort_order' => 8],
+            ['name' => 'Otro', 'hex' => null, 'sort_order' => 99],
+        ];
+
+        foreach ($colors as $color) {
+            CarColor::query()->updateOrCreate(
+                ['slug' => Str::slug($color['name'])],
+                [
+                    'name' => $color['name'],
+                    'hex' => $color['hex'],
+                    'sort_order' => $color['sort_order'],
+                    'is_active' => true,
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        $this->call(CarColorSeeder::class);
+
         // User::factory(10)->create();
 
         User::factory()->create([

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ use STS\Http\Controllers\Api\Admin\UserMigrationController as AdminUserMigration
 use STS\Http\Controllers\Api\v1\AuthController;
 use STS\Http\Controllers\Api\v1\CampaignController as ApiCampaignController;
 use STS\Http\Controllers\Api\v1\CampaignRewardController as ApiCampaignRewardController;
+use STS\Http\Controllers\Api\v1\CarCatalogController;
 use STS\Http\Controllers\Api\v1\CarController;
 use STS\Http\Controllers\Api\v1\ChangelogController;
 use STS\Http\Controllers\Api\v1\ConversationController;
@@ -51,6 +52,9 @@ Route::middleware(['api'])->group(function () {
     Route::get('config', [AuthController::class, 'getConfig']);
     Route::get('changelog', [ChangelogController::class, 'show']);
     Route::get('changelogs', [ChangelogController::class, 'index']);
+    Route::get('car-brands', [CarCatalogController::class, 'brands']);
+    Route::get('car-brands/{carBrand}/models', [CarCatalogController::class, 'models']);
+    Route::get('car-colors', [CarCatalogController::class, 'colors']);
 
     Route::post('logout', [AuthController::class, 'logout']);
     Route::post('activate/{activation_token?}', [AuthController::class, 'active']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use STS\Http\Controllers\Api\Admin\CampaignDonationController;
 use STS\Http\Controllers\Api\Admin\CampaignMilestoneController;
 use STS\Http\Controllers\Api\Admin\CampaignRewardController;
 use STS\Http\Controllers\Api\Admin\CarBrandController as AdminCarBrandController;
+use STS\Http\Controllers\Api\Admin\CarCatalogSyncController as AdminCarCatalogSyncController;
 use STS\Http\Controllers\Api\Admin\CarColorController as AdminCarColorController;
 use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
 use STS\Http\Controllers\Api\Admin\CarModelController as AdminCarModelController;
@@ -248,6 +249,8 @@ Route::middleware(['api'])->group(function () {
         Route::apiResource('car-colors', AdminCarColorController::class)->except(['create', 'edit']);
         Route::apiResource('car-brands', AdminCarBrandController::class)->except(['create', 'edit']);
         Route::apiResource('car-brands.models', AdminCarModelController::class)->except(['create', 'edit']);
+        Route::post('car-catalog/sync', [AdminCarCatalogSyncController::class, 'store']);
+        Route::get('car-catalog/sync-status', [AdminCarCatalogSyncController::class, 'status']);
         Route::get('users/{user}/ratings', [AdminRatingController::class, 'index']);
         Route::patch('ratings/{rating}', [AdminRatingController::class, 'update']);
         Route::patch('references/{reference}', [AdminReferencesController::class, 'update']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,10 @@ use STS\Http\Controllers\Api\Admin\CampaignController;
 use STS\Http\Controllers\Api\Admin\CampaignDonationController;
 use STS\Http\Controllers\Api\Admin\CampaignMilestoneController;
 use STS\Http\Controllers\Api\Admin\CampaignRewardController;
+use STS\Http\Controllers\Api\Admin\CarBrandController as AdminCarBrandController;
+use STS\Http\Controllers\Api\Admin\CarColorController as AdminCarColorController;
 use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
+use STS\Http\Controllers\Api\Admin\CarModelController as AdminCarModelController;
 use STS\Http\Controllers\Api\Admin\ChangelogController as AdminChangelogController;
 use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
@@ -238,6 +241,9 @@ Route::middleware(['api'])->group(function () {
         Route::apiResource('campaigns.rewards', CampaignRewardController::class);
         // Car management routes
         Route::apiResource('cars', AdminCarController::class);
+        Route::apiResource('car-colors', AdminCarColorController::class)->except(['create', 'edit']);
+        Route::apiResource('car-brands', AdminCarBrandController::class)->except(['create', 'edit']);
+        Route::apiResource('car-brands.models', AdminCarModelController::class)->except(['create', 'edit']);
         Route::get('users/{user}/ratings', [AdminRatingController::class, 'index']);
         Route::patch('ratings/{rating}', [AdminRatingController::class, 'update']);
         Route::patch('references/{reference}', [AdminReferencesController::class, 'update']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -44,3 +44,7 @@ Schedule::command('auth:cleanup-reset-tokens')->dailyAt('04:00')->timezone('Amer
 
 // Auto-close resolved support tickets after configured inactivity days
 Schedule::command('support-tickets:autoclose')->dailyAt('04:30')->timezone('America/Argentina/Buenos_Aires');
+
+Schedule::command('car-catalog:sync-argautos --mode=incremental')
+    ->weeklyOn(1, '03:00')
+    ->timezone('America/Argentina/Buenos_Aires');

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -121,6 +121,13 @@ class ScheduleTest extends TestCase
         $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
     }
 
+    public function test_car_catalog_sync_is_scheduled_weekly()
+    {
+        $event = $this->findEvent('car-catalog:sync-argautos');
+        $this->assertEquals('0 3 * * 1', $event->expression);
+        $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
+    }
+
     // -- Overall schedule integrity --
 
     public function test_no_unexpected_commands_in_schedule()
@@ -140,6 +147,7 @@ class ScheduleTest extends TestCase
             'users:calculate-active-per-month',
             'auth:cleanup-reset-tokens',
             'support-tickets:autoclose',
+            'car-catalog:sync-argautos',
         ];
 
         foreach (array_keys($events) as $command) {

--- a/tests/Feature/Http/Admin/CarBrandControllerTest.php
+++ b/tests/Feature/Http/Admin/CarBrandControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Http\Admin;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\Car;
+use STS\Models\CarBrand;
+use STS\Models\User;
+use Tests\TestCase;
+
+class CarBrandControllerTest extends TestCase
+{
+    private function authenticateAdmin(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+        $this->actingAs($admin->fresh(), 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+    }
+
+    public function test_admin_lists_brands(): void
+    {
+        $this->authenticateAdmin();
+        CarBrand::factory()->create(['name' => 'Toyota']);
+
+        $response = $this->getJson('api/admin/car-brands')->assertOk();
+
+        $this->assertTrue(
+            collect($response->json('data'))->contains(fn (array $row) => $row['name'] === 'Toyota')
+        );
+    }
+
+    public function test_admin_stores_brand(): void
+    {
+        $this->authenticateAdmin();
+
+        $response = $this->postJson('api/admin/car-brands', [
+            'name' => 'Ford',
+        ])->assertCreated();
+
+        $this->assertSame('Ford', $response->json('data.name'));
+        $this->assertSame('ford', $response->json('data.slug'));
+    }
+
+    public function test_destroy_deactivates_brand_when_referenced_by_car(): void
+    {
+        $this->authenticateAdmin();
+        $user = User::factory()->create();
+        $car = Car::factory()->withCatalog()->create(['user_id' => $user->id]);
+        $brand = CarBrand::query()->findOrFail($car->car_brand_id);
+
+        $this->deleteJson("api/admin/car-brands/{$brand->id}")
+            ->assertOk()
+            ->assertJsonPath('data.is_active', false);
+
+        $this->assertFalse($brand->fresh()->is_active);
+        $this->assertNotNull(CarBrand::query()->find($brand->id));
+    }
+}

--- a/tests/Feature/Http/Admin/CarCatalogSyncControllerTest.php
+++ b/tests/Feature/Http/Admin/CarCatalogSyncControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Http\Admin;
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use STS\Http\Middleware\UserAdmin;
+use STS\Jobs\SyncArgautosCarCatalogJob;
+use STS\Models\User;
+use STS\Services\Argautos\CarCatalogSyncService;
+use Tests\TestCase;
+
+class CarCatalogSyncControllerTest extends TestCase
+{
+    private function authenticateAdmin(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+        $this->actingAs($admin->fresh(), 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+    }
+
+    public function test_admin_can_queue_sync_job(): void
+    {
+        Bus::fake();
+        Cache::forget(CarCatalogSyncService::STATUS_CACHE_KEY);
+        $this->authenticateAdmin();
+
+        $this->postJson('api/admin/car-catalog/sync')
+            ->assertAccepted()
+            ->assertJsonPath('data.queued', true);
+
+        Bus::assertDispatched(SyncArgautosCarCatalogJob::class);
+    }
+
+    public function test_admin_sync_returns_conflict_when_running(): void
+    {
+        Bus::fake();
+        Cache::put(CarCatalogSyncService::STATUS_CACHE_KEY, [
+            'running' => true,
+            'last_run' => null,
+        ]);
+        $this->authenticateAdmin();
+
+        $this->postJson('api/admin/car-catalog/sync')
+            ->assertStatus(409);
+
+        Bus::assertNotDispatched(SyncArgautosCarCatalogJob::class);
+    }
+
+    public function test_admin_can_read_sync_status(): void
+    {
+        Cache::put(CarCatalogSyncService::STATUS_CACHE_KEY, [
+            'running' => false,
+            'last_run' => ['models_created' => 3],
+        ]);
+        $this->authenticateAdmin();
+
+        $this->getJson('api/admin/car-catalog/sync-status')
+            ->assertOk()
+            ->assertJsonPath('data.last_run.models_created', 3);
+    }
+}

--- a/tests/Feature/Http/Admin/CarColorControllerTest.php
+++ b/tests/Feature/Http/Admin/CarColorControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Http\Admin;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\CarColor;
+use STS\Models\User;
+use Tests\TestCase;
+
+class CarColorControllerTest extends TestCase
+{
+    private function authenticateAdmin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+        $this->actingAs($admin->fresh(), 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        return $admin;
+    }
+
+    public function test_admin_lists_colors_with_hex(): void
+    {
+        $this->authenticateAdmin();
+        CarColor::factory()->create(['name' => 'Blanco', 'hex' => '#FFFFFF']);
+
+        $response = $this->getJson('api/admin/car-colors')->assertOk();
+        $row = collect($response->json('data'))->first();
+
+        $this->assertSame('Blanco', $row['name']);
+        $this->assertSame('#FFFFFF', $row['hex']);
+    }
+
+    public function test_admin_stores_color_with_valid_hex(): void
+    {
+        $this->authenticateAdmin();
+
+        $response = $this->postJson('api/admin/car-colors', [
+            'name' => 'Rojo',
+            'hex' => '#FF0000',
+            'sort_order' => 5,
+        ])->assertCreated();
+
+        $this->assertSame('Rojo', $response->json('data.name'));
+        $this->assertSame('#FF0000', $response->json('data.hex'));
+        $this->assertDatabaseHas('car_colors', ['name' => 'Rojo', 'hex' => '#FF0000']);
+    }
+
+    public function test_store_rejects_invalid_hex(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->postJson('api/admin/car-colors', [
+            'name' => 'Rojo',
+            'hex' => 'red',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['hex']);
+    }
+
+    public function test_admin_updates_color(): void
+    {
+        $this->authenticateAdmin();
+        $color = CarColor::factory()->create(['name' => 'Azul', 'hex' => '#0000FF']);
+
+        $this->putJson("api/admin/car-colors/{$color->id}", [
+            'name' => 'Azul Marino',
+            'hex' => '#000080',
+            'is_active' => true,
+            'sort_order' => 1,
+        ])->assertOk()
+            ->assertJsonPath('data.name', 'Azul Marino')
+            ->assertJsonPath('data.hex', '#000080');
+    }
+}

--- a/tests/Feature/Http/Admin/CarModelControllerTest.php
+++ b/tests/Feature/Http/Admin/CarModelControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Http\Admin;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\CarBrand;
+use STS\Models\CarModel;
+use STS\Models\User;
+use Tests\TestCase;
+
+class CarModelControllerTest extends TestCase
+{
+    private function authenticateAdmin(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+        $this->actingAs($admin->fresh(), 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+    }
+
+    public function test_admin_lists_models_for_brand(): void
+    {
+        $this->authenticateAdmin();
+        $brand = CarBrand::factory()->create();
+        CarModel::factory()->create(['car_brand_id' => $brand->id, 'name' => 'Corolla']);
+
+        $response = $this->getJson("api/admin/car-brands/{$brand->id}/models")->assertOk();
+
+        $this->assertTrue(
+            collect($response->json('data'))->contains(fn (array $row) => $row['name'] === 'Corolla')
+        );
+    }
+
+    public function test_admin_stores_model_for_brand(): void
+    {
+        $this->authenticateAdmin();
+        $brand = CarBrand::factory()->create(['name' => 'Toyota']);
+
+        $response = $this->postJson("api/admin/car-brands/{$brand->id}/models", [
+            'name' => 'Hilux',
+        ])->assertCreated();
+
+        $this->assertSame('Hilux', $response->json('data.name'));
+        $this->assertSame($brand->id, $response->json('data.car_brand_id'));
+    }
+}

--- a/tests/Feature/Http/CarApiTest.php
+++ b/tests/Feature/Http/CarApiTest.php
@@ -3,11 +3,27 @@
 namespace Tests\Feature\Http;
 
 use STS\Models\Car;
+use STS\Models\CarBrand;
+use STS\Models\CarColor;
+use STS\Models\CarModel;
 use STS\Models\User;
 use Tests\TestCase;
 
 class CarApiTest extends TestCase
 {
+    private function catalogPayload(array $overrides = []): array
+    {
+        $brand = CarBrand::factory()->create();
+        $model = CarModel::factory()->create(['car_brand_id' => $brand->id]);
+        $color = CarColor::factory()->create();
+
+        return array_merge([
+            'car_brand_id' => $brand->id,
+            'car_model_id' => $model->id,
+            'car_color_id' => $color->id,
+        ], $overrides);
+    }
+
     public function test_car_routes_require_authentication(): void
     {
         $this->getJson('api/cars')->assertUnauthorized()->assertJson(['message' => 'Unauthorized.']);
@@ -50,10 +66,10 @@ class CarApiTest extends TestCase
         $user = User::factory()->create(['active' => true, 'banned' => false]);
         $this->actingAs($user, 'api');
 
-        $create = $this->postJson('api/cars', [
+        $create = $this->postJson('api/cars', $this->catalogPayload([
             'patente' => 'CR1',
             'description' => 'Compact',
-        ]);
+        ]));
         $create->assertOk();
         $create->assertJsonStructure(['data' => ['id', 'patente', 'description', 'user_id', 'trips_count']]);
         $create->assertJsonPath('data.patente', 'CR1');
@@ -66,10 +82,10 @@ class CarApiTest extends TestCase
             ->assertJsonPath('data.id', $carId)
             ->assertJsonPath('data.patente', 'CR1');
 
-        $this->putJson('api/cars/'.$carId, [
+        $this->putJson('api/cars/'.$carId, $this->catalogPayload([
             'patente' => 'CR1U',
             'description' => 'Updated compact',
-        ])
+        ]))
             ->assertOk()
             ->assertJsonPath('data.patente', 'CR1U')
             ->assertJsonPath('data.description', 'Updated compact');
@@ -117,10 +133,10 @@ class CarApiTest extends TestCase
 
         $this->actingAs($user, 'api');
 
-        $this->postJson('api/cars', [
+        $this->postJson('api/cars', $this->catalogPayload([
             'patente' => 'HAS2',
             'description' => 'Second car',
-        ])
+        ]))
             ->assertOk()
             ->assertJsonPath('data.patente', 'HAS2');
     }
@@ -132,9 +148,9 @@ class CarApiTest extends TestCase
 
         $this->actingAs($user, 'api');
 
-        $this->postJson('api/cars', [
+        $this->postJson('api/cars', $this->catalogPayload([
             'patente' => 'DUP1',
             'description' => 'Duplicate patente',
-        ])->assertStatus(422);
+        ]))->assertStatus(422);
     }
 }

--- a/tests/Feature/Http/CarApiTest.php
+++ b/tests/Feature/Http/CarApiTest.php
@@ -116,6 +116,37 @@ class CarApiTest extends TestCase
             ->assertJsonPath('message', 'Could not found car.');
     }
 
+    public function test_update_allows_catalog_brand_with_custom_model(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        $brand = CarBrand::factory()->create(['name' => 'Ford']);
+        $color = CarColor::factory()->create();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'AE322FE',
+            'year' => 2011,
+            'car_color_id' => $color->id,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->putJson('api/cars/'.$car->id, [
+            'patente' => 'AE322FE',
+            'car_color_id' => $color->id,
+            'year' => 2011,
+            'car_brand_id' => $brand->id,
+            'model_other' => 'MiModelo',
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.car_brand_id', $brand->id)
+            ->assertJsonPath('data.model_other', 'MiModelo');
+
+        $fresh = $car->fresh();
+        $this->assertSame($brand->id, $fresh->car_brand_id);
+        $this->assertNull($fresh->car_model_id);
+        $this->assertSame('MiModelo', $fresh->model_other);
+    }
+
     public function test_create_returns_unprocessable_when_validation_fails(): void
     {
         $user = User::factory()->create(['active' => true, 'banned' => false]);

--- a/tests/Feature/Http/CarApiTest.php
+++ b/tests/Feature/Http/CarApiTest.php
@@ -21,6 +21,7 @@ class CarApiTest extends TestCase
             'car_brand_id' => $brand->id,
             'car_model_id' => $model->id,
             'car_color_id' => $color->id,
+            'year' => (int) date('Y') - 4,
         ], $overrides);
     }
 

--- a/tests/Feature/Http/CarCatalogApiTest.php
+++ b/tests/Feature/Http/CarCatalogApiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Models\CarBrand;
+use STS\Models\CarColor;
+use STS\Models\CarModel;
+use Tests\TestCase;
+
+class CarCatalogApiTest extends TestCase
+{
+    public function test_lists_active_brands_without_auth(): void
+    {
+        CarBrand::factory()->create(['name' => 'Toyota', 'is_active' => true]);
+        CarBrand::factory()->create(['name' => 'Hidden', 'is_active' => false]);
+
+        $response = $this->getJson('api/car-brands')->assertOk();
+
+        $names = collect($response->json('data'))->pluck('name')->all();
+        $this->assertSame(['Toyota'], $names);
+    }
+
+    public function test_lists_active_models_for_brand_without_hex_on_colors(): void
+    {
+        $brand = CarBrand::factory()->create();
+        CarModel::factory()->create(['car_brand_id' => $brand->id, 'name' => 'Corolla', 'is_active' => true]);
+        CarModel::factory()->create(['car_brand_id' => $brand->id, 'name' => 'Hidden', 'is_active' => false]);
+
+        $models = $this->getJson("api/car-brands/{$brand->id}/models")
+            ->assertOk()
+            ->json('data');
+
+        $this->assertSame(['Corolla'], collect($models)->pluck('name')->all());
+    }
+
+    public function test_lists_active_colors_without_hex(): void
+    {
+        CarColor::factory()->create(['name' => 'Blanco', 'hex' => '#FFFFFF', 'sort_order' => 1]);
+        CarColor::factory()->create(['name' => 'Hidden', 'is_active' => false]);
+
+        $row = $this->getJson('api/car-colors')
+            ->assertOk()
+            ->json('data.0');
+
+        $this->assertSame('Blanco', $row['name']);
+        $this->assertArrayNotHasKey('hex', $row);
+    }
+}

--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -239,7 +239,7 @@ class TripControllerIntegrationTest extends TestCase
             'nro_doc' => '30111222',
             'mobile_phone' => '+5493415551234',
         ]);
-        Car::factory()->create([
+        Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'OK123',
         ]);
@@ -313,7 +313,7 @@ class TripControllerIntegrationTest extends TestCase
             'nro_doc' => '30111222',
             'mobile_phone' => '+5493415551234',
         ]);
-        $car = Car::factory()->create([
+        $car = Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'ABC123',
         ]);
@@ -344,7 +344,7 @@ class TripControllerIntegrationTest extends TestCase
             'nro_doc' => '30111222',
             'mobile_phone' => '+5493415551234',
         ]);
-        Car::factory()->create([
+        Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'OK123',
         ]);
@@ -376,7 +376,7 @@ class TripControllerIntegrationTest extends TestCase
             'nro_doc' => '30111222',
             'mobile_phone' => '+5493415551234',
         ]);
-        Car::factory()->create([
+        Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'OK123',
         ]);

--- a/tests/Unit/CarsTest.php
+++ b/tests/Unit/CarsTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Unit;
 
 use STS\Models\Car;
+use STS\Models\CarBrand;
+use STS\Models\CarColor;
+use STS\Models\CarModel;
 use STS\Models\User;
 use STS\Services\Logic\CarsManager;
 use Tests\TestCase;
@@ -17,13 +20,26 @@ class CarsTest extends TestCase
         $this->carManager = $this->app->make(CarsManager::class);
     }
 
+    private function catalogCarData(array $overrides = []): array
+    {
+        $brand = CarBrand::factory()->create();
+        $model = CarModel::factory()->create(['car_brand_id' => $brand->id]);
+        $color = CarColor::factory()->create();
+
+        return array_merge([
+            'patente' => 'ASD123',
+            'description' => 'Sandero',
+            'car_brand_id' => $brand->id,
+            'car_model_id' => $model->id,
+            'car_color_id' => $color->id,
+            'year' => (int) date('Y') - 2,
+        ], $overrides);
+    }
+
     public function test_create_car_persists_for_user(): void
     {
         $user = User::factory()->create();
-        $data = [
-            'patente' => 'ASD123',
-            'description' => 'Sandero',
-        ];
+        $data = $this->catalogCarData();
 
         $car = $this->carManager->create($user, $data);
         $this->assertNotNull($car);

--- a/tests/Unit/Console/Commands/SyncArgautosCarCatalogTest.php
+++ b/tests/Unit/Console/Commands/SyncArgautosCarCatalogTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use STS\Services\Argautos\CarCatalogSyncService;
+use Tests\TestCase;
+
+class SyncArgautosCarCatalogTest extends TestCase
+{
+    public function test_command_runs_incremental_sync(): void
+    {
+        config([
+            'carpoolear.argautos_api_base_url' => 'https://argautos.test/api/v1',
+            'carpoolear.argautos_request_delay_ms' => 0,
+        ]);
+
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), '/brands/19/models')) {
+                return Http::response([
+                    'data' => [['id' => 227, 'brand_id' => 19, 'name' => 'FIESTA', 'slug' => 'fiesta']],
+                    'links' => ['next' => null],
+                ], 200);
+            }
+
+            return Http::response([
+                'data' => [['id' => 19, 'name' => 'FORD', 'slug' => 'ford']],
+                'links' => ['next' => null],
+            ], 200);
+        });
+
+        Cache::lock(CarCatalogSyncService::LOCK_KEY)->forceRelease();
+
+        $this->artisan('car-catalog:sync-argautos', ['--mode' => 'incremental'])
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('car_brands', ['argautos_id' => 19, 'name' => 'FORD']);
+        $this->assertDatabaseHas('car_models', ['argautos_id' => 227, 'name' => 'FIESTA']);
+    }
+}

--- a/tests/Unit/Models/CarBrandTest.php
+++ b/tests/Unit/Models/CarBrandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use STS\Models\CarBrand;
+use STS\Models\CarModel;
+use Tests\TestCase;
+
+class CarBrandTest extends TestCase
+{
+    public function test_car_model_belongs_to_brand(): void
+    {
+        $brand = CarBrand::factory()->create(['name' => 'Toyota']);
+        $model = CarModel::factory()->create([
+            'car_brand_id' => $brand->id,
+            'name' => 'Corolla',
+        ]);
+
+        $this->assertTrue($model->fresh()->brand->is($brand));
+    }
+
+    public function test_active_scope_returns_only_active_brands(): void
+    {
+        CarBrand::factory()->create(['name' => 'Active', 'is_active' => true]);
+        CarBrand::factory()->create(['name' => 'Inactive', 'is_active' => false]);
+
+        $names = CarBrand::active()->pluck('name')->all();
+
+        $this->assertSame(['Active'], $names);
+    }
+
+    public function test_brand_has_many_models(): void
+    {
+        $brand = CarBrand::factory()->create();
+        CarModel::factory()->count(2)->create(['car_brand_id' => $brand->id]);
+
+        $this->assertCount(2, $brand->fresh()->models);
+    }
+}

--- a/tests/Unit/Models/CarColorTest.php
+++ b/tests/Unit/Models/CarColorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use STS\Models\CarColor;
+use Tests\TestCase;
+
+class CarColorTest extends TestCase
+{
+    public function test_active_scope_orders_by_sort_order_then_name(): void
+    {
+        CarColor::factory()->create(['name' => 'Zul', 'sort_order' => 2, 'is_active' => true]);
+        CarColor::factory()->create(['name' => 'Azul', 'sort_order' => 1, 'is_active' => true]);
+        CarColor::factory()->create(['name' => 'Hidden', 'is_active' => false]);
+
+        $names = CarColor::active()->pluck('name')->all();
+
+        $this->assertSame(['Azul', 'Zul'], $names);
+    }
+}

--- a/tests/Unit/Models/CarTest.php
+++ b/tests/Unit/Models/CarTest.php
@@ -115,6 +115,25 @@ class CarTest extends TestCase
         $this->assertTrue($car->isComplete());
     }
 
+    public function test_is_complete_with_catalog_brand_and_custom_model(): void
+    {
+        $user = User::factory()->create();
+        $brand = \STS\Models\CarBrand::factory()->create();
+        $color = \STS\Models\CarColor::factory()->create();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'AB123CD',
+            'year' => (int) date('Y') - 6,
+            'car_color_id' => $color->id,
+            'car_brand_id' => $brand->id,
+            'car_model_id' => null,
+            'brand_other' => null,
+            'model_other' => 'Custom Model',
+        ]);
+
+        $this->assertTrue($car->isComplete());
+    }
+
     public function test_is_complete_with_other_brand_and_model(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Models/CarTest.php
+++ b/tests/Unit/Models/CarTest.php
@@ -106,4 +106,36 @@ class CarTest extends TestCase
 
         $this->assertInstanceOf(CarFactory::class, $factory);
     }
+
+    public function test_is_complete_with_catalog_brand_and_model(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->withCatalog()->create(['user_id' => $user->id]);
+
+        $this->assertTrue($car->isComplete());
+    }
+
+    public function test_is_complete_with_other_brand_and_model(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'AB123CD',
+            'brand_other' => 'Custom Brand',
+            'model_other' => 'Custom Model',
+        ]);
+
+        $this->assertTrue($car->isComplete());
+    }
+
+    public function test_is_not_complete_with_patente_only(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'AB123CD',
+        ]);
+
+        $this->assertFalse($car->isComplete());
+    }
 }

--- a/tests/Unit/Models/CarTest.php
+++ b/tests/Unit/Models/CarTest.php
@@ -118,10 +118,12 @@ class CarTest extends TestCase
     public function test_is_complete_with_other_brand_and_model(): void
     {
         $user = User::factory()->create();
+        $color = \STS\Models\CarColor::factory()->create();
         $car = Car::factory()->create([
             'user_id' => $user->id,
             'patente' => 'AB123CD',
             'year' => (int) date('Y') - 6,
+            'car_color_id' => $color->id,
             'brand_other' => 'Custom Brand',
             'model_other' => 'Custom Model',
         ]);

--- a/tests/Unit/Models/CarTest.php
+++ b/tests/Unit/Models/CarTest.php
@@ -140,6 +140,17 @@ class CarTest extends TestCase
         $this->assertFalse($car->isComplete());
     }
 
+    public function test_is_not_complete_without_color(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->withCatalog()->create([
+            'user_id' => $user->id,
+            'car_color_id' => null,
+        ]);
+
+        $this->assertFalse($car->isComplete());
+    }
+
     public function test_is_not_complete_without_year(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Models/CarTest.php
+++ b/tests/Unit/Models/CarTest.php
@@ -121,6 +121,7 @@ class CarTest extends TestCase
         $car = Car::factory()->create([
             'user_id' => $user->id,
             'patente' => 'AB123CD',
+            'year' => (int) date('Y') - 6,
             'brand_other' => 'Custom Brand',
             'model_other' => 'Custom Model',
         ]);
@@ -134,6 +135,28 @@ class CarTest extends TestCase
         $car = Car::factory()->create([
             'user_id' => $user->id,
             'patente' => 'AB123CD',
+        ]);
+
+        $this->assertFalse($car->isComplete());
+    }
+
+    public function test_is_not_complete_without_year(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->withCatalog()->create([
+            'user_id' => $user->id,
+            'year' => null,
+        ]);
+
+        $this->assertFalse($car->isComplete());
+    }
+
+    public function test_is_not_complete_with_invalid_year(): void
+    {
+        $user = User::factory()->create();
+        $car = Car::factory()->withCatalog()->create([
+            'user_id' => $user->id,
+            'year' => 1800,
         ]);
 
         $this->assertFalse($car->isComplete());

--- a/tests/Unit/Services/Argautos/CarCatalogSyncServiceTest.php
+++ b/tests/Unit/Services/Argautos/CarCatalogSyncServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Services\Argautos;
+
+use Illuminate\Support\Facades\Http;
+use STS\Models\CarBrand;
+use STS\Models\CarModel;
+use STS\Services\Argautos\CarCatalogSyncService;
+use Tests\TestCase;
+
+class CarCatalogSyncServiceTest extends TestCase
+{
+    public function test_should_import_model_name_filters_versions(): void
+    {
+        $service = new CarCatalogSyncService;
+
+        $this->assertFalse($service->shouldImportModelName('4P 1,4 TDCI MAX'));
+        $this->assertFalse($service->shouldImportModelName('FIESTA TDCI'));
+        $this->assertFalse($service->shouldImportModelName('FOCUS AT'));
+        $this->assertFalse($service->shouldImportModelName('COROLLA CVT'));
+        $this->assertTrue($service->shouldImportModelName('COROLLA'));
+        $this->assertTrue($service->shouldImportModelName('HILUX PICK - UP'));
+    }
+
+    public function test_sync_incremental_creates_new_brands_and_models(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), '/brands/60/models')) {
+                return Http::response([
+                    'data' => [
+                        ['id' => 563, 'brand_id' => 60, 'name' => 'COROLLA', 'slug' => 'corolla'],
+                        ['id' => 643, 'brand_id' => 60, 'name' => '4P 1,5 XLS 4AT 2022', 'slug' => 'version'],
+                    ],
+                    'links' => ['next' => null],
+                ], 200);
+            }
+
+            return Http::response([
+                'data' => [
+                    ['id' => 60, 'name' => 'TOYOTA', 'slug' => 'toyota'],
+                ],
+                'links' => ['next' => null],
+            ], 200);
+        });
+
+        $service = new CarCatalogSyncService('https://argautos.test/api/v1', null, 0);
+        $summary = $service->sync('incremental', false);
+
+        $this->assertSame(1, $summary['brands_created']);
+        $this->assertSame(1, $summary['models_created']);
+        $this->assertSame(1, $summary['models_skipped']);
+        $this->assertDatabaseHas('car_brands', ['argautos_id' => 60, 'name' => 'TOYOTA']);
+        $this->assertDatabaseHas('car_models', ['argautos_id' => 563, 'name' => 'COROLLA']);
+        $this->assertDatabaseMissing('car_models', ['argautos_id' => 643]);
+    }
+
+    public function test_sync_incremental_skips_existing_argautos_ids(): void
+    {
+        $brand = CarBrand::factory()->create(['argautos_id' => 60, 'name' => 'TOYOTA']);
+        CarModel::factory()->create([
+            'car_brand_id' => $brand->id,
+            'argautos_id' => 563,
+            'name' => 'COROLLA',
+        ]);
+
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), '/brands/60/models')) {
+                return Http::response([
+                    'data' => [
+                        ['id' => 563, 'brand_id' => 60, 'name' => 'COROLLA', 'slug' => 'corolla'],
+                        ['id' => 564, 'brand_id' => 60, 'name' => 'YARIS', 'slug' => 'yaris'],
+                    ],
+                    'links' => ['next' => null],
+                ], 200);
+            }
+
+            return Http::response([
+                'data' => [
+                    ['id' => 60, 'name' => 'TOYOTA', 'slug' => 'toyota'],
+                ],
+                'links' => ['next' => null],
+            ], 200);
+        });
+
+        $service = new CarCatalogSyncService('https://argautos.test/api/v1', null, 0);
+        $summary = $service->sync('incremental', false);
+
+        $this->assertSame(0, $summary['brands_created']);
+        $this->assertSame(1, $summary['models_created']);
+        $this->assertDatabaseHas('car_models', ['argautos_id' => 564, 'name' => 'YARIS']);
+    }
+}

--- a/tests/Unit/Services/Logic/CarsManagerTest.php
+++ b/tests/Unit/Services/Logic/CarsManagerTest.php
@@ -38,6 +38,7 @@ class CarsManagerTest extends TestCase
             'car_brand_id' => $brand->id,
             'car_model_id' => $model->id,
             'car_color_id' => $color->id,
+            'year' => (int) date('Y') - 1,
         ];
     }
 
@@ -48,6 +49,24 @@ class CarsManagerTest extends TestCase
         $this->assertTrue($v->errors()->has('patente'));
         $this->assertTrue($v->errors()->has('car_color_id'));
         $this->assertTrue($v->errors()->has('car_brand_id'));
+        $this->assertTrue($v->errors()->has('year'));
+    }
+
+    public function test_validator_rejects_year_outside_allowed_range(): void
+    {
+        $v = $this->manager()->validator(array_merge($this->validCarData(), [
+            'year' => 1899,
+        ]), 1, null, true);
+
+        $this->assertTrue($v->fails());
+        $this->assertTrue($v->errors()->has('year'));
+
+        $v = $this->manager()->validator(array_merge($this->validCarData(), [
+            'year' => (int) date('Y') + 1,
+        ]), 1, null, true);
+
+        $this->assertTrue($v->fails());
+        $this->assertTrue($v->errors()->has('year'));
     }
 
     public function test_validator_enforces_unique_patente_per_user_on_create(): void
@@ -368,6 +387,7 @@ class CarsManagerTest extends TestCase
         $car = $manager->create($user, [
             'patente' => 'OT1234',
             'car_color_id' => $color->id,
+            'year' => (int) date('Y') - 5,
             'brand_other' => 'Custom Make',
             'model_other' => 'Custom Model',
         ]);

--- a/tests/Unit/Services/Logic/CarsManagerTest.php
+++ b/tests/Unit/Services/Logic/CarsManagerTest.php
@@ -245,6 +245,60 @@ class CarsManagerTest extends TestCase
         $this->assertSame('After update', $updated->fresh()->description);
     }
 
+    public function test_update_allows_catalog_brand_with_custom_model(): void
+    {
+        $user = User::factory()->create();
+        $brand = CarBrand::factory()->create(['name' => 'Ford']);
+        $color = CarColor::factory()->create();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'AE322FE',
+            'year' => 2011,
+            'car_color_id' => $color->id,
+        ]);
+
+        $manager = $this->manager();
+        $updated = $manager->update($user, $car->id, [
+            'patente' => 'AE322FE',
+            'car_color_id' => $color->id,
+            'year' => 2011,
+            'car_brand_id' => $brand->id,
+            'model_other' => 'MiModelo',
+        ]);
+
+        $this->assertNotNull($updated);
+        $fresh = $updated->fresh();
+        $this->assertSame($brand->id, $fresh->car_brand_id);
+        $this->assertNull($fresh->car_model_id);
+        $this->assertNull($fresh->brand_other);
+        $this->assertSame('MiModelo', $fresh->model_other);
+        $this->assertTrue($fresh->isComplete());
+    }
+
+    public function test_create_allows_catalog_brand_with_custom_model(): void
+    {
+        $user = User::factory()->create();
+        $brand = CarBrand::factory()->create(['name' => 'Ford']);
+        $color = CarColor::factory()->create();
+        $patente = 'CB'.substr(uniqid('', true), 0, 6);
+
+        $manager = $this->manager();
+        $created = $manager->create($user, [
+            'patente' => $patente,
+            'description' => 'Custom model car',
+            'car_brand_id' => $brand->id,
+            'model_other' => 'MiModelo',
+            'car_color_id' => $color->id,
+            'year' => 2011,
+        ]);
+
+        $this->assertNotNull($created);
+        $this->assertSame($brand->id, $created->car_brand_id);
+        $this->assertNull($created->car_model_id);
+        $this->assertSame('MiModelo', $created->model_other);
+        $this->assertTrue($created->isComplete());
+    }
+
     public function test_validator_update_allows_same_patente_for_current_car_id(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Services/Logic/CarsManagerTest.php
+++ b/tests/Unit/Services/Logic/CarsManagerTest.php
@@ -4,6 +4,9 @@ namespace Tests\Unit\Services\Logic;
 
 use Mockery;
 use STS\Models\Car;
+use STS\Models\CarBrand;
+use STS\Models\CarColor;
+use STS\Models\CarModel;
 use STS\Models\User;
 use STS\Repository\CarsRepository;
 use STS\Services\Logic\CarsManager;
@@ -25,19 +28,26 @@ class CarsManagerTest extends TestCase
     private function validCarData(string $patenteSuffix = ''): array
     {
         $suffix = $patenteSuffix ?: substr(uniqid('', true), 0, 4);
+        $brand = CarBrand::factory()->create();
+        $model = CarModel::factory()->create(['car_brand_id' => $brand->id]);
+        $color = CarColor::factory()->create();
 
         return [
             'patente' => 'AA'.$suffix,
             'description' => 'Family car',
+            'car_brand_id' => $brand->id,
+            'car_model_id' => $model->id,
+            'car_color_id' => $color->id,
         ];
     }
 
-    public function test_validator_requires_patente_and_description(): void
+    public function test_validator_requires_patente_and_catalog_on_create(): void
     {
-        $v = $this->manager()->validator([], 1);
+        $v = $this->manager()->validator([], 1, null, true);
         $this->assertTrue($v->fails());
         $this->assertTrue($v->errors()->has('patente'));
-        $this->assertTrue($v->errors()->has('description'));
+        $this->assertTrue($v->errors()->has('car_color_id'));
+        $this->assertTrue($v->errors()->has('car_brand_id'));
     }
 
     public function test_validator_enforces_unique_patente_per_user_on_create(): void
@@ -50,10 +60,10 @@ class CarsManagerTest extends TestCase
             'description' => 'First',
         ]);
 
-        $v = $this->manager()->validator([
+        $v = $this->manager()->validator(array_merge($this->validCarData(), [
             'patente' => $patente,
             'description' => 'Second',
-        ], $user->id);
+        ]), $user->id, null, true);
 
         $this->assertTrue($v->fails());
         $this->assertTrue($v->errors()->has('patente'));
@@ -91,10 +101,10 @@ class CarsManagerTest extends TestCase
         ]);
 
         $manager = $this->manager();
-        $result = $manager->create($user, [
+        $result = $manager->create($user, array_merge($this->validCarData(), [
             'patente' => $patente,
             'description' => 'Duplicate attempt',
-        ]);
+        ]));
 
         $this->assertNull($result);
         $errors = $manager->getErrors();
@@ -113,10 +123,10 @@ class CarsManagerTest extends TestCase
         $old->delete();
 
         $manager = $this->manager();
-        $car = $manager->create($user, [
+        $car = $manager->create($user, array_merge($this->validCarData(), [
             'patente' => $patente,
             'description' => 'Replacement car',
-        ]);
+        ]));
 
         $this->assertInstanceOf(Car::class, $car);
         $this->assertSame($patente, $car->patente);
@@ -135,10 +145,10 @@ class CarsManagerTest extends TestCase
         $old->delete();
 
         $manager = $this->manager();
-        $car = $manager->create($user, [
+        $car = $manager->create($user, array_merge($this->validCarData(), [
             'patente' => $patente,
             'description' => 'Restored car',
-        ]);
+        ]));
 
         $this->assertInstanceOf(Car::class, $car);
         $this->assertSame($oldId, $car->id);
@@ -171,10 +181,10 @@ class CarsManagerTest extends TestCase
         $user = User::factory()->create();
         $manager = $this->manager();
 
-        $result = $manager->create($user, [
+        $result = $manager->create($user, array_merge($this->validCarData(), [
             'patente' => 'TOOLONGPATX',
             'description' => 'x',
-        ]);
+        ]));
 
         $this->assertNull($result);
         $this->assertNotNull($manager->getErrors());
@@ -207,10 +217,10 @@ class CarsManagerTest extends TestCase
         ]);
 
         $manager = $this->manager();
-        $updated = $manager->update($user, $car->id, [
+        $updated = $manager->update($user, $car->id, array_merge($this->validCarData(), [
             'patente' => 'ZZ'.substr(uniqid('', true), 0, 6),
             'description' => 'After update',
-        ]);
+        ]));
 
         $this->assertNotNull($updated);
         $this->assertSame('After update', $updated->fresh()->description);
@@ -228,6 +238,8 @@ class CarsManagerTest extends TestCase
         $v = $this->manager()->validator([
             'patente' => 'AA123BB',
             'description' => 'Updated description',
+            'brand_other' => 'Custom',
+            'model_other' => 'Model',
         ], $user->id, $car->id);
 
         $this->assertFalse($v->fails());
@@ -249,10 +261,10 @@ class CarsManagerTest extends TestCase
         ]);
 
         $manager = $this->manager();
-        $result = $manager->update($user, $target->id, [
+        $result = $manager->update($user, $target->id, array_merge($this->validCarData(), [
             'patente' => 'DUP123',
             'description' => 'Should pass',
-        ]);
+        ]));
 
         $this->assertNotNull($result);
         $this->assertSame('DUP123', $result->fresh()->patente);
@@ -280,11 +292,12 @@ class CarsManagerTest extends TestCase
         $result = $manager->update($user, $car->id, [
             'patente' => 'TOOLONGPATX',
             'description' => '',
+            'brand_other' => 'Other brand',
+            'model_other' => 'Other model',
         ]);
 
         $this->assertNull($result);
         $this->assertTrue($manager->getErrors()->has('patente'));
-        $this->assertTrue($manager->getErrors()->has('description'));
     }
 
     public function test_show_accepts_equivalent_scalar_ids_for_owner_check(): void
@@ -344,6 +357,24 @@ class CarsManagerTest extends TestCase
         $manager = new CarsManager($repo);
         $this->assertNull($manager->delete($user, $car->id));
         $this->assertSame('can_delete_car', $manager->getErrors()['error']);
+    }
+
+    public function test_create_with_other_brand_and_model(): void
+    {
+        $user = User::factory()->create();
+        $color = CarColor::factory()->create();
+        $manager = $this->manager();
+
+        $car = $manager->create($user, [
+            'patente' => 'OT1234',
+            'car_color_id' => $color->id,
+            'brand_other' => 'Custom Make',
+            'model_other' => 'Custom Model',
+        ]);
+
+        $this->assertInstanceOf(Car::class, $car);
+        $this->assertSame('Custom Make', $car->brand_other);
+        $this->assertSame('Custom Model', $car->model_other);
     }
 
     public function test_index_delegates_to_repository(): void

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -79,7 +79,7 @@ class TripsManagerTest extends TestCase
 
     private function carWithPlateFor(User $user, array $overrides = []): Car
     {
-        return Car::factory()->create(array_merge([
+        return Car::factory()->withCatalog()->create(array_merge([
             'user_id' => $user->id,
             'patente' => 'ABC123',
         ], $overrides));
@@ -702,16 +702,36 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_create_driver_trip_rejects_incomplete_car(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $user = $this->completeUser();
+        $car = Car::factory()->create([
+            'user_id' => $user->id,
+            'patente' => 'LEGACY1',
+            'description' => 'Legacy',
+        ]);
+
+        $manager = $this->manager();
+        $result = $manager->create($user, $this->minimalCreatePayload([
+            'car_id' => $car->id,
+        ]));
+
+        $this->assertNull($result);
+        $this->assertTrue($manager->getErrors()->has('car_incomplete'));
+        Carbon::setTestNow();
+    }
+
     public function test_create_driver_trip_requires_car_id_when_user_has_multiple_active_cars(): void
     {
         Carbon::setTestNow('2028-02-01 10:00:00');
         $user = $this->completeUser();
-        Car::factory()->create([
+        Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'CAR001',
             'description' => 'First',
         ]);
-        Car::factory()->create([
+        Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'CAR002',
             'description' => 'Second',
@@ -741,12 +761,12 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow('2028-02-01 10:00:00');
         Event::fake([CreateEvent::class]);
         $user = $this->completeUser();
-        $first = Car::factory()->create([
+        $first = Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'CAR001',
             'description' => 'First',
         ]);
-        $second = Car::factory()->create([
+        $second = Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'CAR002',
             'description' => 'Second',
@@ -781,12 +801,12 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow('2028-02-01 10:00:00');
         Event::fake([CreateEvent::class]);
         $user = $this->completeUser();
-        $deletedCar = Car::factory()->create([
+        $deletedCar = Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'OLD001',
             'description' => 'Removed',
         ]);
-        $replacementCar = Car::factory()->create([
+        $replacementCar = Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'NEW002',
             'description' => 'Replacement',
@@ -847,12 +867,12 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow('2028-02-01 10:00:00');
         Event::fake([CreateEvent::class]);
         $user = $this->completeUser();
-        Car::factory()->create([
+        Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'CAR001',
             'description' => 'First',
         ]);
-        $second = Car::factory()->create([
+        $second = Car::factory()->withCatalog()->create([
             'user_id' => $user->id,
             'patente' => 'CAR002',
             'description' => 'Second',

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -185,10 +185,29 @@ class TripTransformerTest extends TestCase
         $this->assertArrayNotHasKey('hidden', $deletedPayload);
     }
 
+    public function test_transform_includes_catalog_names_on_car(): void
+    {
+        $owner = User::factory()->create(['is_admin' => true]);
+        $car = Car::factory()->withCatalog()->create([
+            'user_id' => $owner->id,
+            'patente' => 'CAT123',
+        ]);
+        $trip = $this->makeTrip([
+            'user_id' => $owner->id,
+            'car_id' => $car->id,
+        ]);
+
+        $payload = (new TripTransformer($owner))->transform($trip->fresh(['car']));
+
+        $this->assertNotEmpty($payload['car']['brand_name']);
+        $this->assertNotEmpty($payload['car']['model_name']);
+        $this->assertNotEmpty($payload['car']['color_name']);
+    }
+
     public function test_transform_marks_soft_deleted_car_on_trip(): void
     {
         $owner = User::factory()->create(['is_admin' => true]);
-        $car = Car::factory()->create([
+        $car = Car::factory()->withCatalog()->create([
             'user_id' => $owner->id,
             'patente' => 'DEL123',
             'description' => 'Removed car',

--- a/tests/Unit/TripsTest.php
+++ b/tests/Unit/TripsTest.php
@@ -49,7 +49,7 @@ class TripsTest extends TestCase
                 'nro_doc' => '30111222',
                 'mobile_phone' => '+5493415551234',
             ]);
-            $car = \STS\Models\Car::factory()->create(['user_id' => $user->id]);
+            $car = \STS\Models\Car::factory()->withCatalog()->create(['user_id' => $user->id]);
             $tripManager = \App::make(\STS\Services\Logic\TripsManager::class);
 
             $data = [


### PR DESCRIPTION
## Summary

Adds structured car data (marca, modelo, año, color) via a catalog + custom “Otro” fields, moves car management to **Configuración → Autos**, and lets drivers edit cars from **Crear viaje** without leaving the form. Trip detail shows structured car info instead of patente-only text.

---

## Backend (`carpoolear_backend` — `car-changes`)

### Car catalog & persistence
- **Cause:** Cars only stored patente/description; no shared marca/modelo/color catalog.
- **Fix:** New `car_brands`, `car_models`, `car_colors` tables; `cars` extended with FKs, `brand_other`/`model_other`, and `year`. Admin CRUD + public catalog API. Argautos sync command/job + weekly cron.

### Car completeness on driver trips
- **Cause:** Incomplete cars could be used on trips; API payloads lacked catalog fields.
- **Fix:** `Car::isComplete()` requires patente, valid year, color, and brand+model (catalog or both “Otro”). `CarsManager` validates on create/update; `TripsManager` blocks incomplete cars; trip/profile transformers expose brand/model/color/year names.

### Catalog brand + custom model (“Otro”)
- **Cause:** Validation used XOR rules (`car_brand_id` ↔ `car_model_id` and `brand_other` ↔ `model_other`), rejecting valid combos like Ford + `model_other`. `normalizePayload()` cleared `model_other` when using a catalog brand.
- **Fix:** Allow `car_brand_id` + `model_other`; persist hybrid in `normalizePayload()`; treat as complete in `Car::isComplete()`. Regression tests in `CarsManagerTest`, `CarApiTest`, `CarTest`.
