### PR TITLE
Message deleted images

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -83,6 +83,7 @@ class ManualIdentityValidationController extends Controller
             'back_image_url' => $item->back_image_path ? $imageUrl('back') : null,
             'selfie_image_url' => $item->selfie_image_path ? $imageUrl('selfie') : null,
             'has_images' => $item->hasImages(),
+            'images_purged_at' => $item->images_purged_at ? $item->images_purged_at->toDateTimeString() : null,
             'support_tickets_count' => SupportTicket::countForUser($item->user_id),
         ];
     }
@@ -203,6 +204,7 @@ class ManualIdentityValidationController extends Controller
             }
             $item->$col = null;
         }
+        $item->images_purged_at = now();
         $item->save();
 
         return response()->json(['message' => 'Photos purged', 'data' => $item->fresh()]);

--- a/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
@@ -271,6 +271,7 @@ class ManualIdentityValidationController extends Controller
         $validationRequest->back_image_path = $backPath;
         $validationRequest->selfie_image_path = $selfiePath;
         $validationRequest->submitted_at = now();
+        $validationRequest->images_purged_at = null;
         $validationRequest->save();
 
         return response()->json([

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -30,6 +30,7 @@ class ManualIdentityValidation extends Model
         'review_note',
         'private_admin_note',
         'manual_validation_started_at',
+        'images_purged_at',
     ];
 
     protected function casts(): array
@@ -40,6 +41,7 @@ class ManualIdentityValidation extends Model
             'paid_at' => 'datetime',
             'reviewed_at' => 'datetime',
             'manual_validation_started_at' => 'datetime',
+            'images_purged_at' => 'datetime',
         ];
     }
 

--- a/database/migrations/2026_06_15_120000_add_images_purged_at_to_manual_identity_validations.php
+++ b/database/migrations/2026_06_15_120000_add_images_purged_at_to_manual_identity_validations.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->timestamp('images_purged_at')->nullable()->after('selfie_image_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->dropColumn('images_purged_at');
+        });
+    }
+};

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -248,6 +248,80 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->assertNull($fresh->front_image_path);
     }
 
+    public function test_show_reports_images_not_purged_when_paid_without_submitted_images(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => null,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/manual-identity-validations/'.$row->id)
+            ->assertOk()
+            ->assertJsonPath('data.has_images', false)
+            ->assertJsonPath('data.images_purged_at', null);
+    }
+
+    public function test_purge_sets_images_purged_at(): void
+    {
+        Storage::fake('local');
+        $admin = $this->admin();
+        $user = User::factory()->create();
+
+        $front = 'idv/purge-front.jpg';
+        Storage::disk('local')->put($front, 'x');
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'front_image_path' => $front,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/purge')
+            ->assertOk();
+
+        $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
+        $this->assertNotNull($fresh->images_purged_at);
+    }
+
+    public function test_show_reports_images_purged_after_admin_purge(): void
+    {
+        Storage::fake('local');
+        $admin = $this->admin();
+        $user = User::factory()->create();
+
+        $front = 'idv/purge-front.jpg';
+        Storage::disk('local')->put($front, 'x');
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'front_image_path' => $front,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/purge')->assertOk();
+
+        $this->getJson('api/admin/manual-identity-validations/'.$row->id)
+            ->assertOk()
+            ->assertJsonPath('data.has_images', false)
+            ->assertJsonPath('data.images_purged_at', fn ($value) => $value !== null);
+    }
+
     public function test_private_note_endpoint_updates_field_and_show_returns_it(): void
     {
         $admin = $this->admin();

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -67,6 +67,17 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $row->manual_validation_started_at);
     }
 
+    public function test_images_purged_at_is_cast_to_datetime(): void
+    {
+        $user = User::factory()->create();
+
+        $row = $this->makeRow($user, [
+            'images_purged_at' => '2026-06-15 12:00:00',
+        ]);
+
+        $this->assertInstanceOf(Carbon::class, $row->fresh()->images_purged_at);
+    }
+
     public function test_has_images_detects_any_uploaded_path(): void
     {
         $user = User::factory()->create();
@@ -120,6 +131,7 @@ class ManualIdentityValidationTest extends TestCase
             'review_note',
             'private_admin_note',
             'manual_validation_started_at',
+            'images_purged_at',
         ], (new ManualIdentityValidation)->getFillable());
     }
 


### PR DESCRIPTION
## Summary

Fixes admin manual verification detail showing "Fotos eliminadas" for paid requests where the user has not uploaded photos yet.

### Cause
The admin review view treated `!has_images` as "photos were purged", but that state also applies when payment is complete and photos were never submitted.

### Backend
- Added `images_purged_at` column to `manual_identity_validations`
- Set `images_purged_at` when an admin purges photos via `POST .../purge`
- Expose `images_purged_at` in the admin show payload
- Clear `images_purged_at` when the user resubmits images

## Test plan
- [ ] Open a paid manual verification request with no submitted photos → "Fotos eliminadas" should **not** appear
- [ ] Open a request with uploaded photos → photos display normally
- [ ] Purge photos as admin → "Fotos eliminadas" appears
- [ ] User resubmits photos after purge → photos display again and purge message disappears