### PR TITLE
Fix ratings crash

### DIFF
--- a/app/Transformers/AdminRatingTransformer.php
+++ b/app/Transformers/AdminRatingTransformer.php
@@ -21,9 +21,9 @@ class AdminRatingTransformer extends TransformerAbstract
 
         return [
             'id' => $rate->id,
-            'from' => $rate->from ? $userTrans->transform($rate->from) : null,
-            'to' => $rate->to ? $userTrans->transform($rate->to) : null,
-            'trip' => $rate->trip ? $tripTrans->transform($rate->trip) : null,
+            'from' => $userTrans->transformOrMissing($rate->from, $rate->user_id_from),
+            'to' => $userTrans->transformOrMissing($rate->to, $rate->user_id_to),
+            'trip' => $tripTrans->transformOrMissing($rate->trip, $rate->trip_id),
             'comment' => $rate->comment,
             'user_to_state' => $rate->user_to_state,
             'user_to_type' => $rate->user_to_type,

--- a/app/Transformers/RatingTransformer.php
+++ b/app/Transformers/RatingTransformer.php
@@ -28,7 +28,7 @@ class RatingTransformer extends TransformerAbstract
             'id' => $rate->id,
             'from' => $userTrans->transformOrMissing($rate->from, $rate->user_id_from),
             // 'to' => $userTrans->transform($rate->to),
-            'trip' => $tripTrans->transform($rate->trip),
+            'trip' => $tripTrans->transformOrMissing($rate->trip, $rate->trip_id),
             'comment' => $rate->comment,
             'user_to_state' => $rate->user_to_state,
             'user_to_type' => $rate->user_to_type,

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -15,6 +15,21 @@ class TripTransformer extends TransformerAbstract
         $this->user = $user;
     }
 
+    public function transformOrMissing(?Trip $trip, ?int $tripId = null): array
+    {
+        return $trip ? $this->transform($trip) : $this->missingTrip($tripId);
+    }
+
+    public function missingTrip(?int $tripId = null): array
+    {
+        return [
+            'id' => $tripId,
+            'from_town' => '',
+            'to_town' => 'Viaje inexistente',
+            'deleted' => true,
+        ];
+    }
+
     /**
      * Turn this item object into a generic array.
      *

--- a/app/Transformers/TripUserTransformer.php
+++ b/app/Transformers/TripUserTransformer.php
@@ -26,7 +26,7 @@ class TripUserTransformer extends TransformerAbstract
     {
         return [
             'id' => $userId,
-            'name' => 'Usuario inexistente',
+            'name' => 'Usuario ya no existe',
             'descripcion' => '',
             'private_note' => '',
             'image' => '',

--- a/tests/Feature/Http/RatingApiTest.php
+++ b/tests/Feature/Http/RatingApiTest.php
@@ -148,7 +148,7 @@ class RatingApiTest extends TestCase
         $rating = collect($response->json('data'))->firstWhere('id', $row->id);
         $this->assertNotNull($rating);
         $this->assertSame($deletedVoterId, $rating['from']['id']);
-        $this->assertSame('Usuario inexistente', $rating['from']['name']);
+        $this->assertSame('Usuario ya no existe', $rating['from']['name']);
     }
 
     public function test_authenticated_user_can_list_ratings_they_received_using_pagination(): void

--- a/tests/Feature/Http/RatingApiTest.php
+++ b/tests/Feature/Http/RatingApiTest.php
@@ -147,8 +147,10 @@ class RatingApiTest extends TestCase
 
         $rating = collect($response->json('data'))->firstWhere('id', $row->id);
         $this->assertNotNull($rating);
+        $this->assertDatabaseHas('rating', ['id' => $row->id]);
         $this->assertSame($deletedVoterId, $rating['from']['id']);
         $this->assertSame('Usuario ya no existe', $rating['from']['name']);
+        $this->assertSame('', $rating['from']['image']);
     }
 
     public function test_authenticated_user_can_list_ratings_they_received_using_pagination(): void

--- a/tests/Feature/Http/RatingApiTest.php
+++ b/tests/Feature/Http/RatingApiTest.php
@@ -75,6 +75,45 @@ class RatingApiTest extends TestCase
             ->assertJson(['message' => 'Unauthorized.']);
     }
 
+    public function test_authenticated_user_can_list_ratings_when_trip_was_deleted(): void
+    {
+        $rated = User::factory()->create(['active' => true, 'banned' => false]);
+        $voter = User::factory()->create(['active' => true, 'banned' => false]);
+        $trip = Trip::factory()->create(['user_id' => $rated->id]);
+        $deletedTripId = $trip->id;
+
+        $row = $this->persistRating([
+            'trip_id' => $deletedTripId,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $rated->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'Orphaned trip',
+            'reply_comment' => '',
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::now(),
+            'available' => 1,
+        ]);
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        $trip->forceDelete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        $this->actingAs($rated, 'api');
+
+        $response = $this->getJson('api/users/'.$rated->id.'/ratings?page_size=200');
+        $response->assertOk();
+
+        $rating = collect($response->json('data'))->firstWhere('id', $row->id);
+        $this->assertNotNull($rating);
+        $this->assertDatabaseHas('rating', ['id' => $row->id]);
+        $this->assertSame($deletedTripId, $rating['trip']['id']);
+        $this->assertSame('Viaje inexistente', $rating['trip']['to_town']);
+        $this->assertTrue($rating['trip']['deleted']);
+    }
+
     public function test_authenticated_user_can_list_ratings_when_voter_was_deleted(): void
     {
         $rated = User::factory()->create(['active' => true, 'banned' => false]);

--- a/tests/Unit/Transformers/RatingTransformerTest.php
+++ b/tests/Unit/Transformers/RatingTransformerTest.php
@@ -114,7 +114,7 @@ class RatingTransformerTest extends TestCase
         $payload = (new RatingTransformer($to))->transform($rate->fresh());
 
         $this->assertSame($deletedFromId, $payload['from']['id']);
-        $this->assertSame('Usuario inexistente', $payload['from']['name']);
+        $this->assertSame('Usuario ya no existe', $payload['from']['name']);
         $this->assertSame('', $payload['from']['image']);
     }
 
@@ -147,7 +147,7 @@ class RatingTransformerTest extends TestCase
         $payload = (new RatingTransformer($from))->transform($rate->fresh());
 
         $this->assertSame($deletedToId, $payload['to']['id']);
-        $this->assertSame('Usuario inexistente', $payload['to']['name']);
+        $this->assertSame('Usuario ya no existe', $payload['to']['name']);
     }
 
     public function test_transform_returns_placeholder_when_trip_was_deleted(): void

--- a/tests/Unit/Transformers/RatingTransformerTest.php
+++ b/tests/Unit/Transformers/RatingTransformerTest.php
@@ -149,4 +149,37 @@ class RatingTransformerTest extends TestCase
         $this->assertSame($deletedToId, $payload['to']['id']);
         $this->assertSame('Usuario inexistente', $payload['to']['name']);
     }
+
+    public function test_transform_returns_placeholder_when_trip_was_deleted(): void
+    {
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $to->id]);
+        $deletedTripId = $trip->id;
+
+        $rate = Rating::query()->create([
+            'trip_id' => $deletedTripId,
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'Trip deleted',
+            'reply_comment' => '',
+            'reply_comment_created_at' => null,
+            'user_to_type' => 1,
+            'user_to_state' => 1,
+            'voted' => true,
+            'voted_hash' => '',
+            'rate_at' => Carbon::parse('2026-04-30 11:00:00'),
+        ]);
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        $trip->forceDelete();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        $payload = (new RatingTransformer($to))->transform($rate->fresh());
+
+        $this->assertSame($deletedTripId, $payload['trip']['id']);
+        $this->assertSame('Viaje inexistente', $payload['trip']['to_town']);
+        $this->assertTrue($payload['trip']['deleted']);
+    }
 }

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -44,6 +44,15 @@ class TripTransformerTest extends TestCase
         ], $overrides));
     }
 
+    public function test_transform_or_missing_returns_placeholder_when_trip_is_null(): void
+    {
+        $payload = (new TripTransformer(null))->transformOrMissing(null, 148201);
+
+        $this->assertSame(148201, $payload['id']);
+        $this->assertSame('Viaje inexistente', $payload['to_town']);
+        $this->assertTrue($payload['deleted']);
+    }
+
     public function test_transform_returns_expected_base_trip_payload_without_user_context(): void
     {
         $trip = $this->makeTrip();

--- a/tests/Unit/Transformers/TripUserTransformerTest.php
+++ b/tests/Unit/Transformers/TripUserTransformerTest.php
@@ -94,7 +94,7 @@ class TripUserTransformerTest extends TestCase
         $this->assertNull($payload['identity_validated_at']);
     }
 
-    public function test_missing_user_returns_placeholder_payload_with_usuario_inexistente_name(): void
+    public function test_missing_user_returns_placeholder_payload_with_usuario_ya_no_existe_name(): void
     {
         $viewer = User::factory()->create();
 
@@ -126,7 +126,7 @@ class TripUserTransformerTest extends TestCase
             'identity_validated_at',
         ], array_keys($payload));
         $this->assertSame(99999, $payload['id']);
-        $this->assertSame('Usuario inexistente', $payload['name']);
+        $this->assertSame('Usuario ya no existe', $payload['name']);
         $this->assertSame('', $payload['descripcion']);
         $this->assertSame('', $payload['private_note']);
         $this->assertSame('', $payload['image']);


### PR DESCRIPTION
## Summary

Fixes a 500 error on `GET /api/users/{id}/ratings` when some ratings reference trips or users that no longer exist in the database — **without deleting any ratings or references**.

### Cause

- Some `rating` rows point at `trip_id` values with no matching row in `trips` (hard-deleted trips).
- `RatingTransformer` called `TripTransformer::transform($rate->trip)` without a null guard → `TypeError`, breaking the entire listing.
- Missing users already had a placeholder via `transformOrMissing`, but used outdated copy (`"Usuario inexistente"`).

### Backend fix

**Missing trips (defensive, no data loss)**
- Added `TripTransformer::transformOrMissing()` / `missingTrip()`.
- Orphaned trips render as: `{ id, from_town: '', to_town: 'Viaje inexistente', deleted: true }`.
- Applied in `RatingTransformer` and `AdminRatingTransformer`.
- Rating rows are **preserved** in the database.

**Missing users (copy update)**
- `TripUserTransformer::missingUser()` now returns `"Usuario ya no existe"` with empty `image` and no profile data.
- Ratings/references for deleted users remain in the DB.

**No schema migration** — no orphan cleanup, no `ON DELETE CASCADE` foreign keys.

### Tests (TDD)

- Unit: `RatingTransformerTest`, `TripTransformerTest`, `TripUserTransformerTest`
- Feature: `RatingApiTest` — listings succeed when trip or voter was hard-deleted; asserts rating rows persist in DB

## Test plan

- [ ] `GET /api/users/324599/ratings?page_size=200` returns 200 with all ratings
- [ ] Ratings for deleted trips show destination `"Viaje inexistente"`
- [ ] Ratings from deleted users show `"Usuario ya no existe"` and no profile image
- [ ] Confirm rating count unchanged in DB after deploy (no rows deleted)