### PR TITLE
Trip checks

### DIFF
--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -982,4 +982,20 @@ class TripRepository
             ->where('created_at', '>=', Carbon::now()->subHours($hours))
             ->get();
     }
+
+    public function findDuplicateTrip($userId, $fromTown, $toTown, $tripDate, $isPassenger)
+    {
+        if (empty($tripDate)) {
+            return null;
+        }
+
+        return Trip::query()
+            ->where('user_id', $userId)
+            ->where('from_town', $fromTown)
+            ->where('to_town', $toTown)
+            ->where('trip_date', Carbon::parse($tripDate)->toDateTimeString())
+            ->where('is_passenger', (int) $isPassenger)
+            ->orderBy('id')
+            ->first();
+    }
 }

--- a/app/Services/Logic/PassengersManager.php
+++ b/app/Services/Logic/PassengersManager.php
@@ -124,9 +124,8 @@ class PassengersManager extends BaseManager
                 }
             }
             // User Request Limited Module
-            $module_user_request_limited = config('carpoolear.module_user_request_limited', false);
-            if ($module_user_request_limited && $module_user_request_limited->enabled) {
-                $hours_range = $module_user_request_limited->hours_range;
+            if (config('carpoolear.module_user_request_limited_enabled', false)) {
+                $hours_range = (int) config('carpoolear.module_user_request_limited_hours_range', 2);
                 $userHasRequests = $user->tripsAsPassenger(null, $hours_range, $trip->trip_date)->count() > 0;
                 if ($userHasRequests) {
                     $this->setErrors(['error' => 'user_has_another_similar_trip']);

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -184,6 +184,22 @@ class TripsManager extends BaseManager
             }
 
             $data['user_id'] = $user->id;
+
+            if (! empty($data['trip_date']) && empty($data['parent_trip_id'])) {
+                $existingTrip = $this->tripRepo->findDuplicateTrip(
+                    $user->id,
+                    $data['from_town'],
+                    $data['to_town'],
+                    $data['trip_date'],
+                    (int) $data['is_passenger']
+                );
+                if ($existingTrip) {
+                    $existingTrip->setAttribute('existing', true);
+
+                    return $existingTrip;
+                }
+            }
+
             $trip = $this->tripRepo->create($data);
             if (isset($data['parent_trip_id'])) {
                 $parentTripId = $data['parent_trip_id'];

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -50,6 +50,7 @@ class TripTransformer extends TransformerAbstract
             'rear_max_two_passengers' => $trip->rear_max_two_passengers,
             'payment_id' => $trip->payment_id,
             'needs_sellado' => $trip->needs_sellado,
+            'existing' => (bool) $trip->getAttribute('existing'),
         ];
 
         // Flag for frontend: show faded (e.g. 80% opacity) and "Falta pagar Sellado" when sellado is unpaid

--- a/tests/Feature/Http/PassengerControllerIntegrationTest.php
+++ b/tests/Feature/Http/PassengerControllerIntegrationTest.php
@@ -16,7 +16,7 @@ class PassengerControllerIntegrationTest extends TestCase
     {
         parent::setUp();
         Config::set('carpoolear.module_unaswered_message_limit', false);
-        Config::set('carpoolear.module_user_request_limited', false);
+        Config::set('carpoolear.module_user_request_limited_enabled', false);
         Config::set('carpoolear.module_trip_seats_payment', false);
         Config::set('carpoolear.module_send_full_trip_message', false);
     }

--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -398,6 +398,39 @@ class TripControllerIntegrationTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_create_returns_existing_trip_with_existing_flag_when_duplicate_submitted(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        $this->seedRouteCacheForMinimalCreatePoints();
+        Http::fake();
+
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'description' => 'Completed description',
+            'image' => 'profile.jpg',
+            'nro_doc' => '30111222',
+            'mobile_phone' => '+5493415551234',
+        ]);
+        Car::factory()->withCatalog()->create([
+            'user_id' => $user->id,
+            'patente' => 'OK123',
+        ]);
+
+        $payload = $this->minimalCreatePayload();
+        $first = $this->actingAs($user, 'api')->postJson('/api/trips', $payload);
+        $first->assertOk();
+        $tripId = (int) $first->json('data.id');
+
+        $second = $this->actingAs($user, 'api')->postJson('/api/trips', $payload);
+        $second->assertOk()
+            ->assertJsonPath('data.id', $tripId)
+            ->assertJsonPath('data.existing', true);
+
+        $this->assertSame(1, Trip::where('user_id', $user->id)->count());
+
+        Carbon::setTestNow();
+    }
+
     public function test_update_persists_rear_max_two_passengers_and_returns_it_in_payload(): void
     {
         Carbon::setTestNow('2028-04-01 12:00:00');

--- a/tests/Unit/PassengersTest.php
+++ b/tests/Unit/PassengersTest.php
@@ -29,7 +29,7 @@ class PassengersTest extends TestCase
         $this->passengerRepository = $this->app->make(PassengersRepository::class);
 
         Config::set('carpoolear.module_unaswered_message_limit', false);
-        Config::set('carpoolear.module_user_request_limited', false);
+        Config::set('carpoolear.module_user_request_limited_enabled', false);
         Config::set('carpoolear.module_trip_seats_payment', false);
         Config::set('carpoolear.module_send_full_trip_message', false);
         Carbon::setTestNow('2028-01-01 10:00:00');

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -893,6 +893,37 @@ class TripRepositoryTest extends TestCase
         $this->assertSame($recent->id, $rows->first()->id);
     }
 
+    public function test_find_duplicate_trip_matches_user_route_datetime_and_passenger_flag(): void
+    {
+        $user = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $user->id,
+            'from_town' => 'Rosario',
+            'to_town' => 'Buenos Aires',
+            'trip_date' => Carbon::parse('2028-06-01 09:30:00'),
+            'is_passenger' => 0,
+        ]);
+
+        $match = $this->repo()->findDuplicateTrip(
+            $user->id,
+            'Rosario',
+            'Buenos Aires',
+            '2028-06-01 09:30:00',
+            0
+        );
+        $differentTime = $this->repo()->findDuplicateTrip(
+            $user->id,
+            'Rosario',
+            'Buenos Aires',
+            '2028-06-01 10:30:00',
+            0
+        );
+
+        $this->assertNotNull($match);
+        $this->assertSame($trip->id, $match->id);
+        $this->assertNull($differentTime);
+    }
+
     public function test_hide_trips_and_unhide_trips_for_sentinel_soft_delete(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Services/Logic/PassengersManagerTest.php
+++ b/tests/Unit/Services/Logic/PassengersManagerTest.php
@@ -35,7 +35,8 @@ class PassengersManagerTest extends TestCase
     {
         parent::setUp();
         Config::set('carpoolear.module_unaswered_message_limit', false);
-        Config::set('carpoolear.module_user_request_limited', false);
+        Config::set('carpoolear.module_user_request_limited_enabled', false);
+        Config::set('carpoolear.module_user_request_limited_hours_range', 2);
         Config::set('carpoolear.module_trip_seats_payment', false);
         Config::set('carpoolear.module_send_full_trip_message', false);
     }
@@ -187,10 +188,8 @@ class PassengersManagerTest extends TestCase
     public function test_new_request_blocks_when_user_request_limited_module_detects_similar_trip(): void
     {
         Event::fake([RequestEvent::class]);
-        Config::set('carpoolear.module_user_request_limited', (object) [
-            'enabled' => true,
-            'hours_range' => 48,
-        ]);
+        Config::set('carpoolear.module_user_request_limited_enabled', true);
+        Config::set('carpoolear.module_user_request_limited_hours_range', 48);
         $driverA = User::factory()->create(['autoaccept_requests' => false]);
         $driverB = User::factory()->create();
         $tripDate = Carbon::parse('2028-07-10 10:00:00');

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -702,6 +702,73 @@ class TripsManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_create_returns_existing_trip_when_same_route_date_and_time(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), 'route/v1/driving')) {
+                return Http::response([
+                    'code' => 'Ok',
+                    'routes' => [['distance' => 365_000, 'duration' => 18_000]],
+                ], 200);
+            }
+
+            return Http::response('unexpected url in test', 404);
+        });
+
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        Event::fake([CreateEvent::class]);
+        $user = $this->completeUser();
+        $this->carWithPlateFor($user);
+        $manager = $this->manager();
+        $payload = $this->minimalCreatePayload();
+
+        $first = $manager->create($user, $payload);
+        $this->assertNotNull($first);
+        Event::assertDispatched(CreateEvent::class, 1);
+
+        Event::fake([CreateEvent::class]);
+        $second = $manager->create($user, $payload);
+
+        $this->assertNotNull($second);
+        $this->assertSame($first->id, $second->id);
+        $this->assertTrue($second->existing);
+        Event::assertNotDispatched(CreateEvent::class);
+        $this->assertSame(1, Trip::where('user_id', $user->id)->count());
+        Carbon::setTestNow();
+    }
+
+    public function test_create_creates_new_trip_when_trip_date_differs(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), 'route/v1/driving')) {
+                return Http::response([
+                    'code' => 'Ok',
+                    'routes' => [['distance' => 365_000, 'duration' => 18_000]],
+                ], 200);
+            }
+
+            return Http::response('unexpected url in test', 404);
+        });
+
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        Event::fake([CreateEvent::class]);
+        $user = $this->completeUser();
+        $this->carWithPlateFor($user);
+        $manager = $this->manager();
+
+        $first = $manager->create($user, $this->minimalCreatePayload());
+        $second = $manager->create($user, $this->minimalCreatePayload([
+            'trip_date' => '2028-03-11 15:00:00',
+        ]));
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertNotSame($first->id, $second->id);
+        $this->assertFalse($second->existing ?? false);
+        $this->assertSame(2, Trip::where('user_id', $user->id)->count());
+        Carbon::setTestNow();
+    }
+
     public function test_create_driver_trip_rejects_incomplete_car(): void
     {
         Carbon::setTestNow('2028-02-01 10:00:00');

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -577,6 +577,7 @@ class TripsManagerTest extends TestCase
         $repo = Mockery::mock(TripRepository::class);
         $repo->shouldReceive('getRecentTrips')->once()->with($user->id, 24)->andReturn(collect([1, 2]));
         $repo->shouldReceive('getTripInfo')->once()->andReturn([]);
+        $repo->shouldReceive('findDuplicateTrip')->once()->andReturn(null);
         $repo->shouldReceive('create')->once()->andReturnUsing(function (array $data) use ($user) {
             return Trip::factory()->create([
                 'user_id' => $data['user_id'] ?? $user->id,

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -78,6 +78,7 @@ class TripTransformerTest extends TestCase
             'rear_max_two_passengers',
             'payment_id',
             'needs_sellado',
+            'existing',
             'sellado_pending',
             'sellado_pending_label',
             'request',
@@ -90,10 +91,21 @@ class TripTransformerTest extends TestCase
         $this->assertSame(15000, $payload['seat_price_cents']);
         $this->assertSame(false, $payload['sellado_pending']);
         $this->assertIsBool($payload['sellado_pending']);
+        $this->assertSame(false, $payload['existing']);
         $this->assertNull($payload['sellado_pending_label']);
         $this->assertSame('', $payload['request']);
         $this->assertSame([], $payload['passenger']);
         $this->assertArrayNotHasKey('car', $payload);
+    }
+
+    public function test_transform_sets_existing_true_when_trip_marked_as_existing(): void
+    {
+        $trip = $this->makeTrip();
+        $trip->setAttribute('existing', true);
+
+        $payload = (new TripTransformer(null))->transform($trip);
+
+        $this->assertTrue($payload['existing']);
     }
 
     public function test_transform_omits_car_for_unrelated_viewer_on_driver_trip(): void


### PR DESCRIPTION
## Summary

Fixes a production bug where the passenger “similar trip” limit never ran, and prevents duplicate driver/passenger trips with the same origin, destination, date, and time.

## Cause

### Passenger similar-trip check
`PassengersManager` read `config('carpoolear.module_user_request_limited')` (legacy object key), but production config only defines:
- `module_user_request_limited_enabled`
- `module_user_request_limited_hours_range`

So the block for `user_has_another_similar_trip` was effectively disabled in production.

### Duplicate trip creation
There was no backend or frontend guard against creating the same trip twice. Concurrent or repeated submits could insert multiple identical rows. The API always created a new trip and the frontend always redirected to the new `id`.

## Fix

### Backend
- **Passenger check:** `PassengersManager` now uses `module_user_request_limited_enabled` and `module_user_request_limited_hours_range` (aligned with `ModuleLimitedRequest` listener and `carpoolear.php`).
- **Duplicate trip create:** Before insert, `TripsManager` looks up an existing active trip for the same `user_id`, `from_town`, `to_town`, `trip_date`, and `is_passenger`.
  - If found, returns that trip with `existing: true` (no new row, no `CreateEvent`).
  - `TripTransformer` exposes `existing` on all trip payloads.
