### PR TITLE
Fix override

### DIFF
--- a/app/Http/Controllers/Api/v1/UserController.php
+++ b/app/Http/Controllers/Api/v1/UserController.php
@@ -32,11 +32,14 @@ class UserController extends Controller
 
     protected $anonymizationService;
 
+    protected UserEditablePropertiesService $userEditablePropertiesService;
+
     public function __construct(
         UsersManager $userLogic,
         DeviceManager $deviceLogic,
         UserDeletionService $userDeletionService,
-        AnonymizationService $anonymizationService
+        AnonymizationService $anonymizationService,
+        UserEditablePropertiesService $userEditablePropertiesService
     ) {
         $this->middleware('logged')->except(['create', 'registerDonation', 'bankData', 'terms']);
         $this->middleware('logged.optional')->only(['create', 'registerDonation', 'bankData', 'terms']);
@@ -44,6 +47,7 @@ class UserController extends Controller
         $this->deviceLogic = $deviceLogic;
         $this->userDeletionService = $userDeletionService;
         $this->anonymizationService = $anonymizationService;
+        $this->userEditablePropertiesService = $userEditablePropertiesService;
     }
 
     public function create(Request $request)
@@ -294,7 +298,7 @@ class UserController extends Controller
 
     public function changeBooleanProperty($property, $value, Request $request)
     {
-        $allowed = app(UserEditablePropertiesService::class)->getChangeBooleanAllowedProperties();
+        $allowed = $this->userEditablePropertiesService->getChangeBooleanAllowedProperties();
         if (! in_array($property, $allowed, true)) {
             throw new ExceptionWithErrors('Could not update user.', [
                 'property' => ['This property cannot be changed via this endpoint.'],

--- a/app/Http/Controllers/Api/v1/UserController.php
+++ b/app/Http/Controllers/Api/v1/UserController.php
@@ -18,6 +18,7 @@ use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
 use STS\Services\MercadoPagoOAuthService;
 use STS\Services\UserDeletionService;
+use STS\Services\UserEditablePropertiesService;
 use STS\Transformers\ProfileTransformer;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -293,6 +294,13 @@ class UserController extends Controller
 
     public function changeBooleanProperty($property, $value, Request $request)
     {
+        $allowed = app(UserEditablePropertiesService::class)->getChangeBooleanAllowedProperties();
+        if (! in_array($property, $allowed, true)) {
+            throw new ExceptionWithErrors('Could not update user.', [
+                'property' => ['This property cannot be changed via this endpoint.'],
+            ]);
+        }
+
         $user = auth()->user();
         $profile = $this->userLogic->update($user, [$property => $value > 0 ? 1 : 0], false, false);
         if (! $profile) {

--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -39,6 +39,9 @@ class UserRepository
         return User::create($data);
     }
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public function update($user, array $data, bool $allowProtectedFields = false)
     {
         unset($data['is_admin']);

--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -12,6 +12,23 @@ use STS\Support\UserSearchFilter;
 class UserRepository
 {
     /**
+     * Fields that must not be mass-assigned unless the caller explicitly opts in
+     * (e.g. admin updates or trusted system flows like account activation).
+     *
+     * @var list<string>
+     */
+    private const PROTECTED_FIELDS = [
+        'banned',
+        'active',
+        'driver_is_verified',
+        'identity_validated',
+        'identity_validated_at',
+        'identity_validation_type',
+        'identity_validation_reject_reason',
+        'validate_by_date',
+    ];
+
+    /**
      * Create a new user instance after a valid registration.
      *
      *
@@ -22,9 +39,14 @@ class UserRepository
         return User::create($data);
     }
 
-    public function update($user, array $data)
+    public function update($user, array $data, bool $allowProtectedFields = false)
     {
         unset($data['is_admin']);
+        if (! $allowProtectedFields) {
+            foreach (self::PROTECTED_FIELDS as $field) {
+                unset($data[$field]);
+            }
+        }
         $user->update($data);
     }
 

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -597,10 +597,16 @@ class UsersManager extends BaseManager
 
                 return;
             }
-            $data['active'] = true;
-            $data['password'] = bcrypt($data['password']);
-            unset($data['password_confirmation']);
-            $this->repo->update($user, $data);
+            $filtered = $this->userEditablePropertiesService->filterForUser(
+                array_intersect_key($data, array_flip(['password', 'password_confirmation'])),
+                false,
+                $user
+            );
+            $updateData = [
+                'password' => bcrypt($filtered['password']),
+                'active' => true,
+            ];
+            $this->repo->update($user, $updateData);
             $this->repo->deleteResetToken('email', $user->email);
 
             return true;

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -165,7 +165,7 @@ class UsersManager extends BaseManager
                         $user_name_lower = strtolower($u->name);
                         foreach ($banned_words as $word) {
                             if (str_contains($user_name_lower, strtolower($word))) {
-                                $this->repo->update($u, ['banned' => 1]);
+                                $this->repo->update($u, ['banned' => 1], true);
                                 \Log::info('User banned due to name containing banned word: '.$u->name.' (matched: '.$word.')');
                                 break;
                             }
@@ -217,7 +217,7 @@ class UsersManager extends BaseManager
                         $user_name_lower = strtolower($u->name);
                         foreach ($banned_words as $word) {
                             if (str_contains($user_name_lower, strtolower($word))) {
-                                $this->repo->update($u, ['banned' => 1]);
+                                $this->repo->update($u, ['banned' => 1], true);
                                 \Log::info('User banned due to name containing banned word: '.$u->name.' (matched: '.$word.')');
                                 break;
                             }
@@ -350,7 +350,7 @@ class UsersManager extends BaseManager
             unset($data['patente'], $data['car_description']);
         }
 
-        $this->repo->update($user, $data);
+        $this->repo->update($user, $data, $is_admin);
         if ($user->banned > 0) {
             // hide user trips
             $this->tripRepository->hideTrips($user);
@@ -498,7 +498,7 @@ class UsersManager extends BaseManager
     {
         $user = $this->repo->getUserBy('activation_token', $activation_token);
         if ($user) {
-            $this->repo->update($user, ['active' => true, 'activation_token' => null]);
+            $this->repo->update($user, ['active' => true, 'activation_token' => null], true);
 
             return $user;
         } else {
@@ -616,7 +616,7 @@ class UsersManager extends BaseManager
                 return;
             }
             $updateData = $this->buildPasswordResetUpdateData($data, $user);
-            $this->repo->update($user, $updateData);
+            $this->repo->update($user, $updateData, true);
             $this->repo->deleteResetToken('email', $user->email);
 
             return true;

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -587,6 +587,24 @@ class UsersManager extends BaseManager
         }
     }
 
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function buildPasswordResetUpdateData(array $data, User $user): array
+    {
+        $filtered = $this->userEditablePropertiesService->filterForUser(
+            array_intersect_key($data, array_flip(['password', 'password_confirmation'])),
+            false,
+            $user
+        );
+
+        return [
+            'password' => bcrypt($filtered['password']),
+            'active' => true,
+        ];
+    }
+
     public function changePassword($token, $data)
     {
         $user = $this->repo->getUserByResetToken($token);
@@ -597,15 +615,7 @@ class UsersManager extends BaseManager
 
                 return;
             }
-            $filtered = $this->userEditablePropertiesService->filterForUser(
-                array_intersect_key($data, array_flip(['password', 'password_confirmation'])),
-                false,
-                $user
-            );
-            $updateData = [
-                'password' => bcrypt($filtered['password']),
-                'active' => true,
-            ];
+            $updateData = $this->buildPasswordResetUpdateData($data, $user);
             $this->repo->update($user, $updateData);
             $this->repo->deleteResetToken('email', $user->email);
 

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -128,6 +128,7 @@ class ProfileTransformer extends TransformerAbstract
                 : null;
         }
         if ($this->user && $this->user->is_admin) {
+            // Admin-only moderation fields (not exposed to regular users to prevent client round-trips).
             $data['banned'] = intval($user->banned);
         }
 

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -68,7 +68,6 @@ class ProfileTransformer extends TransformerAbstract
             'donations' => $user->donations,
             'has_pin' => intval($user->has_pin),
             'is_member' => intval($user->is_member),
-            'banned' => intval($user->banned),
             'active' => intval($user->active),
             'do_not_alert_request_seat' => intval($user->do_not_alert_request_seat),
             'do_not_alert_accept_passenger' => intval($user->do_not_alert_accept_passenger),
@@ -127,6 +126,9 @@ class ProfileTransformer extends TransformerAbstract
             $data['validate_by_date'] = $user->validate_by_date
                 ? $user->validate_by_date->format('Y-m-d')
                 : null;
+        }
+        if ($this->user && $this->user->is_admin) {
+            $data['banned'] = intval($user->banned);
         }
 
         switch ($user->data_visibility) {

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -698,6 +698,21 @@ class UserControllerApiTest extends TestCase
         $this->assertFalse((bool) $user->fresh()->emails_notifications);
     }
 
+    public function test_change_boolean_property_rejects_non_allowlisted_property(): void
+    {
+        $user = User::factory()->create([
+            'active' => true,
+            'banned' => true,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->getJson('/api/users/change/banned/0')
+            ->assertStatus(422);
+
+        $this->assertTrue((bool) $user->fresh()->banned);
+    }
+
     public function test_mercadopago_oauth_url_returns_503_when_identity_validation_disabled(): void
     {
         config([

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -19,6 +19,7 @@ use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
 use STS\Services\MercadoPagoOAuthService;
 use STS\Services\UserDeletionService;
+use STS\Services\UserEditablePropertiesService;
 use Tests\TestCase;
 
 class UserControllerApiTest extends TestCase
@@ -35,7 +36,8 @@ class UserControllerApiTest extends TestCase
             Mockery::mock(UsersManager::class),
             Mockery::mock(DeviceManager::class),
             Mockery::mock(UserDeletionService::class),
-            Mockery::mock(AnonymizationService::class)
+            Mockery::mock(AnonymizationService::class),
+            Mockery::mock(UserEditablePropertiesService::class)
         );
 
         $middlewares = $controller->getMiddleware();

--- a/tests/Feature/Http/UserControllerApiTest.php
+++ b/tests/Feature/Http/UserControllerApiTest.php
@@ -702,15 +702,15 @@ class UserControllerApiTest extends TestCase
     {
         $user = User::factory()->create([
             'active' => true,
-            'banned' => true,
+            'banned' => false,
         ]);
 
         $this->actingAs($user, 'api');
 
-        $this->getJson('/api/users/change/banned/0')
+        $this->getJson('/api/users/change/banned/1')
             ->assertStatus(422);
 
-        $this->assertTrue((bool) $user->fresh()->banned);
+        $this->assertFalse((bool) $user->fresh()->banned);
     }
 
     public function test_mercadopago_oauth_url_returns_503_when_identity_validation_disabled(): void

--- a/tests/Unit/Http/UserControllerMutationSurvivorsTest.php
+++ b/tests/Unit/Http/UserControllerMutationSurvivorsTest.php
@@ -13,6 +13,7 @@ use STS\Services\AnonymizationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
 use STS\Services\UserDeletionService;
+use STS\Services\UserEditablePropertiesService;
 use Tests\TestCase;
 use Tymon\JWTAuth\Exceptions\JWTException;
 
@@ -65,6 +66,7 @@ class UserControllerMutationSurvivorsTest extends TestCase
             Mockery::mock(DeviceManager::class),
             Mockery::mock(UserDeletionService::class),
             Mockery::mock(AnonymizationService::class),
+            Mockery::mock(UserEditablePropertiesService::class),
         );
 
         $response = $controller->create($request);
@@ -133,6 +135,7 @@ class UserControllerMutationSurvivorsTest extends TestCase
             $device,
             $deletion,
             Mockery::mock(AnonymizationService::class),
+            Mockery::mock(UserEditablePropertiesService::class),
         );
 
         $response = $controller->deleteAccount(Request::create('/api/users/delete-account', 'POST'));
@@ -177,6 +180,7 @@ class UserControllerMutationSurvivorsTest extends TestCase
             $device,
             Mockery::mock(UserDeletionService::class),
             $anon,
+            Mockery::mock(UserEditablePropertiesService::class),
         );
 
         $response = $controller->deleteAccount(Request::create('/api/users/delete-account', 'POST'));

--- a/tests/Unit/Repository/UserRepositoryTest.php
+++ b/tests/Unit/Repository/UserRepositoryTest.php
@@ -145,6 +145,42 @@ class UserRepositoryTest extends TestCase
         $this->assertFalse((bool) $user->is_admin);
     }
 
+    public function test_update_strips_banned_and_active_from_payload_by_default(): void
+    {
+        $user = User::factory()->create([
+            'banned' => true,
+            'active' => false,
+        ]);
+
+        $this->repo()->update($user, [
+            'name' => 'Still Banned',
+            'banned' => 0,
+            'active' => true,
+        ]);
+
+        $user->refresh();
+        $this->assertSame('Still Banned', $user->name);
+        $this->assertTrue((bool) $user->banned);
+        $this->assertFalse((bool) $user->active);
+    }
+
+    public function test_update_allows_protected_fields_when_explicitly_enabled(): void
+    {
+        $user = User::factory()->create([
+            'banned' => true,
+            'active' => false,
+        ]);
+
+        $this->repo()->update($user, [
+            'banned' => 0,
+            'active' => true,
+        ], allowProtectedFields: true);
+
+        $user->refresh();
+        $this->assertFalse((bool) $user->banned);
+        $this->assertTrue((bool) $user->active);
+    }
+
     public function test_show_nulls_private_note_and_loads_relations(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Services/Logic/UsersManagerTest.php
+++ b/tests/Unit/Services/Logic/UsersManagerTest.php
@@ -1322,6 +1322,28 @@ class UsersManagerTest extends TestCase
         $this->assertTrue(\Hash::check('newsecret12', $user->fresh()->password));
     }
 
+    public function test_change_password_does_not_clear_banned_when_payload_includes_banned_zero(): void
+    {
+        Queue::fake();
+        $user = User::factory()->create([
+            'banned' => true,
+            'active' => true,
+        ]);
+        $token = $this->manager()->resetPassword($user->email);
+        $this->assertNotNull($token);
+
+        $manager = $this->manager();
+        $this->assertTrue($manager->changePassword($token, [
+            'password' => 'newsecret12',
+            'password_confirmation' => 'newsecret12',
+            'banned' => 0,
+        ]));
+
+        $fresh = $user->fresh();
+        $this->assertTrue((bool) $fresh->banned);
+        $this->assertTrue(\Hash::check('newsecret12', $fresh->password));
+    }
+
     public function test_change_password_returns_null_for_invalid_token(): void
     {
         $manager = $this->manager();

--- a/tests/Unit/Services/Logic/UsersManagerTest.php
+++ b/tests/Unit/Services/Logic/UsersManagerTest.php
@@ -635,7 +635,7 @@ class UsersManagerTest extends TestCase
         $userRepo = Mockery::mock(UserRepository::class);
         $userRepo->shouldReceive('update')
             ->once()
-            ->with($user, Mockery::on(fn ($data) => ($data['description'] ?? null) === 'updated'))
+            ->with($user, Mockery::on(fn ($data) => ($data['description'] ?? null) === 'updated'), false)
             ->andReturnUsing(function ($targetUser, $data) {
                 $targetUser->description = $data['description'];
 
@@ -677,7 +677,7 @@ class UsersManagerTest extends TestCase
         $userRepo = Mockery::mock(UserRepository::class);
         $userRepo->shouldReceive('update')
             ->once()
-            ->with($user, Mockery::on(fn ($data) => ($data['description'] ?? null) === 'updated allowed'))
+            ->with($user, Mockery::on(fn ($data) => ($data['description'] ?? null) === 'updated allowed'), false)
             ->andReturnUsing(function ($targetUser, $data) {
                 $targetUser->description = $data['description'];
 
@@ -726,7 +726,7 @@ class UsersManagerTest extends TestCase
         $userRepo = Mockery::mock(UserRepository::class);
         $userRepo->shouldReceive('update')
             ->once()
-            ->with($user, $filteredData)
+            ->with($user, $filteredData, false)
             ->andReturnUsing(function ($targetUser, $data) {
                 $targetUser->description = $data['description'];
 
@@ -780,7 +780,7 @@ class UsersManagerTest extends TestCase
         $userRepo = Mockery::mock(UserRepository::class);
         $userRepo->shouldReceive('update')
             ->once()
-            ->with($user, $requestData)
+            ->with($user, $requestData, true)
             ->andReturnUsing(function ($targetUser, $data) {
                 $targetUser->nro_doc = $data['nro_doc'];
                 $targetUser->description = $data['description'];

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -37,7 +37,6 @@ class ProfileTransformerTest extends TestCase
             'donations',
             'has_pin',
             'is_member',
-            'banned',
             'active',
             'do_not_alert_request_seat',
             'do_not_alert_accept_passenger',
@@ -124,7 +123,7 @@ class ProfileTransformerTest extends TestCase
         $this->assertArrayHasKey('donations', $payload);
         $this->assertArrayHasKey('has_pin', $payload);
         $this->assertArrayHasKey('is_member', $payload);
-        $this->assertArrayHasKey('banned', $payload);
+        $this->assertArrayNotHasKey('banned', $payload);
         $this->assertArrayHasKey('active', $payload);
         $this->assertArrayHasKey('do_not_alert_request_seat', $payload);
         $this->assertArrayHasKey('do_not_alert_accept_passenger', $payload);
@@ -209,6 +208,26 @@ class ProfileTransformerTest extends TestCase
 
         $this->assertArrayHasKey('identity_validation_required_for_user', $payload);
         $this->assertSame('self@example.test', $payload['email']);
+    }
+
+    public function test_transform_does_not_expose_banned_for_non_admin_viewers(): void
+    {
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $subject = User::factory()->create(['banned' => true]);
+
+        $payload = (new ProfileTransformer($viewer))->transform($subject->fresh());
+
+        $this->assertArrayNotHasKey('banned', $payload);
+    }
+
+    public function test_transform_exposes_banned_for_admin_viewers(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $subject = User::factory()->create(['banned' => true]);
+
+        $payload = (new ProfileTransformer($admin))->transform($subject->fresh());
+
+        $this->assertSame(1, $payload['banned']);
     }
 
     public function test_transform_includes_sensitive_fields_for_admin_viewing_other_user(): void


### PR DESCRIPTION
## Summary

Fixes a security gap where banned users could clear moderation flags through unfiltered update paths. Hardens admin-only user fields (`banned`, `active`, identity flags, etc.) across password reset, repository updates, profile API responses, and boolean toggle endpoints.

## Cause

- `PUT /api/users` was already protected by `UserEditablePropertiesService::filterForUser()`, but **`changePassword()` bypassed it**, passing `$request->all()` straight to `UserRepository::update()`. A banned user could request a password reset and POST `banned: 0` to clear the ban.
- `UserRepository::update()` only stripped `is_admin`, so any unfiltered path could persist protected fields.
- `ProfileTransformer` exposed `banned` to all viewers, encouraging clients to round-trip the field on save.
- `changeBooleanProperty` had an allowlist defined but never enforced it.

## Fix (backend)

1. **`UsersManager::changePassword()`** — filters payload through the editable-properties allowlist; only password (+ system `active`) are persisted.
2. **`UserRepository::update()`** — strips protected fields by default; trusted flows (admin updates, activation, password reset) opt in via `$allowProtectedFields`.
3. **`ProfileTransformer`** — includes `banned` only when the viewer is an admin.
4. **`UserController::changeBooleanProperty()`** — rejects properties outside `getChangeBooleanAllowedProperties()`.
