### PR TITLE
Admin cancel trip

### DIFF
--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -472,6 +472,20 @@ class TripControllerIntegrationTest extends TestCase
         $this->assertNotNull($trip->fresh()->deleted_at);
     }
 
+    public function test_admin_can_delete_another_users_trip(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $trip = Trip::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($admin, 'api')
+            ->deleteJson("/api/trips/{$trip->id}")
+            ->assertOk()
+            ->assertExactJson(['data' => 'ok']);
+
+        $this->assertNotNull($trip->fresh()->deleted_at);
+    }
+
     public function test_show_returns_trip_when_visibility_allows(): void
     {
         $driver = User::factory()->create();

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -1018,6 +1018,16 @@ class TripsManagerTest extends TestCase
         $this->assertSame(trans('errors.tripowner'), $manager->getErrors());
     }
 
+    public function test_delete_allows_admin_to_cancel_non_owned_trip(): void
+    {
+        $driver = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        $this->assertTrue((bool) $this->manager()->delete($admin, $trip->id));
+        $this->assertNotNull($trip->fresh()->deleted_at);
+    }
+
     public function test_update_sets_tripowner_error_for_non_owner(): void
     {
         Carbon::setTestNow('2028-04-01 10:00:00');


### PR DESCRIPTION
## Summary

Adds admin trip cancellation and a structured trips table on the admin user trips page (`/app/admin/users/:userId/trips`).

## Cause

Admins viewing a user's trips only saw trip cards with a modal preview. There was no table with key trip metadata, no way to cancel trips from admin, and no clear split between opening the in-app detail popup vs. the public trip URL.

## Fix

### Backend (`carpoolear_backend`)

- No API changes required. Admins can already cancel trips via `DELETE /api/trips/{id}` (`TripsManager::delete` allows `is_admin`).
- Added regression tests:
  - Feature: `test_admin_can_delete_another_users_trip`
  - Unit: `test_delete_allows_admin_to_cancel_non_owned_trip`
