### PR TITLE
Group chat trip

### DIFF
--- a/app/Http/Controllers/Api/v1/ConversationController.php
+++ b/app/Http/Controllers/Api/v1/ConversationController.php
@@ -60,6 +60,17 @@ class ConversationController extends Controller
         }
     }
 
+    public function showByTrip($tripId)
+    {
+        $this->user = auth()->user();
+        $conversation = $this->conversationLogic->getConversationByTrip($this->user, $tripId);
+        if ($conversation) {
+            return $this->item($conversation, new ConversationsTransformer($this->user));
+        }
+
+        throw new ExceptionWithErrors('Bad request exceptions');
+    }
+
     public function create(Request $request)
     {
         $this->user = auth()->user();

--- a/app/Http/Controllers/Api/v1/ConversationController.php
+++ b/app/Http/Controllers/Api/v1/ConversationController.php
@@ -131,6 +131,18 @@ class ConversationController extends Controller
         throw new ExceptionWithErrors('Bad request exceptions', $this->conversationLogic->getErrors());
     }
 
+    public function updateNotifications(Request $request, $id)
+    {
+        $this->user = auth()->user();
+        $enabled = parse_boolean($request->get('enabled'));
+        $conversation = $this->conversationLogic->setConversationNotifications($this->user, $id, $enabled);
+        if ($conversation) {
+            return $this->item($conversation, new ConversationsTransformer($this->user));
+        }
+
+        throw new ExceptionWithErrors('Bad request exceptions', $this->conversationLogic->getErrors());
+    }
+
     public function users(Request $request, $id)
     {
         $this->user = auth()->user();

--- a/app/Listeners/Conversation/addUserConversation.php
+++ b/app/Listeners/Conversation/addUserConversation.php
@@ -3,33 +3,35 @@
 namespace STS\Listeners\Conversation;
 
 use STS\Events\Passenger\Accept;
-use STS\Repository\ConversationRepository; 
+use STS\Repository\ConversationRepository;
+use STS\Services\Logic\ConversationsManager;
 
 class addUserConversation
 {
     protected $conversationRepo;
 
-    /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct(ConversationRepository $repo)
+    protected $conversationLogic;
+
+    public function __construct(ConversationRepository $repo, ConversationsManager $logic)
     {
         $this->conversationRepo = $repo;
+        $this->conversationLogic = $logic;
     }
 
-    /**
-     * Handle the event.
-     *
-     * @param  Accept  $event
-     * @return void
-     */
     public function handle(Accept $event)
     {
         $converstion = $event->trip->conversation;
         if ($converstion) {
             $this->conversationRepo->addUser($converstion, $event->to);
+            $subject = is_object($event->to) ? $event->to : \STS\Models\User::find($event->to);
+            if ($subject) {
+                $this->conversationLogic->sendSystemMessage(
+                    $converstion->fresh(),
+                    $subject,
+                    'notifications.group_chat_user_joined',
+                    ['name' => $subject->name]
+                );
+            }
         }
     }
 }

--- a/app/Listeners/Conversation/removeUserConversation.php
+++ b/app/Listeners/Conversation/removeUserConversation.php
@@ -3,33 +3,35 @@
 namespace STS\Listeners\Conversation;
 
 use STS\Events\Passenger\Cancel;
-use STS\Repository\ConversationRepository; 
+use STS\Models\User;
+use STS\Repository\ConversationRepository;
+use STS\Services\Logic\ConversationsManager;
 
 class removeUserConversation
 {
     protected $conversationRepo;
 
-    /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct(ConversationRepository $logic)
+    protected $conversationLogic;
+
+    public function __construct(ConversationRepository $logic, ConversationsManager $conversationLogic)
     {
         $this->conversationRepo = $logic;
+        $this->conversationLogic = $conversationLogic;
     }
 
-    /**
-     * Handle the event.
-     *
-     * @param  Cancel  $event
-     * @return void
-     */
     public function handle(Cancel $event)
     {
         $converstion = $event->trip->conversation;
         if ($converstion) {
             $user = $event->trip->user_id == $event->from->id ? $event->to : $event->from;
+            if ($user instanceof User) {
+                $this->conversationLogic->sendSystemMessage(
+                    $converstion->fresh(),
+                    $user,
+                    'notifications.group_chat_user_left',
+                    ['name' => $user->name]
+                );
+            }
             $this->conversationRepo->removeUser($converstion, $user);
         }
     }

--- a/app/Listeners/Notification/MessageSend.php
+++ b/app/Listeners/Notification/MessageSend.php
@@ -28,6 +28,13 @@ class MessageSend implements ShouldQueue
         $from = $event->from;
         $to = $event->to;
         $message = $event->message;
+        $conversation = $message->conversation ?? null;
+        if (! $conversation && isset($message->conversation_id)) {
+            $conversation = \STS\Models\Conversation::find($message->conversation_id);
+        }
+        if ($conversation && ! $conversation->notificationsEnabled($to)) {
+            return;
+        }
         $notification = new NewMessagePushNotification;
         $notification->setAttribute('from', $from);
         $notification->setAttribute('messages', $message);

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -39,7 +39,7 @@ class Conversation extends Model
 
     public function users()
     {
-        return $this->belongsToMany('STS\Models\User', 'conversations_users', 'conversation_id', 'user_id')->withPivot('read')->withTimestamps();
+        return $this->belongsToMany('STS\Models\User', 'conversations_users', 'conversation_id', 'user_id')->withPivot('read', 'notifications_enabled')->withTimestamps();
     }
 
     public function read(UserModel $user)
@@ -47,6 +47,17 @@ class Conversation extends Model
         $userRelation = $this->users()->whereKey($user->id)->first();
 
         return $userRelation ? $userRelation->pivot->read : false;
+    }
+
+    public function notificationsEnabled(UserModel $user)
+    {
+        $userRelation = $this->users()->whereKey($user->id)->first();
+
+        if (! $userRelation) {
+            return true;
+        }
+
+        return (bool) ($userRelation->pivot->notifications_enabled ?? true);
     }
 
     public function messages()

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -18,6 +18,7 @@ class Message extends Model
         'text',
         'estado',
         'conversation_id',
+        'is_system',
     ];
 
     protected $touches = ['conversation'];
@@ -26,6 +27,7 @@ class Message extends Model
         'user_id' => 'integer',
         'conversation_id' => 'integer',
         'created_at' => 'datetime',
+        'is_system' => 'boolean',
     ];
 
     public function conversation()

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -229,7 +229,8 @@ class Trip extends Model
 
     public function conversation()
     {
-        return $this->hasOne('STS\Models\Conversation', 'trip_id');
+        return $this->hasOne('STS\Models\Conversation', 'trip_id')
+            ->where('type', Conversation::TYPE_TRIP_CONVERSATION);
     }
 
     public function payments()
@@ -250,6 +251,21 @@ class Trip extends Model
     public function isPassenger($user)
     {
         return $this->passengerAccepted->where('user_id', $user->id)->count() > 0;
+    }
+
+    public function canAccessGroupChat($user)
+    {
+        if ((int) $this->user_id === (int) $user->id) {
+            return true;
+        }
+
+        return $this->passenger()
+            ->where('user_id', $user->id)
+            ->whereIn('request_state', [
+                Passenger::STATE_ACCEPTED,
+                Passenger::STATE_WAITING_PAYMENT,
+            ])
+            ->exists();
     }
 
     public function getSeatsAvailableAttribute()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -277,7 +277,7 @@ class User extends Authenticatable implements JWTSubject
 
     public function conversations()
     {
-        return $this->belongsToMany('STS\Models\Conversation', 'conversations_users', 'user_id', 'conversation_id')->withPivot('read');
+        return $this->belongsToMany('STS\Models\Conversation', 'conversations_users', 'user_id', 'conversation_id')->withPivot('read', 'notifications_enabled');
     }
 
     public function tripsAsPassenger($state = null, $hours_range = null, $date = null)

--- a/app/Notifications/NewMessagePushNotification.php
+++ b/app/Notifications/NewMessagePushNotification.php
@@ -2,17 +2,17 @@
 
 namespace STS\Notifications;
 
-use  STS\Services\Notifications\BaseNotification;
-use  STS\Services\Notifications\Channels\MailChannel;
-use  STS\Services\Notifications\Channels\PushChannel;
-use  STS\Services\Notifications\Channels\DatabaseChannel;
-use  STS\Services\Notifications\Channels\FacebookChannel;
+use STS\Models\Conversation;
+use STS\Models\Trip;
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
 
 class NewMessagePushNotification extends BaseNotification
 {
     protected $via = [
         PushChannel::class,
-        DatabaseChannel::class, 
+        DatabaseChannel::class,
     ];
 
     public function toEmail($user)
@@ -25,22 +25,25 @@ class NewMessagePushNotification extends BaseNotification
         return [
             'title' => __('notifications.new_message.title', ['name' => $senderName]),
             'email_view' => 'new_message',
-            'url' => config('app.url') . '/app/conversations/'.$conversationId,
+            'url' => config('app.url').'/app/conversations/'.$conversationId,
             'name_app' => config('carpoolear.name_app'),
-            'domain' => config('app.url')
+            'domain' => config('app.url'),
         ];
     }
 
     public function toString()
     {
         $from = $this->getAttribute('from');
+        $message = $this->getAttribute('messages');
         $senderName = $from ? $from->name : __('notifications.someone');
-        return __('notifications.new_message.title', ['name' => $senderName]);
+
+        return $this->buildNotificationText($message, $senderName, false);
     }
 
     public function getExtras()
     {
         $messages = $this->getAttribute('messages');
+
         return [
             'type' => 'conversation',
             'conversation_id' => $messages ? $messages->conversation_id : null,
@@ -52,11 +55,10 @@ class NewMessagePushNotification extends BaseNotification
         $message = $this->getAttribute('messages');
         $from = $this->getAttribute('from');
         $senderName = $from ? $from->name : __('notifications.new_message.new_message');
-        $messageText = $message ? $message->text : '';
         $conversationId = $message ? $message->conversation_id : '';
 
         return [
-            'message' => $senderName.' @ '.$messageText,
+            'message' => $this->buildNotificationText($message, $senderName, true),
             'url' => '/conversations/'.$conversationId,
             'type' => 'conversation',
             'extras' => [
@@ -64,5 +66,41 @@ class NewMessagePushNotification extends BaseNotification
             ],
             'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
         ];
+    }
+
+    private function buildNotificationText($message, string $senderName, bool $includeMessageText): string
+    {
+        $messageText = $message ? $message->text : '';
+
+        if ($message && $message->conversation_id) {
+            $conversation = Conversation::find($message->conversation_id);
+            if ($conversation
+                && (int) $conversation->type === Conversation::TYPE_TRIP_CONVERSATION
+                && $conversation->trip_id) {
+                $trip = Trip::find($conversation->trip_id);
+                if ($trip && $trip->trip_date) {
+                    $tripTitle = __('notifications.group_chat_message.trip_title', [
+                        'date' => $trip->trip_date->format('d/m/Y'),
+                        'hour' => $trip->trip_date->format('H:i'),
+                    ]);
+
+                    if ($includeMessageText) {
+                        return __('notifications.group_chat_message.title', [
+                            'trip' => $tripTitle,
+                            'name' => $senderName,
+                            'text' => $messageText,
+                        ]);
+                    }
+
+                    return $tripTitle.': '.__('notifications.new_message.title', ['name' => $senderName]);
+                }
+            }
+        }
+
+        if ($includeMessageText) {
+            return $senderName.' @ '.$messageText;
+        }
+
+        return __('notifications.new_message.title', ['name' => $senderName]);
     }
 }

--- a/app/Repository/ConversationRepository.php
+++ b/app/Repository/ConversationRepository.php
@@ -52,7 +52,9 @@ class ConversationRepository
 
     public function getConversationByTripId($tripId, ?User $user = null)
     {
-        $query = Conversation::query()->where('trip_id', $tripId);
+        $query = Conversation::query()
+            ->where('trip_id', $tripId)
+            ->where('type', Conversation::TYPE_TRIP_CONVERSATION);
 
         if ($user !== null) {
             $query->whereHas('users', fn ($q) => $q->whereKey($user->id));

--- a/app/Repository/ConversationRepository.php
+++ b/app/Repository/ConversationRepository.php
@@ -78,7 +78,7 @@ class ConversationRepository
 
     public function addUser(Conversation $conversation, $userID)
     {
-        $conversation->users()->attach($userID, ['read' => true]);
+        $conversation->users()->attach($userID, ['read' => true, 'notifications_enabled' => true]);
     }
 
     public function removeUser(Conversation $conversation, User $user)
@@ -122,6 +122,11 @@ class ConversationRepository
     public function changeConversationReadState(Conversation $conversation, User $user, $read_state)
     {
         $conversation->users()->updateExistingPivot($user->id, ['read' => $read_state]);
+    }
+
+    public function changeConversationNotificationsEnabled(Conversation $conversation, User $user, bool $enabled)
+    {
+        $conversation->users()->updateExistingPivot($user->id, ['notifications_enabled' => $enabled]);
     }
 
     public function getConversationReadState(Conversation $conversation, User $user)

--- a/app/Services/Logic/ConversationsManager.php
+++ b/app/Services/Logic/ConversationsManager.php
@@ -253,7 +253,9 @@ class ConversationsManager extends BaseManager
                 $newMessage = $this->newMessage($data);
                 $otherUsers = $conversation->users()->where('user_id', '!=', $user->id)->get()->unique('id');
                 foreach ($otherUsers as $to) {
-                    event(new MessageSend($user, $to, $newMessage));
+                    if ($conversation->notificationsEnabled($to)) {
+                        event(new MessageSend($user, $to, $newMessage));
+                    }
                     $this->messageRepository->createMessageReadState($newMessage, $to, false);
                     $this->conversationRepository->changeConversationReadState($conversation, $to, false);
                 }
@@ -408,5 +410,19 @@ class ConversationsManager extends BaseManager
         }
 
         return true;
+    }
+
+    public function setConversationNotifications(User $user, $conversationId, bool $enabled)
+    {
+        $conversation = $this->getConversation($user, $conversationId);
+        if (! $conversation) {
+            $this->setErrors(['conversation_id' => 'user_does_not_have_access_to_conversation']);
+
+            return;
+        }
+
+        $this->conversationRepository->changeConversationNotificationsEnabled($conversation, $user, $enabled);
+
+        return $conversation->fresh();
     }
 }

--- a/app/Services/Logic/ConversationsManager.php
+++ b/app/Services/Logic/ConversationsManager.php
@@ -425,4 +425,27 @@ class ConversationsManager extends BaseManager
 
         return $conversation->fresh();
     }
+
+    public function sendSystemMessage(Conversation $conversation, User $subjectUser, string $translationKey, array $params = [])
+    {
+        $message = new Message;
+        $message->user_id = $subjectUser->id;
+        $message->text = __($translationKey, $params);
+        $message->conversation_id = $conversation->id;
+        $message->estado = Message::STATE_NOLEIDO;
+        $message->already_notified = 1;
+        $message->is_system = true;
+        $this->messageRepository->store($message);
+
+        $conversation = $conversation->fresh(['users']);
+        foreach ($conversation->users as $participant) {
+            $read = $participant->id === $subjectUser->id;
+            $this->messageRepository->createMessageReadState($message, $participant, $read);
+            if (! $read) {
+                $this->conversationRepository->changeConversationReadState($conversation, $participant, false);
+            }
+        }
+
+        return $message;
+    }
 }

--- a/app/Services/Logic/ConversationsManager.php
+++ b/app/Services/Logic/ConversationsManager.php
@@ -139,10 +139,24 @@ class ConversationsManager extends BaseManager
     public function getConversationByTrip(User $user, $trip_id)
     {
         if ($user->is_admin) {
-            $user = null;
+            return $this->conversationRepository->getConversationByTripId($trip_id, null);
         }
 
-        return $this->conversationRepository->getConversationByTripId($trip_id, $user);
+        $trip = Trip::find($trip_id);
+        if ($trip === null || ! $trip->canAccessGroupChat($user)) {
+            return null;
+        }
+
+        $conversation = $this->conversationRepository->getConversationByTripId($trip_id, null);
+        if ($conversation === null) {
+            return null;
+        }
+
+        if (! $conversation->users()->whereKey($user->id)->exists()) {
+            $this->conversationRepository->addUser($conversation, $user->id);
+        }
+
+        return $conversation->fresh();
     }
 
     /* CONVERSATION - USER MANIPULATION */

--- a/app/Transformers/ConversationsTransformer.php
+++ b/app/Transformers/ConversationsTransformer.php
@@ -75,6 +75,7 @@ class ConversationsTransformer extends TransformerAbstract
         }
 
         $data['unread'] = ! $conversation->read($this->user);
+        $data['notifications_enabled'] = $conversation->notificationsEnabled($this->user);
         $data['update_at'] = $conversation->updated_at ? $conversation->updated_at->toDateTimeString() : null;
 
         $m = $conversation->messages()->orderBy('created_at', 'desc')->first();

--- a/app/Transformers/ConversationsTransformer.php
+++ b/app/Transformers/ConversationsTransformer.php
@@ -27,23 +27,30 @@ class ConversationsTransformer extends TransformerAbstract
             'type' => $conversation->type,
         ];
 
+        $trip = null;
+        if ($conversation->trip_id) {
+            $trip = Trip::find($conversation->trip_id);
+        }
+
+        if ($conversation->type === Conversation::TYPE_TRIP_CONVERSATION && $trip) {
+            $data['trip_id'] = $trip->id;
+            $data['trip_date'] = $trip->trip_date ? $trip->trip_date->toDateTimeString() : null;
+        }
+
         $module_module_coordinate_by_message = filter_var(
             config('carpoolear.module_coordinate_by_message'),
             FILTER_VALIDATE_BOOLEAN
         );
-        if ($module_module_coordinate_by_message) {
-            $trip = Trip::find($conversation->trip_id);
+        if ($module_module_coordinate_by_message && $trip) {
             // old client, maybe null
-            if ($trip) {
-                $tripTransformer = new TripTransformer($this->user);
-                if ($trip->return_trip_id) {
-                    $returnTrip = Trip::find($trip->return_trip_id);
-                    if ($returnTrip) {
-                        $data['return_trip'] = $tripTransformer->transform($returnTrip);
-                    }
+            $tripTransformer = new TripTransformer($this->user);
+            if ($trip->return_trip_id) {
+                $returnTrip = Trip::find($trip->return_trip_id);
+                if ($returnTrip) {
+                    $data['return_trip'] = $tripTransformer->transform($returnTrip);
                 }
-                $data['trip'] = $tripTransformer->transform($trip);
             }
+            $data['trip'] = $tripTransformer->transform($trip);
         }
 
         switch ($conversation->type) {
@@ -83,6 +90,7 @@ class ConversationsTransformer extends TransformerAbstract
             $data['users'][] = [
                 'id' => $u->id,
                 'name' => $u->name,
+                'image' => $u->image ? '/image/profile/'.$u->image : '',
                 'last_connection' => $u->last_connection ? $u->last_connection->toDateTimeString() : null,
                 'identity_validated_at' => $u->identity_validated_at ? $u->identity_validated_at->toDateTimeString() : null,
                 'positive_ratings' => $u->positive_ratings,

--- a/app/Transformers/MessageTransformer.php
+++ b/app/Transformers/MessageTransformer.php
@@ -2,8 +2,8 @@
 
 namespace STS\Transformers;
 
-use STS\Models\Message;
 use League\Fractal\TransformerAbstract;
+use STS\Models\Message;
 
 class MessageTransformer extends TransformerAbstract
 {
@@ -31,6 +31,7 @@ class MessageTransformer extends TransformerAbstract
         if ($this->user->id == $message->user_id) {
             $data['no_of_read'] = $message->numberOfRead();
         }
+        $data['is_system'] = (bool) $message->is_system;
 
         return $data;
     }

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -99,6 +99,20 @@ class TripTransformer extends TransformerAbstract
             // passengerPending
             $data['passengerPending_count'] = count($trip->passengerPending);
 
+            $data['group_chat_conversation_id'] = null;
+            $data['group_chat_unread_count'] = 0;
+            if ($trip->user_id == $this->user->id || $trip->isPassenger($this->user)) {
+                $conversationRepo = app(\STS\Repository\ConversationRepository::class);
+                $messageRepo = app(\STS\Repository\MessageRepository::class);
+                $groupConversation = $conversationRepo->getConversationByTripId($trip->id, $this->user);
+                if ($groupConversation) {
+                    $data['group_chat_conversation_id'] = $groupConversation->id;
+                    $data['group_chat_unread_count'] = $messageRepo
+                        ->getUnreadMessages($groupConversation, $this->user)
+                        ->count();
+                }
+            }
+
         }
 
         return $data;

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -101,11 +101,11 @@ class TripTransformer extends TransformerAbstract
 
             $data['group_chat_conversation_id'] = null;
             $data['group_chat_unread_count'] = 0;
-            if ($trip->user_id == $this->user->id || $trip->isPassenger($this->user)) {
-                $conversationRepo = app(\STS\Repository\ConversationRepository::class);
-                $messageRepo = app(\STS\Repository\MessageRepository::class);
-                $groupConversation = $conversationRepo->getConversationByTripId($trip->id, $this->user);
+            if ($trip->canAccessGroupChat($this->user)) {
+                $conversationManager = app(\STS\Services\Logic\ConversationsManager::class);
+                $groupConversation = $conversationManager->getConversationByTrip($this->user, $trip->id);
                 if ($groupConversation) {
+                    $messageRepo = app(\STS\Repository\MessageRepository::class);
                     $data['group_chat_conversation_id'] = $groupConversation->id;
                     $data['group_chat_unread_count'] = $messageRepo
                         ->getUnreadMessages($groupConversation, $this->user)

--- a/database/migrations/2026_06_10_120000_add_notifications_enabled_to_conversations_users.php
+++ b/database/migrations/2026_06_10_120000_add_notifications_enabled_to_conversations_users.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conversations_users', function (Blueprint $table) {
+            $table->boolean('notifications_enabled')->default(true)->after('read');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conversations_users', function (Blueprint $table) {
+            $table->dropColumn('notifications_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_06_10_130000_add_is_system_to_messages.php
+++ b/database/migrations/2026_06_10_130000_add_is_system_to_messages.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->boolean('is_system')->default(false)->after('already_notified');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropColumn('is_system');
+        });
+    }
+};

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -74,6 +74,11 @@ return [
     'new_message.message' => 'De :name has recibido nuevos mensajes.',
     'new_message.new_message' => 'Nuevo mensaje',
 
+    'group_chat_user_joined' => ':name se sumó al chat',
+    'group_chat_user_left' => ':name se fue del chat',
+    'group_chat_message.trip_title' => 'Viaje :date :hour',
+    'group_chat_message.title' => ':trip: :name @ :text',
+
     // NewUserNotification
     'new_user.title' => '¡Bienvenido a Carpoolear!',
     'new_user.message' => '¡Bienvenido a Carpoolear!',

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -68,6 +68,11 @@ return [
     'new_message.message' => 'De :name has recibido nuevos mensajes.',
     'new_message.new_message' => 'Nuevo mensaje',
 
+    'group_chat_user_joined' => ':name se sumó al chat',
+    'group_chat_user_left' => ':name se fue del chat',
+    'group_chat_message.trip_title' => 'Viaje :date :hour',
+    'group_chat_message.title' => ':trip: :name @ :text',
+
     // NewUserNotification
     'new_user.title' => '¡Bienvenido a Carpoolear!',
     'new_user.message' => '¡Bienvenido a Carpoolear!',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -68,6 +68,12 @@ return [
     'new_message.message' => 'You have received new messages from :name.',
     'new_message.new_message' => 'New message',
 
+    // Group chat
+    'group_chat_user_joined' => ':name joined the chat',
+    'group_chat_user_left' => ':name left the chat',
+    'group_chat_message.trip_title' => 'Trip :date :hour',
+    'group_chat_message.title' => ':trip: :name @ :text',
+
     // NewUserNotification
     'new_user.title' => 'Welcome to Carpoolear!',
     'new_user.message' => 'Welcome to Carpoolear!',

--- a/routes/api.php
+++ b/routes/api.php
@@ -180,6 +180,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('/', [ConversationController::class, 'create']);
         Route::get('/user-list', [ConversationController::class, 'userList']);
         Route::get('/unread', [ConversationController::class, 'getMessagesUnread']);
+        Route::get('/trip/{tripId}', [ConversationController::class, 'showByTrip']);
         Route::get('/show/{id?}', [ConversationController::class, 'show']);
 
         Route::get('/{id?}', [ConversationController::class, 'getConversation']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -188,6 +188,7 @@ Route::middleware(['api'])->group(function () {
         Route::post('/{id?}/users', [ConversationController::class, 'addUser']);
         Route::delete('/{id?}/users/{userId?}', [ConversationController::class, 'deleteUser']);
         Route::post('/{id?}/send', [ConversationController::class, 'send']);
+        Route::post('/{id?}/notifications', [ConversationController::class, 'updateNotifications']);
         Route::post('/multi-send', [ConversationController::class, 'multiSend']);
     });
 

--- a/tests/Feature/Http/ConversationApiTest.php
+++ b/tests/Feature/Http/ConversationApiTest.php
@@ -623,4 +623,21 @@ class ConversationApiTest extends TestCase
         $this->assertSame(Conversation::TYPE_TRIP_CONVERSATION, $response->json('data.type'));
         $this->assertSame($conversation->id, $response->json('data.id'));
     }
+
+    public function test_participant_can_disable_and_re_enable_conversation_notifications(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::factory()->create(['type' => Conversation::TYPE_PRIVATE_CONVERSATION]);
+        $conversation->users()->attach($user->id, ['read' => true, 'notifications_enabled' => true]);
+
+        $this->actingAs($user, 'api');
+
+        $response = $this->postJson("api/conversations/{$conversation->id}/notifications", ['enabled' => false]);
+        $response->assertOk();
+        $this->assertFalse($response->json('data.notifications_enabled'));
+
+        $response = $this->postJson("api/conversations/{$conversation->id}/notifications", ['enabled' => true]);
+        $response->assertOk();
+        $this->assertTrue($response->json('data.notifications_enabled'));
+    }
 }

--- a/tests/Feature/Http/ConversationApiTest.php
+++ b/tests/Feature/Http/ConversationApiTest.php
@@ -624,6 +624,140 @@ class ConversationApiTest extends TestCase
         $this->assertSame($conversation->id, $response->json('data.id'));
     }
 
+    public function test_show_by_trip_returns_group_chat_when_passenger_also_has_private_trip_scoped_chat(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = \STS\Models\Trip::factory()->create(['user_id' => $driver->id]);
+
+        $groupChat = $this->conversationManager->createTripConversation($trip->id);
+        $this->conversationRepository->addUser($groupChat, $driver);
+        $this->conversationRepository->addUser($groupChat, $passenger);
+
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => \STS\Models\Passenger::STATE_ACCEPTED,
+        ]);
+
+        $privateChat = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+        $privateChat->users()->attach($driver->id, ['read' => true]);
+        $privateChat->users()->attach($passenger->id, ['read' => true]);
+        $this->assertGreaterThan($groupChat->id, $privateChat->id);
+
+        $this->actingAs($passenger, 'api');
+        $response = $this->getJson("api/conversations/trip/{$trip->id}");
+
+        $response->assertOk();
+        $this->assertSame($groupChat->id, $response->json('data.id'));
+        $this->assertSame(Conversation::TYPE_TRIP_CONVERSATION, $response->json('data.type'));
+        $this->assertSame(
+            $driver->name,
+            collect($response->json('data.users'))->firstWhere('id', $driver->id)['name']
+        );
+        $this->assertSame(
+            $passenger->name,
+            collect($response->json('data.users'))->firstWhere('id', $passenger->id)['name']
+        );
+    }
+
+    public function test_show_by_trip_includes_accepted_passengers_for_driver(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = \STS\Models\Trip::factory()->create(['user_id' => $driver->id]);
+
+        $groupChat = $this->conversationManager->createTripConversation($trip->id);
+        $this->conversationRepository->addUser($groupChat, $driver);
+        $this->conversationRepository->addUser($groupChat, $passenger);
+
+        Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+
+        $this->actingAs($driver, 'api');
+        $response = $this->getJson("api/conversations/trip/{$trip->id}");
+
+        $response->assertOk();
+        $this->assertSame($groupChat->id, $response->json('data.id'));
+        $userIds = collect($response->json('data.users'))->pluck('id')->all();
+        $this->assertContains($driver->id, $userIds);
+        $this->assertContains($passenger->id, $userIds);
+    }
+
+    public function test_show_by_trip_enrolls_accepted_passenger_missing_from_group_chat(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = \STS\Models\Trip::factory()->create(['user_id' => $driver->id]);
+
+        $groupChat = $this->conversationManager->createTripConversation($trip->id);
+        $this->conversationRepository->addUser($groupChat, $driver);
+
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => \STS\Models\Passenger::STATE_ACCEPTED,
+        ]);
+
+        $this->actingAs($passenger, 'api');
+        $response = $this->getJson("api/conversations/trip/{$trip->id}");
+
+        $response->assertOk();
+        $this->assertSame($groupChat->id, $response->json('data.id'));
+        $this->assertTrue($groupChat->fresh()->users()->whereKey($passenger->id)->exists());
+        $userIds = collect($response->json('data.users'))->pluck('id')->all();
+        $this->assertContains($passenger->id, $userIds);
+    }
+
+    public function test_show_by_trip_enrolls_passenger_waiting_payment_missing_from_group_chat(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = \STS\Models\Trip::factory()->create(['user_id' => $driver->id]);
+
+        $groupChat = $this->conversationManager->createTripConversation($trip->id);
+        $this->conversationRepository->addUser($groupChat, $driver);
+
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => \STS\Models\Passenger::STATE_WAITING_PAYMENT,
+        ]);
+
+        $this->actingAs($passenger, 'api');
+        $response = $this->getJson("api/conversations/trip/{$trip->id}");
+
+        $response->assertOk();
+        $this->assertSame($groupChat->id, $response->json('data.id'));
+        $this->assertTrue($groupChat->fresh()->users()->whereKey($passenger->id)->exists());
+    }
+
+    public function test_show_by_trip_denies_pending_passenger_not_in_group_chat(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = \STS\Models\Trip::factory()->create(['user_id' => $driver->id]);
+
+        $groupChat = $this->conversationManager->createTripConversation($trip->id);
+        $this->conversationRepository->addUser($groupChat, $driver);
+
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => \STS\Models\Passenger::STATE_PENDING,
+        ]);
+
+        $this->actingAs($passenger, 'api');
+        $response = $this->getJson("api/conversations/trip/{$trip->id}");
+
+        $response->assertStatus(422);
+    }
+
     public function test_participant_can_disable_and_re_enable_conversation_notifications(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Http/ConversationApiTest.php
+++ b/tests/Feature/Http/ConversationApiTest.php
@@ -608,4 +608,19 @@ class ConversationApiTest extends TestCase
         $this->expectExceptionMessage('Bad request exceptions');
         $controller->deleteUser(new Request, 300, $toDelete->id);
     }
+
+    public function test_show_by_trip_returns_trip_conversation_for_participant(): void
+    {
+        $driver = User::factory()->create();
+        $trip = \STS\Models\Trip::factory()->create(['user_id' => $driver->id]);
+        $conversation = $this->conversationManager->createTripConversation($trip->id);
+        $this->conversationRepository->addUser($conversation, $driver);
+
+        $this->actingAs($driver, 'api');
+        $response = $this->getJson("api/conversations/trip/{$trip->id}");
+
+        $response->assertOk();
+        $this->assertSame(Conversation::TYPE_TRIP_CONVERSATION, $response->json('data.type'));
+        $this->assertSame($conversation->id, $response->json('data.id'));
+    }
 }

--- a/tests/Unit/Listeners/Conversation/RemoveUserConversationListenerTest.php
+++ b/tests/Unit/Listeners/Conversation/RemoveUserConversationListenerTest.php
@@ -44,6 +44,7 @@ class RemoveUserConversationListenerTest extends TestCase
         $driver = User::factory()->create();
         $passenger = User::factory()->create();
         $conversation = Mockery::mock(Conversation::class);
+        $conversation->shouldReceive('fresh')->andReturnSelf();
 
         $trip = new \stdClass;
         $trip->user_id = $driver->id;
@@ -70,6 +71,7 @@ class RemoveUserConversationListenerTest extends TestCase
         $passenger = User::factory()->create();
         $moderator = User::factory()->create();
         $conversation = Mockery::mock(Conversation::class);
+        $conversation->shouldReceive('fresh')->andReturnSelf();
 
         $trip = new \stdClass;
         $trip->user_id = $driver->id;
@@ -95,6 +97,7 @@ class RemoveUserConversationListenerTest extends TestCase
         $driver = User::factory()->create();
         $passenger = User::factory()->create();
         $conversation = Mockery::mock(Conversation::class);
+        $conversation->shouldReceive('fresh')->andReturnSelf();
 
         $trip = new \stdClass;
         $trip->user_id = (string) $driver->id;

--- a/tests/Unit/Listeners/Conversation/RemoveUserConversationListenerTest.php
+++ b/tests/Unit/Listeners/Conversation/RemoveUserConversationListenerTest.php
@@ -8,10 +8,18 @@ use STS\Listeners\Conversation\removeUserConversation;
 use STS\Models\Conversation;
 use STS\Models\User;
 use STS\Repository\ConversationRepository;
+use STS\Services\Logic\ConversationsManager;
 use Tests\TestCase;
 
 class RemoveUserConversationListenerTest extends TestCase
 {
+    private function makeListener(ConversationRepository $repo, ?ConversationsManager $logic = null): removeUserConversation
+    {
+        $logic = $logic ?? Mockery::mock(ConversationsManager::class);
+
+        return new removeUserConversation($repo, $logic);
+    }
+
     public function test_handle_does_not_call_repository_when_trip_has_no_conversation(): void
     {
         $driver = User::factory()->create();
@@ -23,8 +31,10 @@ class RemoveUserConversationListenerTest extends TestCase
 
         $repo = Mockery::mock(ConversationRepository::class);
         $repo->shouldNotReceive('removeUser');
+        $logic = Mockery::mock(ConversationsManager::class);
+        $logic->shouldNotReceive('sendSystemMessage');
 
-        (new removeUserConversation($repo))->handle(
+        $this->makeListener($repo, $logic)->handle(
             new PassengerCanceled($trip, $driver, $passenger, 0)
         );
     }
@@ -40,6 +50,8 @@ class RemoveUserConversationListenerTest extends TestCase
         $trip->conversation = $conversation;
 
         $repo = Mockery::mock(ConversationRepository::class);
+        $logic = Mockery::mock(ConversationsManager::class);
+        $logic->shouldReceive('sendSystemMessage')->once();
         $repo->shouldReceive('removeUser')
             ->once()
             ->with(
@@ -47,7 +59,7 @@ class RemoveUserConversationListenerTest extends TestCase
                 Mockery::on(fn (User $user) => $user->is($passenger))
             );
 
-        (new removeUserConversation($repo))->handle(
+        $this->makeListener($repo, $logic)->handle(
             new PassengerCanceled($trip, $driver, $passenger, 0)
         );
     }
@@ -64,6 +76,8 @@ class RemoveUserConversationListenerTest extends TestCase
         $trip->conversation = $conversation;
 
         $repo = Mockery::mock(ConversationRepository::class);
+        $logic = Mockery::mock(ConversationsManager::class);
+        $logic->shouldReceive('sendSystemMessage')->once();
         $repo->shouldReceive('removeUser')
             ->once()
             ->with(
@@ -71,7 +85,7 @@ class RemoveUserConversationListenerTest extends TestCase
                 Mockery::on(fn (User $user) => $user->is($moderator))
             );
 
-        (new removeUserConversation($repo))->handle(
+        $this->makeListener($repo, $logic)->handle(
             new PassengerCanceled($trip, $moderator, $passenger, 0)
         );
     }
@@ -87,6 +101,8 @@ class RemoveUserConversationListenerTest extends TestCase
         $trip->conversation = $conversation;
 
         $repo = Mockery::mock(ConversationRepository::class);
+        $logic = Mockery::mock(ConversationsManager::class);
+        $logic->shouldReceive('sendSystemMessage')->once();
         $repo->shouldReceive('removeUser')
             ->once()
             ->with(
@@ -94,7 +110,7 @@ class RemoveUserConversationListenerTest extends TestCase
                 Mockery::on(fn (User $user) => $user->is($passenger))
             );
 
-        (new removeUserConversation($repo))->handle(
+        $this->makeListener($repo, $logic)->handle(
             new PassengerCanceled($trip, $driver, $passenger, 0)
         );
     }

--- a/tests/Unit/Listeners/Notification/MessageSendListenerTest.php
+++ b/tests/Unit/Listeners/Notification/MessageSendListenerTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\Listeners\Notification;
 use Illuminate\Support\Facades\Log;
 use STS\Events\MessageSend as SendEvent;
 use STS\Listeners\Notification\MessageSend;
+use STS\Models\Message;
+use STS\Models\User;
 use STS\Notifications\NewMessagePushNotification;
 use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
@@ -53,5 +55,24 @@ class MessageSendListenerTest extends TestCase
         Log::shouldHaveReceived('warning')
             ->with('Error on sending notification', ['message' => 'push channel unavailable'])
             ->once();
+    }
+
+    public function test_handle_skips_notification_when_recipient_muted_conversation(): void
+    {
+        $from = User::factory()->create(['name' => 'Sender']);
+        $to = User::factory()->create();
+        $conversation = \STS\Models\Conversation::factory()->create();
+        $conversation->users()->attach($to->id, ['read' => true, 'notifications_enabled' => false]);
+        $message = Message::query()->create([
+            'user_id' => $from->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'hello',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
+
+        $listener = new MessageSend;
+        $listener->handle(new SendEvent($from, $to, $message));
     }
 }

--- a/tests/Unit/MessagesTest.php
+++ b/tests/Unit/MessagesTest.php
@@ -280,4 +280,38 @@ class MessagesTest extends TestCase
         $this->assertNotNull($leaveMessage);
         $this->assertStringContainsString($accepted->name, $leaveMessage->text);
     }
+
+    public function test_accept_adds_passenger_to_group_chat_when_private_trip_scoped_chat_exists(): void
+    {
+        $driver = User::factory()->create();
+        $accepted = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        $createListener = new \STS\Listeners\Conversation\createConversation(
+            $this->conversationManager,
+            $this->conversationRepository
+        );
+        $createListener->handle(new \STS\Events\Trip\Create($trip));
+        $groupChat = $trip->fresh()->conversation;
+
+        $privateChat = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+        $privateChat->users()->attach($driver->id, ['read' => true]);
+        $privateChat->users()->attach($accepted->id, ['read' => true]);
+
+        $addListener = new \STS\Listeners\Conversation\addUserConversation(
+            $this->conversationRepository,
+            $this->conversationManager
+        );
+        $addListener->handle(new \STS\Events\Passenger\Accept($trip, $driver, $accepted));
+
+        $this->assertTrue($groupChat->fresh()->users()->whereKey($accepted->id)->exists());
+        $this->assertSame(2, $groupChat->fresh()->users()->count());
+        $this->assertSame(2, $privateChat->fresh()->users()->count());
+        $joinMessage = $groupChat->messages()->where('is_system', true)->first();
+        $this->assertNotNull($joinMessage);
+        $this->assertStringContainsString($accepted->name, $joinMessage->text);
+    }
 }

--- a/tests/Unit/MessagesTest.php
+++ b/tests/Unit/MessagesTest.php
@@ -260,12 +260,24 @@ class MessagesTest extends TestCase
         $this->assertInstanceOf(Conversation::class, $conversation);
         $this->assertSame(1, $conversation->users()->count(), 'trip creator is attached on conversation creation');
 
-        $addListener = new \STS\Listeners\Conversation\addUserConversation($this->conversationRepository);
+        $addListener = new \STS\Listeners\Conversation\addUserConversation(
+            $this->conversationRepository,
+            $this->conversationManager
+        );
         $addListener->handle(new \STS\Events\Passenger\Accept($trip, $driver, $accepted));
         $this->assertSame(2, $conversation->fresh()->users()->count());
+        $joinMessage = $conversation->messages()->where('is_system', true)->first();
+        $this->assertNotNull($joinMessage);
+        $this->assertStringContainsString($accepted->name, $joinMessage->text);
 
-        $removeListener = new \STS\Listeners\Conversation\removeUserConversation($this->conversationRepository);
+        $removeListener = new \STS\Listeners\Conversation\removeUserConversation(
+            $this->conversationRepository,
+            $this->conversationManager
+        );
         $removeListener->handle(new \STS\Events\Passenger\Cancel($trip, $driver, $accepted, 0));
         $this->assertSame(1, $conversation->fresh()->users()->count());
+        $leaveMessage = $conversation->messages()->where('is_system', true)->orderByDesc('id')->first();
+        $this->assertNotNull($leaveMessage);
+        $this->assertStringContainsString($accepted->name, $leaveMessage->text);
     }
 }

--- a/tests/Unit/Models/ConversationTest.php
+++ b/tests/Unit/Models/ConversationTest.php
@@ -65,6 +65,27 @@ class ConversationTest extends TestCase
         $this->assertSame($trip->id, $conversation->trip_id);
     }
 
+    public function test_add_user_sets_notifications_enabled_true_by_default(): void
+    {
+        $conversation = Conversation::factory()->create();
+        $user = User::factory()->create();
+        $repo = $this->app->make(\STS\Repository\ConversationRepository::class);
+
+        $repo->addUser($conversation, $user->id);
+
+        $pivot = $conversation->fresh()->users()->whereKey($user->id)->first()->pivot;
+        $this->assertTrue((bool) $pivot->notifications_enabled);
+    }
+
+    public function test_notifications_enabled_helper(): void
+    {
+        $conversation = Conversation::factory()->create();
+        $user = User::factory()->create();
+        $conversation->users()->attach($user->id, ['read' => true, 'notifications_enabled' => false]);
+
+        $this->assertFalse($conversation->fresh()->notificationsEnabled($user));
+    }
+
     public function test_soft_delete_excludes_from_default_query(): void
     {
         $conversation = Conversation::factory()->create();

--- a/tests/Unit/Models/MessageTest.php
+++ b/tests/Unit/Models/MessageTest.php
@@ -18,6 +18,7 @@ class MessageTest extends TestCase
             'text',
             'estado',
             'conversation_id',
+            'is_system',
         ], (new Message)->getFillable());
     }
 

--- a/tests/Unit/Notifications/NewMessagePushNotificationTest.php
+++ b/tests/Unit/Notifications/NewMessagePushNotificationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Notifications;
 
+use STS\Models\Trip;
 use STS\Models\User;
 use STS\Notifications\NewMessagePushNotification;
 use STS\Services\Notifications\Channels\DatabaseChannel;
@@ -83,5 +84,35 @@ class NewMessagePushNotificationTest extends TestCase
         $this->assertSame(777, $push['extras']['id']);
         $this->assertSame('conversation', $push['type']);
         $this->assertSame('https://carpoolear.com.ar/app/static/img/carpoolear_logo.png', $push['image']);
+    }
+
+    public function test_to_push_includes_trip_title_for_trip_group_conversation(): void
+    {
+        $driver = User::factory()->create(['name' => 'Driver']);
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'trip_date' => '2026-06-10 14:30:00',
+        ]);
+        $conversation = \STS\Models\Conversation::factory()->create([
+            'type' => \STS\Models\Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+        $message = \STS\Models\Message::query()->create([
+            'user_id' => $driver->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Hola grupo',
+            'estado' => \STS\Models\Message::STATE_NOLEIDO,
+        ]);
+
+        $notification = new NewMessagePushNotification;
+        $notification->setAttribute('from', $driver);
+        $notification->setAttribute('messages', $message);
+
+        $push = $notification->toPush(null, null);
+
+        $this->assertStringContainsString('10/06/2026', $push['message']);
+        $this->assertStringContainsString('14:30', $push['message']);
+        $this->assertStringContainsString('Driver', $push['message']);
+        $this->assertStringContainsString('Hola grupo', $push['message']);
     }
 }

--- a/tests/Unit/Repository/ConversationRepositoryTest.php
+++ b/tests/Unit/Repository/ConversationRepositoryTest.php
@@ -180,7 +180,7 @@ class ConversationRepositoryTest extends TestCase
         // Mutation intent: preserve `$conversation->users()->attach($userID, ['read' => true])` (~83–86 RemoveMethodCall).
         $conversation = Mockery::mock(Conversation::class)->makePartial();
         $relation = Mockery::mock();
-        $relation->shouldReceive('attach')->once()->with(99, ['read' => true]);
+        $relation->shouldReceive('attach')->once()->with(99, ['read' => true, 'notifications_enabled' => true]);
 
         $conversation->shouldReceive('users')->once()->andReturn($relation);
 

--- a/tests/Unit/Repository/ConversationRepositoryTest.php
+++ b/tests/Unit/Repository/ConversationRepositoryTest.php
@@ -121,13 +121,50 @@ class ConversationRepositoryTest extends TestCase
     public function test_get_conversation_by_trip_id_returns_trip_conversation_without_user_filter(): void
     {
         $trip = Trip::factory()->create();
-        $conversation = Conversation::factory()->create(['trip_id' => $trip->id]);
+        $conversation = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
 
         $repo = new ConversationRepository;
         $found = $repo->getConversationByTripId($trip->id);
 
         $this->assertNotNull($found);
         $this->assertTrue($found->is($conversation));
+    }
+
+    public function test_get_conversation_by_trip_id_returns_group_chat_when_private_trip_scoped_chat_exists(): void
+    {
+        $trip = Trip::factory()->create();
+        $groupChat = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
+        $privateChat = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+        $this->assertGreaterThan($groupChat->id, $privateChat->id);
+
+        $found = (new ConversationRepository)->getConversationByTripId($trip->id);
+
+        $this->assertTrue($found->is($groupChat));
+        $this->assertSame(Conversation::TYPE_TRIP_CONVERSATION, (int) $found->type);
+    }
+
+    public function test_trip_conversation_relationship_returns_group_chat_when_private_trip_scoped_chat_exists(): void
+    {
+        $trip = Trip::factory()->create();
+        $groupChat = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
+        Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+
+        $this->assertTrue($trip->fresh()->conversation->is($groupChat));
     }
 
     public function test_get_conversation_by_trip_id_requires_membership_when_user_provided(): void
@@ -137,7 +174,10 @@ class ConversationRepositoryTest extends TestCase
         $trip = Trip::factory()->create();
         $member = User::factory()->create();
         $stranger = User::factory()->create();
-        $conversation = Conversation::factory()->create(['trip_id' => $trip->id]);
+        $conversation = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
         $conversation->users()->attach($member->id, ['read' => false]);
 
         $repo = new ConversationRepository;

--- a/tests/Unit/Services/Logic/ConversationsManagerTest.php
+++ b/tests/Unit/Services/Logic/ConversationsManagerTest.php
@@ -228,6 +228,52 @@ class ConversationsManagerTest extends TestCase
         $this->assertTrue($found->is($conversation));
     }
 
+    public function test_get_conversation_by_trip_enrolls_accepted_passenger_missing_from_group_chat(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $conversation = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
+        $conversation->users()->attach($driver->id, ['read' => true]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $found = $this->manager()->getConversationByTrip($passenger, $trip->id);
+
+        $this->assertNotNull($found);
+        $this->assertTrue($found->is($conversation));
+        $this->assertTrue($conversation->fresh()->users()->whereKey($passenger->id)->exists());
+    }
+
+    public function test_get_conversation_by_trip_denies_pending_passenger(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $conversation = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
+        $conversation->users()->attach($driver->id, ['read' => true]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_PENDING,
+        ]);
+
+        $found = $this->manager()->getConversationByTrip($passenger, $trip->id);
+
+        $this->assertNull($found);
+    }
+
     public function test_get_conversation_by_trip_returns_trip_thread_for_admin_user(): void
     {
         $admin = User::factory()->create(['is_admin' => true]);

--- a/tests/Unit/Services/Logic/ConversationsManagerTest.php
+++ b/tests/Unit/Services/Logic/ConversationsManagerTest.php
@@ -319,4 +319,33 @@ class ConversationsManagerTest extends TestCase
                 && str_contains((string) $e->message->text, $trip->to_town);
         });
     }
+
+    public function test_send_does_not_dispatch_message_send_for_muted_recipient(): void
+    {
+        Event::fake([MessageSend::class]);
+
+        $sender = User::factory()->create(['is_admin' => true]);
+        $muted = User::factory()->create();
+        $conversation = Conversation::factory()->create(['type' => Conversation::TYPE_PRIVATE_CONVERSATION]);
+        $conversation->users()->attach($sender->id, ['read' => true, 'notifications_enabled' => true]);
+        $conversation->users()->attach($muted->id, ['read' => true, 'notifications_enabled' => false]);
+
+        $this->manager()->send($sender, $conversation->id, 'Hola');
+
+        Event::assertNotDispatched(MessageSend::class);
+    }
+
+    public function test_set_conversation_notifications_updates_pivot(): void
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::factory()->create(['type' => Conversation::TYPE_PRIVATE_CONVERSATION]);
+        $conversation->users()->attach($user->id, ['read' => true, 'notifications_enabled' => true]);
+
+        $updated = $this->manager()->setConversationNotifications($user, $conversation->id, false);
+        $this->assertNotNull($updated);
+        $this->assertFalse($updated->notificationsEnabled($user));
+
+        $updated = $this->manager()->setConversationNotifications($user, $conversation->id, true);
+        $this->assertTrue($updated->notificationsEnabled($user));
+    }
 }

--- a/tests/Unit/Services/Logic/ConversationsManagerTest.php
+++ b/tests/Unit/Services/Logic/ConversationsManagerTest.php
@@ -348,4 +348,26 @@ class ConversationsManagerTest extends TestCase
         $updated = $this->manager()->setConversationNotifications($user, $conversation->id, true);
         $this->assertTrue($updated->notificationsEnabled($user));
     }
+
+    public function test_send_system_message_creates_message_with_is_system_flag_and_no_notification_event(): void
+    {
+        Event::fake([MessageSend::class]);
+
+        $subject = User::factory()->create(['name' => 'Ana']);
+        $other = User::factory()->create();
+        $conversation = Conversation::factory()->create(['type' => Conversation::TYPE_TRIP_CONVERSATION]);
+        $conversation->users()->attach($subject->id, ['read' => true, 'notifications_enabled' => true]);
+        $conversation->users()->attach($other->id, ['read' => true, 'notifications_enabled' => true]);
+
+        $message = $this->manager()->sendSystemMessage(
+            $conversation->fresh(),
+            $subject,
+            'notifications.group_chat_user_joined',
+            ['name' => 'Ana']
+        );
+
+        Event::assertNotDispatched(MessageSend::class);
+        $this->assertTrue($message->is_system);
+        $this->assertStringContainsString('Ana', $message->text);
+    }
 }

--- a/tests/Unit/Transformers/ConversationsTransformerTest.php
+++ b/tests/Unit/Transformers/ConversationsTransformerTest.php
@@ -167,6 +167,7 @@ class ConversationsTransformerTest extends TestCase
         $expectedKeys = [
             'id',
             'name',
+            'image',
             'last_connection',
             'identity_validated_at',
             'positive_ratings',

--- a/tests/Unit/Transformers/ConversationsTransformerTest.php
+++ b/tests/Unit/Transformers/ConversationsTransformerTest.php
@@ -260,6 +260,45 @@ class ConversationsTransformerTest extends TestCase
         $this->assertSame(1, $otherRow['negative_ratings']);
     }
 
+    public function test_transform_trip_conversation_includes_trip_id_and_date_without_coordinate_module(): void
+    {
+        config(['carpoolear.module_coordinate_by_message' => false]);
+
+        $viewer = User::factory()->create();
+        $trip = Trip::factory()->create(['trip_date' => Carbon::parse('2026-06-10 14:30:00')]);
+        $conversation = Conversation::query()->create([
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+        $conversation->users()->attach($viewer->id, ['read' => true]);
+
+        $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
+
+        $this->assertSame(Conversation::TYPE_TRIP_CONVERSATION, $payload['type']);
+        $this->assertSame($trip->id, $payload['trip_id']);
+        $this->assertSame('2026-06-10 14:30:00', $payload['trip_date']);
+        $this->assertArrayNotHasKey('trip', $payload);
+    }
+
+    public function test_transform_users_include_profile_image_path_or_empty_string(): void
+    {
+        $viewer = User::factory()->create(['image' => 'avatar.png']);
+        $other = User::factory()->create(['image' => null]);
+        $conversation = Conversation::query()->create([
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+            'title' => 'Chat',
+        ]);
+        $conversation->users()->attach($viewer->id, ['read' => true]);
+        $conversation->users()->attach($other->id, ['read' => true]);
+
+        $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
+
+        $viewerRow = collect($payload['users'])->firstWhere('id', $viewer->id);
+        $otherRow = collect($payload['users'])->firstWhere('id', $other->id);
+        $this->assertSame('/image/profile/avatar.png', $viewerRow['image']);
+        $this->assertSame('', $otherRow['image']);
+    }
+
     public function test_transform_users_list_includes_identity_and_last_connection_fields(): void
     {
         $viewer = User::factory()->create([

--- a/tests/Unit/Transformers/MessageTransformerTest.php
+++ b/tests/Unit/Transformers/MessageTransformerTest.php
@@ -33,6 +33,7 @@ class MessageTransformerTest extends TestCase
             'created_at',
             'user_id',
             'conversation_id',
+            'is_system',
         ], array_keys($payload));
         $this->assertSame($message->id, $payload['id']);
         $this->assertSame('Hello there', $payload['text']);

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -419,4 +419,29 @@ class TripTransformerTest extends TestCase
         $this->assertSame($conversation->id, $payload['group_chat_conversation_id']);
         $this->assertSame(2, $payload['group_chat_unread_count']);
     }
+
+    public function test_trip_includes_group_chat_for_passenger_waiting_payment_not_yet_in_conversation(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = $this->makeTrip(['user_id' => $driver->id]);
+
+        $conversation = \STS\Models\Conversation::factory()->create([
+            'type' => \STS\Models\Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+        $conversation->users()->attach($driver->id, ['read' => true, 'notifications_enabled' => true]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_WAITING_PAYMENT,
+        ]);
+
+        $trip = $trip->fresh(['passenger', 'passengerAccepted']);
+        $payload = (new TripTransformer($passenger))->transform($trip);
+
+        $this->assertSame($conversation->id, $payload['group_chat_conversation_id']);
+        $this->assertTrue($conversation->fresh()->users()->whereKey($passenger->id)->exists());
+    }
 }

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -378,4 +378,45 @@ class TripTransformerTest extends TestCase
 
         $this->assertArrayNotHasKey('driver_is_friend', $payload);
     }
+
+    public function test_trip_includes_group_chat_unread_count_for_accepted_passenger(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = $this->makeTrip(['user_id' => $driver->id]);
+
+        $conversation = \STS\Models\Conversation::factory()->create([
+            'type' => \STS\Models\Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+        $conversation->users()->attach($driver->id, ['read' => true, 'notifications_enabled' => true]);
+        $conversation->users()->attach($passenger->id, ['read' => true, 'notifications_enabled' => true]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $msgOne = \STS\Models\Message::query()->create([
+            'user_id' => $driver->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'One',
+            'estado' => \STS\Models\Message::STATE_NOLEIDO,
+        ]);
+        $msgTwo = \STS\Models\Message::query()->create([
+            'user_id' => $driver->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Two',
+            'estado' => \STS\Models\Message::STATE_NOLEIDO,
+        ]);
+        $msgOne->users()->attach($passenger->id, ['read' => false]);
+        $msgTwo->users()->attach($passenger->id, ['read' => false]);
+
+        $trip = $trip->fresh(['passenger', 'passengerAccepted']);
+        $payload = (new TripTransformer($passenger))->transform($trip);
+
+        $this->assertSame($conversation->id, $payload['group_chat_conversation_id']);
+        $this->assertSame(2, $payload['group_chat_unread_count']);
+    }
 }


### PR DESCRIPTION
## Summary

Adds **trip group chat** as a separate conversation from the existing 1:1 driver–passenger chat. Drivers and eligible passengers can open **Chat grupal** from trip detail, see a trip-date title in the list/header, view participants, mute notifications, and receive join/leave system messages.

---

## Backend (`carpoolear_backend`)

### Feature
- **`GET /api/conversations/trip/{tripId}`** — resolve and return the trip group conversation for eligible users
- **Trip payload** — `group_chat_conversation_id`, `group_chat_unread_count`
- **Conversation payload** — `trip_id`, `trip_date`, participant `image`, `notifications_enabled`
- **`POST /api/conversations/{id}/notifications`** — mute/unmute group chat notifications per user
- **System messages** — join/leave messages when passengers are accepted or cancel
- **Push notifications** — group chat copy uses trip date/time title
- **Muted users** — skip message notifications when notifications are disabled on the pivot

### Bug: wrong conversation / missing passengers
**Cause:** Trip lookups used `trip_id` only, without filtering `type = 1`. Private trip-scoped chats (`type = 0` with `trip_id`) could win `orderByDesc('id')`, so **Chat grupal** opened the driver private chat. `Trip::conversation()` had the same issue, so accepted passengers could be attached to the private chat instead of the group chat.

**Fix:** Filter trip lookups and `Trip::conversation()` to **`TYPE_TRIP_CONVERSATION` only**.

### Bug: passenger could not open group chat (422)
**Cause:** `GET /conversations/trip/{id}` required prior membership in `conversations_users`. Passengers accepted before the fix, or in **`WAITING_PAYMENT`**, were not members even though the UI showed **Chat grupal**.

**Fix:** Added `Trip::canAccessGroupChat()` (driver, accepted, waiting payment). `getConversationByTrip()` now verifies access, loads the group chat, and **auto-enrolls** missing eligible users. `TripTransformer` uses the same path for unread/badge fields.

### Tests
- API, repository, manager, transformer, listener, and push notification coverage
- Regression tests for private+group coexistence, passenger enrollment, and pending passenger denial

