### PR TITLE
Accept jpeg

### DIFF
--- a/app/Services/ImageUploadValidator.php
+++ b/app/Services/ImageUploadValidator.php
@@ -3,6 +3,7 @@
 namespace STS\Services;
 
 use Illuminate\Http\UploadedFile;
+use STS\Support\ImageAttachmentRules;
 
 class ImageUploadValidator
 {
@@ -30,11 +31,11 @@ class ImageUploadValidator
 
         $errors = [];
 
-        if (! in_array($mime, $allowedMimes, true)) {
+        if (! $this->isAllowedMime($mime, $allowedMimes)) {
             $errors[$field] = ['Invalid image MIME type. Allowed: jpeg, png, webp, heic.'];
         }
 
-        if (! in_array($extension, $allowedExtensions, true)) {
+        if (! $this->isAllowedExtension($extension, $allowedExtensions)) {
             $errors[$field] = $errors[$field] ?? ['Invalid image file extension. Allowed: jpeg, png, webp, heic.'];
         }
 
@@ -47,5 +48,41 @@ class ImageUploadValidator
         }
 
         return ['valid' => true];
+    }
+
+    /**
+     * @param  list<string>  $allowedMimes
+     */
+    private function isAllowedMime(?string $mime, array $allowedMimes): bool
+    {
+        if ($mime === null || $mime === '') {
+            return false;
+        }
+
+        if (in_array($mime, $allowedMimes, true)) {
+            return true;
+        }
+
+        if (in_array($mime, ImageAttachmentRules::JPEG_MIMES, true)) {
+            return ! empty(array_intersect($allowedMimes, ImageAttachmentRules::JPEG_MIMES));
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $allowedExtensions
+     */
+    private function isAllowedExtension(string $extension, array $allowedExtensions): bool
+    {
+        if (in_array($extension, $allowedExtensions, true)) {
+            return true;
+        }
+
+        if (in_array($extension, ImageAttachmentRules::JPEG_EXTENSIONS, true)) {
+            return ! empty(array_intersect($allowedExtensions, ImageAttachmentRules::JPEG_EXTENSIONS));
+        }
+
+        return false;
     }
 }

--- a/app/Support/ImageAttachmentRules.php
+++ b/app/Support/ImageAttachmentRules.php
@@ -8,7 +8,13 @@ final class ImageAttachmentRules
     public const FILE = 'file|mimes:jpg,jpeg,png,webp|max:10240';
 
     /** @var list<string> */
-    public const ALLOWED_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+    public const JPEG_EXTENSIONS = ['jpg', 'jpeg'];
+
+    /** @var list<string> */
+    public const JPEG_MIMES = ['image/jpeg', 'image/jpg'];
+
+    /** @var list<string> */
+    public const ALLOWED_MIMES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
 
     /** @var list<string> */
     public const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -64,7 +64,7 @@ return [
     'qr_payment_pos_external_id' => env('MERCADO_PAGO_QR_PAYMENT_POS_EXTERNAL_ID', ''),
 
     // Document/identity image uploads: allowed types, size limit, HEIC conversion
-    'image_upload_allowed_mimes' => ['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif'],
+    'image_upload_allowed_mimes' => ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/heic', 'image/heif'],
     'image_upload_allowed_extensions' => ['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif'],
     'image_upload_max_bytes' => (int) env('IMAGE_UPLOAD_MAX_BYTES', 10 * 1024 * 1024),
     'image_upload_convert_heic_to_jpeg' => filter_var(env('IMAGE_UPLOAD_CONVERT_HEIC', true), FILTER_VALIDATE_BOOLEAN),

--- a/tests/Feature/Http/DriverDocsApiTest.php
+++ b/tests/Feature/Http/DriverDocsApiTest.php
@@ -16,7 +16,7 @@ class DriverDocsApiTest extends TestCase
 
     public function test_create_user_with_valid_driver_doc_succeeds(): void
     {
-        $file = UploadedFile::fake()->image('doc.jpg', 100, 100)->size(500);
+        $file = UploadedFile::fake()->image('doc.jpeg', 100, 100)->size(500);
         $data = [
             'name' => 'Driver User',
             'email' => 'driver'.time().'@example.com',

--- a/tests/Unit/ImageUploadValidatorTest.php
+++ b/tests/Unit/ImageUploadValidatorTest.php
@@ -18,10 +18,40 @@ class ImageUploadValidatorTest extends TestCase
 
     public function test_valid_jpeg_passes(): void
     {
-        $file = UploadedFile::fake()->image('photo.jpg', 100, 100)->size(500);
+        $file = UploadedFile::fake()->image('photo.jpeg', 100, 100)->size(500);
         $result = $this->validator->validate($file);
         $this->assertTrue($result['valid']);
         $this->assertArrayNotHasKey('errors', $result);
+    }
+
+    public function test_jpeg_extension_passes_when_allowed_extensions_include_only_jpg(): void
+    {
+        config()->set('carpoolear.image_upload_allowed_mimes', ['image/jpeg']);
+        config()->set('carpoolear.image_upload_allowed_extensions', ['jpg']);
+
+        $file = UploadedFile::fake()->image('photo.jpeg', 100, 100)->size(500);
+        $result = $this->validator->validate($file, 'cover');
+
+        $this->assertTrue($result['valid']);
+    }
+
+    public function test_jpg_extension_passes_when_allowed_extensions_include_only_jpeg(): void
+    {
+        config()->set('carpoolear.image_upload_allowed_mimes', ['image/jpeg']);
+        config()->set('carpoolear.image_upload_allowed_extensions', ['jpeg']);
+
+        $file = UploadedFile::fake()->image('photo.jpg', 100, 100)->size(500);
+        $result = $this->validator->validate($file, 'cover');
+
+        $this->assertTrue($result['valid']);
+    }
+
+    public function test_image_jpg_mime_alias_passes(): void
+    {
+        $file = UploadedFile::fake()->create('photo.jpeg', 100, 'image/jpg');
+        $result = $this->validator->validate($file);
+
+        $this->assertTrue($result['valid']);
     }
 
     public function test_valid_png_passes(): void
@@ -163,7 +193,7 @@ class ImageUploadValidatorTest extends TestCase
         config()->set('carpoolear.image_upload_allowed_mimes', ['image/jpeg']);
         config()->set('carpoolear.image_upload_allowed_extensions', ['jpg']);
 
-        $file = UploadedFile::fake()->create('photo.jpeg', 100, 'image/jpeg');
+        $file = UploadedFile::fake()->create('photo.jfif', 100, 'image/jpeg');
         $result = $this->validator->validate($file, 'cover');
 
         $this->assertFalse($result['valid']);


### PR DESCRIPTION
## Summary

Fix image uploads rejecting `.jpeg` files while `.jpg` was accepted.

### Cause
- **Backend:** `ImageUploadValidator` treated `jpg` and `jpeg` as distinct extensions. If only one was in the allowed list (or a client sent the non-standard `image/jpg` MIME), valid JPEG uploads could be rejected.
- **Frontend:** Upload inputs used inconsistent `accept` values and had no shared client-side rules, so some pickers/devices could surface `.jpeg` files without the app handling them consistently.

### Fix

**Backend**
- Treat `jpg` and `jpeg` as equivalent extensions in `ImageUploadValidator`.
- Accept `image/jpg` as a JPEG MIME alias.
- Centralize JPEG constants in `ImageAttachmentRules`.
- Add tests for `.jpeg` uploads, extension aliasing, and `image/jpg` MIME.

## Test plan
- [ ] Upload a `.jpeg` photo in manual identity validation
- [ ] Upload a `.jpeg` driver document on register/profile
- [ ] Attach a `.jpeg` image to a support ticket
- [ ] Upload profile photo from mobile (Capacitor camera / gallery)
- [ ] Confirm `.jpg` uploads still work in all flows