### PR TITLE
Account verification changes

### DIFF
--- a/app/Http/Controllers/Api/Admin/UserController.php
+++ b/app/Http/Controllers/Api/Admin/UserController.php
@@ -15,6 +15,7 @@ use STS\Models\User;
 use STS\Services\AnonymizationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\UserDeletionService;
+use STS\Services\UserIdentityVerificationResetService;
 use STS\Support\UserSearchFilter;
 use STS\Transformers\ProfileTransformer;
 
@@ -24,16 +25,17 @@ class UserController extends Controller
 
     protected $anonymizationService;
 
-    protected $deviceLogic;
+    protected $identityVerificationResetService;
 
     public function __construct(
         UserDeletionService $userDeletionService,
         AnonymizationService $anonymizationService,
-        DeviceManager $deviceLogic
+        protected DeviceManager $deviceLogic,
+        UserIdentityVerificationResetService $identityVerificationResetService,
     ) {
         $this->userDeletionService = $userDeletionService;
         $this->anonymizationService = $anonymizationService;
-        $this->deviceLogic = $deviceLogic;
+        $this->identityVerificationResetService = $identityVerificationResetService;
     }
 
     /**
@@ -114,12 +116,7 @@ class UserController extends Controller
      */
     public function clearIdentityValidation(User $user): JsonResponse
     {
-        $user->identity_validated = false;
-        $user->identity_validated_at = null;
-        $user->identity_validation_type = null;
-        $user->identity_validation_rejected_at = null;
-        $user->identity_validation_reject_reason = null;
-        $user->save();
+        $this->identityVerificationResetService->clearForUser($user);
 
         return response()->json([
             'message' => 'Identity validation cleared',

--- a/app/Services/UserIdentityVerificationResetService.php
+++ b/app/Services/UserIdentityVerificationResetService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace STS\Services;
+
+use Illuminate\Support\Facades\Storage;
+use STS\Models\ManualIdentityValidation;
+use STS\Models\MercadoPagoRejectedValidation;
+use STS\Models\User;
+
+class UserIdentityVerificationResetService
+{
+    public function clearForUser(User $user): void
+    {
+        $this->deleteManualIdentityValidationsForUser($user);
+        MercadoPagoRejectedValidation::query()
+            ->where('user_id', $user->id)
+            ->delete();
+
+        $user->identity_validated = false;
+        $user->identity_validated_at = null;
+        $user->identity_validation_type = null;
+        $user->identity_validation_rejected_at = null;
+        $user->identity_validation_reject_reason = null;
+        $user->save();
+    }
+
+    private function deleteManualIdentityValidationsForUser(User $user): void
+    {
+        ManualIdentityValidation::query()
+            ->where('user_id', $user->id)
+            ->get()
+            ->each(function (ManualIdentityValidation $item): void {
+                foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
+                    $path = $item->$column;
+                    if ($path && Storage::disk('local')->exists($path)) {
+                        Storage::disk('local')->delete($path);
+                    }
+                }
+                $item->delete();
+            });
+    }
+}

--- a/app/Transformers/ProfileTransformer.php
+++ b/app/Transformers/ProfileTransformer.php
@@ -126,6 +126,7 @@ class ProfileTransformer extends TransformerAbstract
             $data['validate_by_date'] = $user->validate_by_date
                 ? $user->validate_by_date->format('Y-m-d')
                 : null;
+            $data['manual_identity_validations_count'] = $user->manualIdentityValidations()->count();
         }
         if ($this->user && $this->user->is_admin) {
             // Admin-only moderation fields (not exposed to regular users to prevent client round-trips).

--- a/tests/Feature/Http/AdminUserControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminUserControllerIntegrationTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature\Http;
 
+use Illuminate\Support\Facades\Storage;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\AdminActionLog;
 use STS\Models\BannedUser;
 use STS\Models\DeleteAccountRequest;
+use STS\Models\ManualIdentityValidation;
+use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\Rating;
 use STS\Models\Trip;
 use STS\Models\User;
@@ -175,6 +178,56 @@ class AdminUserControllerIntegrationTest extends TestCase
             ->assertJsonPath('message', 'Identity validation cleared')
             ->assertJsonPath('data.identity_validated', false)
             ->assertJsonPath('data.identity_validation_type', null);
+
+        $fresh = $target->fresh();
+        $this->assertFalse($fresh->identity_validated);
+        $this->assertNull($fresh->identity_validated_at);
+        $this->assertNull($fresh->identity_validation_type);
+        $this->assertNull($fresh->identity_validation_rejected_at);
+        $this->assertNull($fresh->identity_validation_reject_reason);
+    }
+
+    public function test_clear_identity_validation_deletes_manual_rows_photos_and_mp_rejections(): void
+    {
+        Storage::fake('local');
+
+        $admin = $this->admin();
+        $target = User::factory()->create([
+            'identity_validated' => false,
+            'identity_validated_at' => null,
+            'identity_validation_type' => null,
+            'identity_validation_rejected_at' => now()->subDay(),
+            'identity_validation_reject_reason' => 'name_mismatch',
+        ]);
+
+        $frontPath = 'idv/clear-front.jpg';
+        Storage::disk('local')->put($frontPath, 'front-bytes');
+
+        $manual = ManualIdentityValidation::query()->create([
+            'user_id' => $target->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'front_image_path' => $frontPath,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'review_note' => 'Prueba',
+        ]);
+
+        $mpRejected = MercadoPagoRejectedValidation::query()->create([
+            'user_id' => $target->id,
+            'reject_reason' => 'dni_mismatch',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/users/'.$target->id.'/clear-identity-validation')
+            ->assertOk()
+            ->assertJsonPath('message', 'Identity validation cleared');
+
+        $this->assertDatabaseMissing('manual_identity_validations', ['id' => $manual->id]);
+        $this->assertDatabaseMissing('mercado_pago_rejected_validations', ['id' => $mpRejected->id]);
+        Storage::disk('local')->assertMissing($frontPath);
 
         $fresh = $target->fresh();
         $this->assertFalse($fresh->identity_validated);

--- a/tests/Unit/Transformers/ProfileTransformerTest.php
+++ b/tests/Unit/Transformers/ProfileTransformerTest.php
@@ -484,6 +484,23 @@ class ProfileTransformerTest extends TestCase
         $this->assertSame('2025-05-11 09:00:00', $payload['identity_validation_rejected_at']);
         $this->assertSame('Document unreadable', $payload['identity_validation_reject_reason']);
         $this->assertSame('2025-06-30', $payload['validate_by_date']);
+        $this->assertSame(0, $payload['manual_identity_validations_count']);
+    }
+
+    public function test_transform_exposes_manual_identity_validations_count_for_admin(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $subject = User::factory()->create();
+
+        \STS\Models\ManualIdentityValidation::query()->create([
+            'user_id' => $subject->id,
+            'paid' => false,
+            'review_status' => \STS\Models\ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $payload = (new ProfileTransformer($admin))->transform($subject->fresh());
+
+        $this->assertSame(1, $payload['manual_identity_validations_count']);
     }
 
     public function test_transform_does_not_expose_extended_admin_detail_fields_for_non_admin(): void
@@ -502,5 +519,6 @@ class ProfileTransformerTest extends TestCase
         $this->assertArrayNotHasKey('identity_validation_rejected_at', $payload);
         $this->assertArrayNotHasKey('identity_validation_reject_reason', $payload);
         $this->assertArrayNotHasKey('validate_by_date', $payload);
+        $this->assertArrayNotHasKey('manual_identity_validations_count', $payload);
     }
 }


### PR DESCRIPTION
## Summary

Fixes manual identity verification rejections incorrectly showing the green "Verificación exitosa" banner, adds a retry prompt with Mercado Pago / manual options on rejection, and makes admin "Remover verificación de cuenta" fully reset all verification state (MP + manual).


## Backend

### Cause
`clearIdentityValidation` only cleared user identity columns. It did not delete `manual_identity_validations` rows/photos or `mercado_pago_rejected_validations` records, so partial manual verifications could not be fully reset from admin.

### Fix
- Added `UserIdentityVerificationResetService` used by admin `clearIdentityValidation`.
- Clears all user identity fields (`identity_validated`, `identity_validated_at`, `identity_validation_type`, rejection fields).
- Deletes all manual identity validation DB rows and stored photos.
- Deletes all Mercado Pago rejected validation records for the user.
- Exposes `manual_identity_validations_count` on admin profile payloads so the frontend can show the clear button for partial manual state.
