### PR TITLE
Create trip multi step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,11 @@ MODULE_TRIP_CREATION_PAYMENT_ENABLED=false # If enabled, the trip creator will b
 MODULE_TRIP_CREATION_PAYMENT_AMOUNT_CENTS=1500 # Amount in cents that the trip creator will have to pay if enabled
 MODULE_TRIP_CREATION_PAYMENT_TRIPS_THRESHOLD=2 # If the user creates more than this amount, they will need to pay Sellado
 
+# Trip creation anti-abuse limits (auto-ban when exceeded within the time window)
+DISABLE_TRIP_CREATION_LIMITS=false # Set true in local dev to skip the limit check entirely
+TRIP_CREATION_LIMIT_MAX_TRIPS=5 # Maximum trips allowed within the window before auto-ban
+TRIP_CREATION_LIMIT_TIME_WINDOW_HOURS=24 # Rolling window in hours
+
 MODULE_SEAT_PRICE_ENABLED=false # If enabled, drivers can set a price per passenger
 
 MODULE_MAX_PRICE_ENABLED=true # If enabled, a maximum price will be set based on the trip distance, fuel price, allowed variance, etc.

--- a/app/Http/Controllers/Api/v1/TripCreationTemplateController.php
+++ b/app/Http/Controllers/Api/v1/TripCreationTemplateController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\TripCreationTemplate;
+
+class TripCreationTemplateController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('logged');
+    }
+
+    public function index()
+    {
+        $templates = TripCreationTemplate::query()
+            ->where('user_id', auth()->id())
+            ->orderBy('name')
+            ->get()
+            ->map(fn (TripCreationTemplate $template) => [
+                'name' => $template->name,
+                'data' => $template->data,
+            ])
+            ->values();
+
+        return response()->json(['data' => $templates]);
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'data' => ['required', 'array'],
+        ]);
+
+        $name = trim($validated['name']);
+        if ($name === '') {
+            return response()->json(['message' => 'The name field is required.'], 422);
+        }
+
+        $template = TripCreationTemplate::query()->updateOrCreate(
+            [
+                'user_id' => auth()->id(),
+                'name' => $name,
+            ],
+            [
+                'data' => $validated['data'],
+            ]
+        );
+
+        return response()->json([
+            'data' => [
+                'name' => $template->name,
+                'data' => $template->data,
+            ],
+        ]);
+    }
+
+    public function show(string $name)
+    {
+        $template = TripCreationTemplate::query()
+            ->where('user_id', auth()->id())
+            ->where('name', urldecode($name))
+            ->first();
+
+        if ($template === null) {
+            return response()->json(['message' => 'Not found.'], 404);
+        }
+
+        return response()->json([
+            'data' => [
+                'name' => $template->name,
+                'data' => $template->data,
+            ],
+        ]);
+    }
+}

--- a/app/Models/TripCreationTemplate.php
+++ b/app/Models/TripCreationTemplate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TripCreationTemplate extends Model
+{
+    protected $table = 'trip_creation_templates';
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'data',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'data' => 'array',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/Logic/TripsManager.php
+++ b/app/Services/Logic/TripsManager.php
@@ -129,18 +129,20 @@ class TripsManager extends BaseManager
             }
 
             // Check trip creation limits
-            $maxTrips = config('carpoolear.trip_creation_limits.max_trips', 5);
-            $timeWindow = config('carpoolear.trip_creation_limits.time_window_hours', 24);
+            if (! config('carpoolear.disable_trip_creation_limits', false)) {
+                $maxTrips = config('carpoolear.trip_creation_limits.max_trips', 5);
+                $timeWindow = config('carpoolear.trip_creation_limits.time_window_hours', 24);
 
-            $recentTrips = $this->tripRepo->getRecentTrips($user->id, $timeWindow);
-            if ($recentTrips->count() > $maxTrips) {
-                $this->userManager->update($user, ['banned' => 1], false, true);
-                \Log::info('User banned due to exceeding trip creation limits. User ID: '.$user->id.', Trips created: '.$recentTrips->count().' in last '.$timeWindow.' hours');
-                $messageBag = new MessageBag;
-                $messageBag->add('banned', 'Your account has been banned due to excessive trip creation.');
-                $this->setErrors($messageBag);
+                $recentTrips = $this->tripRepo->getRecentTrips($user->id, $timeWindow);
+                if ($recentTrips->count() > $maxTrips) {
+                    $this->userManager->update($user, ['banned' => 1], false, true);
+                    \Log::info('User banned due to exceeding trip creation limits. User ID: '.$user->id.', Trips created: '.$recentTrips->count().' in last '.$timeWindow.' hours');
+                    $messageBag = new MessageBag;
+                    $messageBag->add('banned', 'Your account has been banned due to excessive trip creation.');
+                    $this->setErrors($messageBag);
 
-                return;
+                    return;
+                }
             }
 
             // Check for banned words and phone numbers in description

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -97,9 +97,12 @@ return [
     ],
 
     'trip_creation_limits' => [
-        'max_trips' => 5,        // Maximum number of trips allowed
-        'time_window_hours' => 24,     // Time window in hours
+        'max_trips' => (int) env('TRIP_CREATION_LIMIT_MAX_TRIPS', 5),
+        'time_window_hours' => (int) env('TRIP_CREATION_LIMIT_TIME_WINDOW_HOURS', 24),
     ],
+
+    // Set to true to disable auto-ban for excessive trip creation (local dev only)
+    'disable_trip_creation_limits' => env('DISABLE_TRIP_CREATION_LIMITS', false),
 
     // Password reset rate limiting
     // Set to true to disable rate limiting for debugging (find culprit emails)

--- a/database/migrations/2026_06_11_000000_create_trip_creation_templates_table.php
+++ b/database/migrations/2026_06_11_000000_create_trip_creation_templates_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('trip_creation_templates', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('name');
+            $table->json('data');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->unique(['user_id', 'name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('trip_creation_templates');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,7 @@ use STS\Http\Controllers\Api\v1\SocialController;
 use STS\Http\Controllers\Api\v1\SubscriptionController;
 use STS\Http\Controllers\Api\v1\SupportTicketController;
 use STS\Http\Controllers\Api\v1\TripController;
+use STS\Http\Controllers\Api\v1\TripCreationTemplateController;
 use STS\Http\Controllers\Api\v1\TripLiveShareController;
 use STS\Http\Controllers\Api\v1\UserController;
 
@@ -213,6 +214,13 @@ Route::middleware(['api'])->group(function () {
         Route::put('/{id?}', [CarController::class, 'update']);
         Route::delete('/{id?}', [CarController::class, 'delete']);
         Route::get('/{id?}', [CarController::class, 'show']);
+    });
+
+    Route::prefix('trip-creation-templates')->group(function () {
+        Route::get('/', [TripCreationTemplateController::class, 'index']);
+        Route::post('/', [TripCreationTemplateController::class, 'store']);
+        Route::get('/{name}', [TripCreationTemplateController::class, 'show'])
+            ->where('name', '.+');
     });
 
     Route::prefix('subscriptions')->group(function () {

--- a/tests/Feature/Http/TripCreationTemplateApiTest.php
+++ b/tests/Feature/Http/TripCreationTemplateApiTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Models\TripCreationTemplate;
+use STS\Models\User;
+use Tests\TestCase;
+
+class TripCreationTemplateApiTest extends TestCase
+{
+    private function templatePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Rosario a BA',
+            'data' => [
+                'trip' => ['is_passenger' => 0, 'total_seats' => 3],
+                'points' => [
+                    ['name' => 'Rosario'],
+                    ['name' => 'Buenos Aires'],
+                ],
+                'date' => '',
+                'dateAnswer' => '',
+                'time' => '',
+            ],
+        ], $overrides);
+    }
+
+    public function test_trip_creation_template_routes_require_authentication(): void
+    {
+        $this->getJson('api/trip-creation-templates')
+            ->assertUnauthorized()
+            ->assertJson(['message' => 'Unauthorized.']);
+
+        $this->postJson('api/trip-creation-templates', $this->templatePayload())
+            ->assertUnauthorized()
+            ->assertJson(['message' => 'Unauthorized.']);
+    }
+
+    public function test_index_returns_empty_list_when_user_has_no_templates(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        $this->actingAs($user, 'api');
+
+        $this->getJson('api/trip-creation-templates')
+            ->assertOk()
+            ->assertJson(['data' => []]);
+    }
+
+    public function test_store_creates_template_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        $this->actingAs($user, 'api');
+
+        $response = $this->postJson('api/trip-creation-templates', $this->templatePayload());
+        $response->assertOk();
+        $response->assertJsonPath('data.name', 'Rosario a BA');
+        $response->assertJsonPath('data.data.trip.total_seats', 3);
+
+        $this->assertDatabaseHas('trip_creation_templates', [
+            'user_id' => $user->id,
+            'name' => 'Rosario a BA',
+        ]);
+    }
+
+    public function test_store_upserts_template_with_same_name_for_user(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        $this->actingAs($user, 'api');
+
+        $this->postJson('api/trip-creation-templates', $this->templatePayload([
+            'data' => ['trip' => ['total_seats' => 2]],
+        ]))->assertOk();
+
+        $this->postJson('api/trip-creation-templates', $this->templatePayload([
+            'data' => ['trip' => ['total_seats' => 4]],
+        ]))
+            ->assertOk()
+            ->assertJsonPath('data.data.trip.total_seats', 4);
+
+        $this->assertSame(1, TripCreationTemplate::where('user_id', $user->id)->count());
+    }
+
+    public function test_index_lists_only_current_user_templates(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        $other = User::factory()->create(['active' => true, 'banned' => false]);
+
+        TripCreationTemplate::create([
+            'user_id' => $user->id,
+            'name' => 'Semanal',
+            'data' => ['trip' => ['total_seats' => 2]],
+        ]);
+        TripCreationTemplate::create([
+            'user_id' => $other->id,
+            'name' => 'Otro',
+            'data' => ['trip' => ['total_seats' => 5]],
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $response = $this->getJson('api/trip-creation-templates')->assertOk();
+        $payload = $response->json('data');
+        $this->assertCount(1, $payload);
+        $this->assertSame('Semanal', $payload[0]['name']);
+    }
+
+    public function test_show_returns_named_template_for_current_user(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        TripCreationTemplate::create([
+            'user_id' => $user->id,
+            'name' => 'Fin de semana',
+            'data' => ['trip' => ['total_seats' => 3]],
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->getJson('api/trip-creation-templates/Fin%20de%20semana')
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Fin de semana')
+            ->assertJsonPath('data.data.trip.total_seats', 3);
+    }
+}

--- a/tests/Unit/Services/Logic/TripsManagerTest.php
+++ b/tests/Unit/Services/Logic/TripsManagerTest.php
@@ -23,6 +23,12 @@ use Tests\TestCase;
 
 class TripsManagerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['carpoolear.disable_trip_creation_limits' => false]);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();
@@ -281,6 +287,41 @@ class TripsManagerTest extends TestCase
         $this->assertNull($result);
         $this->assertTrue($manager->getErrors()->has('banned'));
         $this->assertSame(1, (int) $user->fresh()->banned);
+        Carbon::setTestNow();
+    }
+
+    public function test_create_skips_trip_limit_check_when_disabled_in_config(): void
+    {
+        Carbon::setTestNow('2028-02-01 10:00:00');
+        config([
+            'carpoolear.disable_trip_creation_limits' => true,
+            'carpoolear.trip_creation_limits.max_trips' => 0,
+            'carpoolear.trip_creation_limits.time_window_hours' => 24,
+        ]);
+        $user = $this->completeUser(['banned' => 0]);
+        $this->carWithPlateFor($user);
+
+        $repo = Mockery::mock(TripRepository::class);
+        $repo->shouldNotReceive('getRecentTrips');
+        $repo->shouldReceive('getTripInfo')->once()->andReturn([]);
+        $repo->shouldReceive('findDuplicateTrip')->once()->andReturn(null);
+        $repo->shouldReceive('create')->once()->andReturnUsing(function (array $data) use ($user) {
+            return Trip::factory()->create([
+                'user_id' => $data['user_id'] ?? $user->id,
+                'from_town' => $data['from_town'] ?? 'X',
+                'to_town' => $data['to_town'] ?? 'Y',
+                'trip_date' => $data['trip_date'] ?? Carbon::now()->addDays(5),
+                'total_seats' => $data['total_seats'] ?? 3,
+                'friendship_type_id' => $data['friendship_type_id'] ?? Trip::PRIVACY_PUBLIC,
+            ]);
+        });
+
+        Event::fake([CreateEvent::class]);
+        $manager = new TripsManager($repo, $this->app->make(UsersManager::class));
+        $result = $manager->create($user, $this->minimalCreatePayload());
+
+        $this->assertNotNull($result);
+        $this->assertSame(0, (int) $user->fresh()->banned);
         Carbon::setTestNow();
     }
 


### PR DESCRIPTION
### Features
- **Trip creation templates API** — `GET/POST /api/trip-creation-templates`, `GET /api/trip-creation-templates/{name}`. Authenticated, per-user, upsert by name. Migration: `trip_creation_templates`.
- **Configurable trip creation limits** — `TRIP_CREATION_LIMIT_MAX_TRIPS`, `TRIP_CREATION_LIMIT_TIME_WINDOW_HOURS`, `DISABLE_TRIP_CREATION_LIMITS` env vars (replacing hardcoded limits).
### Cause → fix
| Issue | Cause | Fix |
|-------|-------|-----|
| Templates only in localStorage | No server persistence; lost across devices/browsers | New `TripCreationTemplate` model, controller, routes, and migration |
| Trip limits hard to tune per env | Limits baked into code/config | Expose via env-backed `config/carpoolear.php` |
