### PR TITLE
Account verification override fix

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -9,6 +9,7 @@ use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\SupportTicket;
 use STS\Services\ManualIdentityValidationReviewNotifier;
+use STS\Services\UserIdentityVerificationSuccessService;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ManualIdentityValidationController extends Controller
@@ -148,12 +149,7 @@ class ManualIdentityValidationController extends Controller
 
         $user = $item->user;
         if ($validated['action'] === 'approve') {
-            $user->identity_validated = true;
-            $user->identity_validated_at = now();
-            $user->identity_validation_type = 'manual';
-            $user->identity_validation_rejected_at = null;
-            $user->identity_validation_reject_reason = null;
-            $user->save();
+            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
         } else {
             // Reject or Pending: clear identity validation flags and metadata
             $user->identity_validated = false;

--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\SupportTicket;
+use STS\Services\UserIdentityVerificationSuccessService;
 
 class MercadoPagoRejectedValidationController extends Controller
 {
@@ -71,12 +72,7 @@ class MercadoPagoRejectedValidationController extends Controller
         $item->reviewed_by = $admin->id;
 
         if ($validated['action'] === 'approve') {
-            $user->identity_validated = true;
-            $user->identity_validated_at = now();
-            $user->identity_validation_type = 'manual';
-            $user->identity_validation_rejected_at = null;
-            $user->identity_validation_reject_reason = null;
-            $user->save();
+            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
             $item->approved_at = now();
             $item->approved_by = $admin->id;
         } else {

--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -72,7 +72,9 @@ class MercadoPagoRejectedValidationController extends Controller
         $item->reviewed_by = $admin->id;
 
         if ($validated['action'] === 'approve') {
-            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
+            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual', [
+                'preserve_mercado_pago_rejected_validation_ids' => [$item->id],
+            ]);
             $item->approved_at = now();
             $item->approved_by = $admin->id;
         } else {

--- a/app/Http/Controllers/Api/v1/MercadoPagoOAuthController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoOAuthController.php
@@ -8,6 +8,7 @@ use STS\Http\Controllers\Controller;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\User;
 use STS\Services\MercadoPagoOAuthService;
+use STS\Services\UserIdentityVerificationSuccessService;
 
 class MercadoPagoOAuthController extends Controller
 {
@@ -104,12 +105,7 @@ class MercadoPagoOAuthController extends Controller
                 return redirect($oauthService->getFrontendRedirectUrl($rejectReason, $details));
             }
 
-            $user->identity_validated = true;
-            $user->identity_validated_at = now();
-            $user->identity_validation_type = 'mercado_pago';
-            $user->identity_validation_rejected_at = null;
-            $user->identity_validation_reject_reason = null;
-            $user->save();
+            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'mercado_pago');
 
             return redirect($oauthService->getFrontendRedirectUrl('success'));
         } catch (\Exception $e) {

--- a/app/Services/ManualIdentityValidationDeletion.php
+++ b/app/Services/ManualIdentityValidationDeletion.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace STS\Services;
+
+use Illuminate\Support\Facades\Storage;
+use STS\Models\ManualIdentityValidation;
+
+class ManualIdentityValidationDeletion
+{
+    public static function deleteRecords(iterable $records): void
+    {
+        foreach ($records as $item) {
+            self::deleteRecord($item);
+        }
+    }
+
+    public static function deleteRecord(ManualIdentityValidation $item): void
+    {
+        foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
+            $path = $item->$column;
+            if ($path && Storage::disk('local')->exists($path)) {
+                Storage::disk('local')->delete($path);
+            }
+        }
+
+        $item->delete();
+    }
+}

--- a/app/Services/UserIdentityVerificationResetService.php
+++ b/app/Services/UserIdentityVerificationResetService.php
@@ -2,7 +2,6 @@
 
 namespace STS\Services;
 
-use Illuminate\Support\Facades\Storage;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\User;
@@ -26,17 +25,10 @@ class UserIdentityVerificationResetService
 
     private function deleteManualIdentityValidationsForUser(User $user): void
     {
-        ManualIdentityValidation::query()
+        $records = ManualIdentityValidation::query()
             ->where('user_id', $user->id)
-            ->get()
-            ->each(function (ManualIdentityValidation $item): void {
-                foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
-                    $path = $item->$column;
-                    if ($path && Storage::disk('local')->exists($path)) {
-                        Storage::disk('local')->delete($path);
-                    }
-                }
-                $item->delete();
-            });
+            ->get();
+
+        ManualIdentityValidationDeletion::deleteRecords($records);
     }
 }

--- a/app/Services/UserIdentityVerificationSuccessService.php
+++ b/app/Services/UserIdentityVerificationSuccessService.php
@@ -2,7 +2,6 @@
 
 namespace STS\Services;
 
-use Illuminate\Support\Facades\Storage;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\User;
@@ -32,18 +31,11 @@ class UserIdentityVerificationSuccessService
 
     private function deleteRejectedManualIdentityValidationsForUser(User $user): void
     {
-        ManualIdentityValidation::query()
+        $records = ManualIdentityValidation::query()
             ->where('user_id', $user->id)
             ->where('review_status', ManualIdentityValidation::REVIEW_STATUS_REJECTED)
-            ->get()
-            ->each(function (ManualIdentityValidation $item): void {
-                foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
-                    $path = $item->$column;
-                    if ($path && Storage::disk('local')->exists($path)) {
-                        Storage::disk('local')->delete($path);
-                    }
-                }
-                $item->delete();
-            });
+            ->get();
+
+        ManualIdentityValidationDeletion::deleteRecords($records);
     }
 }

--- a/app/Services/UserIdentityVerificationSuccessService.php
+++ b/app/Services/UserIdentityVerificationSuccessService.php
@@ -8,9 +8,9 @@ use STS\Models\User;
 
 class UserIdentityVerificationSuccessService
 {
-    public function applyVerification(User $user, string $validationType): void
+    public function applyVerification(User $user, string $validationType, array $options = []): void
     {
-        $this->clearPriorRejectionState($user);
+        $this->clearPriorRejectionState($user, $options);
 
         $user->identity_validated = true;
         $user->identity_validated_at = now();
@@ -20,11 +20,15 @@ class UserIdentityVerificationSuccessService
         $user->save();
     }
 
-    public function clearPriorRejectionState(User $user): void
+    public function clearPriorRejectionState(User $user, array $options = []): void
     {
-        MercadoPagoRejectedValidation::query()
-            ->where('user_id', $user->id)
-            ->delete();
+        $preserveMpRejectedIds = $options['preserve_mercado_pago_rejected_validation_ids'] ?? [];
+
+        $mpRejectedQuery = MercadoPagoRejectedValidation::query()->where('user_id', $user->id);
+        if ($preserveMpRejectedIds !== []) {
+            $mpRejectedQuery->whereNotIn('id', $preserveMpRejectedIds);
+        }
+        $mpRejectedQuery->delete();
 
         $this->deleteRejectedManualIdentityValidationsForUser($user);
     }

--- a/app/Services/UserIdentityVerificationSuccessService.php
+++ b/app/Services/UserIdentityVerificationSuccessService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace STS\Services;
+
+use Illuminate\Support\Facades\Storage;
+use STS\Models\ManualIdentityValidation;
+use STS\Models\MercadoPagoRejectedValidation;
+use STS\Models\User;
+
+class UserIdentityVerificationSuccessService
+{
+    public function applyVerification(User $user, string $validationType): void
+    {
+        $this->clearPriorRejectionState($user);
+
+        $user->identity_validated = true;
+        $user->identity_validated_at = now();
+        $user->identity_validation_type = $validationType;
+        $user->identity_validation_rejected_at = null;
+        $user->identity_validation_reject_reason = null;
+        $user->save();
+    }
+
+    public function clearPriorRejectionState(User $user): void
+    {
+        MercadoPagoRejectedValidation::query()
+            ->where('user_id', $user->id)
+            ->delete();
+
+        $this->deleteRejectedManualIdentityValidationsForUser($user);
+    }
+
+    private function deleteRejectedManualIdentityValidationsForUser(User $user): void
+    {
+        ManualIdentityValidation::query()
+            ->where('user_id', $user->id)
+            ->where('review_status', ManualIdentityValidation::REVIEW_STATUS_REJECTED)
+            ->get()
+            ->each(function (ManualIdentityValidation $item): void {
+                foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
+                    $path = $item->$column;
+                    if ($path && Storage::disk('local')->exists($path)) {
+                        Storage::disk('local')->delete($path);
+                    }
+                }
+                $item->delete();
+            });
+    }
+}

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\SupportTicket;
 use STS\Models\User;
 use STS\Notifications\ManualIdentityValidationReviewNotification;
@@ -187,6 +188,54 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $user->refresh();
         $this->assertTrue((bool) $user->identity_validated);
         $this->assertSame('manual', (string) $user->identity_validation_type);
+    }
+
+    public function test_review_approve_clears_prior_rejection_state(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create([
+            'identity_validated' => false,
+            'identity_validation_rejected_at' => now()->subDay(),
+            'identity_validation_reject_reason' => 'dni_mismatch',
+        ]);
+
+        $rejectedManual = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now()->subDays(2),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'review_note' => 'Old rejection.',
+        ]);
+
+        MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'name_mismatch',
+            'mp_payload' => ['first_name' => 'Jane'],
+        ]);
+
+        $paid = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$paid->id.'/review', [
+            'action' => 'approve',
+        ])->assertOk()->assertJsonPath('data.review_status', 'approved');
+
+        $user->refresh();
+        $this->assertTrue((bool) $user->identity_validated);
+        $this->assertNull($user->identity_validation_rejected_at);
+        $this->assertNull($user->identity_validation_reject_reason);
+        $this->assertDatabaseMissing('manual_identity_validations', ['id' => $rejectedManual->id]);
+        $this->assertDatabaseHas('manual_identity_validations', ['id' => $paid->id, 'review_status' => 'approved']);
+        $this->assertSame(0, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
     }
 
     public function test_review_reject_clears_identity_on_user_row_in_database(): void

--- a/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
+++ b/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Http;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use STS\Models\ManualIdentityValidation;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\User;
 use Tests\TestCase;
@@ -340,6 +341,52 @@ class MercadoPagoOAuthCallbackTest extends TestCase
 
         $this->assertSame(0, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
 
+    }
+
+    public function test_success_clears_prior_manual_rejection_state(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Jane Doe',
+            'nro_doc' => '30.123.456',
+            'identity_validated' => false,
+            'identity_validation_rejected_at' => now()->subDay(),
+            'identity_validation_reject_reason' => 'name_mismatch',
+        ]);
+        Cache::put('mp_oauth_state:clear-rejection-state', ['user_id' => $user->id], 600);
+
+        $rejectedManual = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'review_note' => 'Illegible documents.',
+        ]);
+
+        MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'dni_mismatch',
+            'mp_payload' => ['first_name' => 'Jane'],
+        ]);
+
+        Http::fake([
+            '*oauth/token*' => Http::response(['access_token' => 'tok'], 200),
+            '*users/me*' => Http::response([
+                'first_name' => 'Jane',
+                'last_name' => 'Doe',
+                'identification' => ['type' => 'DNI', 'number' => '30123456'],
+            ], 200),
+        ]);
+
+        $this->get('/api/mercadopago/oauth/callback?code=auth-code&state=clear-rejection-state')
+            ->assertRedirect($this->identityRedirect('success'));
+
+        $user->refresh();
+        $this->assertTrue($user->identity_validated);
+        $this->assertNull($user->identity_validation_rejected_at);
+        $this->assertNull($user->identity_validation_reject_reason);
+        $this->assertDatabaseMissing('manual_identity_validations', ['id' => $rejectedManual->id]);
+        $this->assertSame(0, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
     }
 
     public function test_resolves_user_when_cached_user_id_is_numeric_string(): void

--- a/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
+++ b/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use STS\Models\ManualIdentityValidation;
+use STS\Models\MercadoPagoRejectedValidation;
+use STS\Models\User;
+use STS\Services\UserIdentityVerificationSuccessService;
+use Tests\TestCase;
+
+class UserIdentityVerificationSuccessServiceTest extends TestCase
+{
+    public function test_apply_verification_clears_prior_rejection_state(): void
+    {
+        $user = User::factory()->create([
+            'identity_validated' => false,
+            'identity_validation_rejected_at' => now()->subDay(),
+            'identity_validation_reject_reason' => 'name_mismatch',
+        ]);
+
+        $rejectedManual = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'review_note' => 'Illegible documents.',
+        ]);
+
+        MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'dni_mismatch',
+            'mp_payload' => ['first_name' => 'Jane'],
+        ]);
+
+        app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'mercado_pago');
+
+        $fresh = $user->fresh();
+        $this->assertTrue((bool) $fresh->identity_validated);
+        $this->assertSame('mercado_pago', $fresh->identity_validation_type);
+        $this->assertNotNull($fresh->identity_validated_at);
+        $this->assertNull($fresh->identity_validation_rejected_at);
+        $this->assertNull($fresh->identity_validation_reject_reason);
+        $this->assertDatabaseMissing('manual_identity_validations', ['id' => $rejectedManual->id]);
+        $this->assertSame(0, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
+    }
+}

--- a/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
+++ b/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
@@ -44,4 +44,29 @@ class UserIdentityVerificationSuccessServiceTest extends TestCase
         $this->assertDatabaseMissing('manual_identity_validations', ['id' => $rejectedManual->id]);
         $this->assertSame(0, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
     }
+
+    public function test_apply_verification_can_preserve_mercado_pago_rejected_validation_for_audit(): void
+    {
+        $user = User::factory()->create(['identity_validated' => false]);
+
+        $preserved = MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'dni_mismatch',
+            'mp_payload' => ['first_name' => 'Jane'],
+        ]);
+
+        MercadoPagoRejectedValidation::create([
+            'user_id' => $user->id,
+            'reject_reason' => 'name_mismatch',
+            'mp_payload' => ['first_name' => 'John'],
+        ]);
+
+        app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual', [
+            'preserve_mercado_pago_rejected_validation_ids' => [$preserved->id],
+        ]);
+
+        $this->assertTrue((bool) $user->fresh()->identity_validated);
+        $this->assertDatabaseHas('mercado_pago_rejected_validations', ['id' => $preserved->id]);
+        $this->assertSame(1, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where users who were verified after a prior rejection still saw rejection state on the account verification page.

### Cause
If a user had a manual verification rejection (or MP rejection metadata), then later got approved via Mercado Pago account verification, stale rejection data remained in the database and the frontend still treated them as rejected.

### Backend
- Added `UserIdentityVerificationSuccessService` to centralize successful verification handling.
- On verification success, clears:
  - User rejection fields (`identity_validation_rejected_at`, `identity_validation_reject_reason`)
  - `mercado_pago_rejected_validations` records for the user
  - Rejected `manual_identity_validations` records (with stored images)
- Wired into:
  - Mercado Pago OAuth callback
  - Admin manual identity validation approval
  - Admin Mercado Pago rejected validation approval (preserves the row under review for audit)
- Extracted shared `ManualIdentityValidationDeletion` helper used by reset/success flows.
- Regression tests: unit + integration for OAuth and manual admin approval paths.

## Test plan
- [x] Backend unit tests (`UserIdentityVerificationSuccessServiceTest`)
- [x] Backend integration tests (MP OAuth + admin manual approval)
- [x] Frontend unit tests (`manualIdentityValidationStatus`, `identityValidationSuccessBanner`)
- [x] Full backend test suite
- [x] Frontend ESLint
- [ ] Manual: user with manual rejection → verify via Mercado Pago → verification page shows success banner, not rejection