### PR TITLE
Admin dashboard

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Api/Admin/AdminDashboardController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use STS\Http\Controllers\Controller;
+use STS\Models\ManualIdentityValidation;
+
+class AdminDashboardController extends Controller
+{
+    public function show(): JsonResponse
+    {
+        $manualIdentityValidations = ManualIdentityValidation::query()
+            ->with('user:id,name')
+            ->readyForAdminReview()
+            ->orderByRaw('COALESCE(submitted_at, paid_at, created_at) ASC')
+            ->orderBy('id')
+            ->limit(10)
+            ->get()
+            ->map(fn (ManualIdentityValidation $item) => [
+                'id' => $item->id,
+                'user_id' => $item->user_id,
+                'user_name' => $item->user?->name,
+                'submitted_at' => $item->submitted_at?->toDateTimeString(),
+                'paid_at' => $item->paid_at?->toDateTimeString(),
+            ]);
+
+        return response()->json([
+            'data' => [
+                'manual_identity_validations' => $manualIdentityValidations,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Api/Admin/AdminDashboardController.php
@@ -5,6 +5,7 @@ namespace STS\Http\Controllers\Api\Admin;
 use Illuminate\Http\JsonResponse;
 use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\SupportTicket;
 
 class AdminDashboardController extends Controller
 {
@@ -17,18 +18,51 @@ class AdminDashboardController extends Controller
             ->orderBy('id')
             ->limit(10)
             ->get()
-            ->map(fn (ManualIdentityValidation $item) => [
-                'id' => $item->id,
-                'user_id' => $item->user_id,
-                'user_name' => $item->user?->name,
-                'submitted_at' => $item->submitted_at?->toDateTimeString(),
-                'paid_at' => $item->paid_at?->toDateTimeString(),
-            ]);
+            ->map(fn (ManualIdentityValidation $item) => $this->mapManualIdentityValidation($item));
+
+        $supportTickets = SupportTicket::query()
+            ->with('user:id,name')
+            ->adminNeedsAttention()
+            ->orderBy('updated_at')
+            ->orderBy('id')
+            ->limit(10)
+            ->get()
+            ->map(fn (SupportTicket $ticket) => $this->mapSupportTicket($ticket));
 
         return response()->json([
             'data' => [
                 'manual_identity_validations' => $manualIdentityValidations,
+                'support_tickets' => $supportTickets,
             ],
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapManualIdentityValidation(ManualIdentityValidation $item): array
+    {
+        return [
+            'id' => $item->id,
+            'user_id' => $item->user_id,
+            'user_name' => $item->user?->name,
+            'submitted_at' => $item->submitted_at?->toDateTimeString(),
+            'paid_at' => $item->paid_at?->toDateTimeString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapSupportTicket(SupportTicket $ticket): array
+    {
+        return [
+            'id' => $ticket->id,
+            'user_id' => $ticket->user_id,
+            'user_name' => $ticket->user?->name,
+            'subject' => $ticket->subject,
+            'status' => $ticket->status,
+            'updated_at' => $ticket->updated_at?->toDateTimeString(),
+        ];
     }
 }

--- a/app/Http/Controllers/Api/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Api/Admin/AdminDashboardController.php
@@ -46,8 +46,11 @@ class AdminDashboardController extends Controller
             'id' => $item->id,
             'user_id' => $item->user_id,
             'user_name' => $item->user?->name,
-            'submitted_at' => $item->submitted_at?->toDateTimeString(),
             'paid_at' => $item->paid_at?->toDateTimeString(),
+            'submitted_at' => $item->submitted_at?->toDateTimeString(),
+            'manual_validation_started_at' => $item->manual_validation_started_at?->toDateTimeString(),
+            'paid' => $item->paid,
+            'review_status' => $item->review_status,
         ];
     }
 
@@ -59,10 +62,17 @@ class AdminDashboardController extends Controller
         return [
             'id' => $ticket->id,
             'user_id' => $ticket->user_id,
-            'user_name' => $ticket->user?->name,
+            'user' => $ticket->user ? [
+                'id' => $ticket->user->id,
+                'name' => $ticket->user->name,
+            ] : null,
             'subject' => $ticket->subject,
+            'type' => $ticket->type,
+            'priority' => $ticket->priority,
             'status' => $ticket->status,
+            'created_at' => $ticket->created_at?->toDateTimeString(),
             'updated_at' => $ticket->updated_at?->toDateTimeString(),
+            'unread_for_admin' => $ticket->unread_for_admin,
         ];
     }
 }

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -59,4 +59,18 @@ class ManualIdentityValidation extends Model
     {
         return ! empty($this->front_image_path) || ! empty($this->back_image_path) || ! empty($this->selfie_image_path);
     }
+
+    /**
+     * Paid requests with submitted documents awaiting admin review.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<self>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<self>
+     */
+    public function scopeReadyForAdminReview($query)
+    {
+        return $query
+            ->where('paid', true)
+            ->where('review_status', self::REVIEW_STATUS_PENDING)
+            ->whereNotNull('submitted_at');
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use STS\Http\Controllers\Api\Admin\AdminDashboardController;
 use STS\Http\Controllers\Api\Admin\BadgeController;
 use STS\Http\Controllers\Api\Admin\CampaignController;
 use STS\Http\Controllers\Api\Admin\CampaignDonationController;
@@ -240,6 +241,7 @@ Route::middleware(['api'])->group(function () {
 
     // Admin routes
     Route::prefix('admin')->middleware('user.admin')->group(function () {
+        Route::get('dashboard', [AdminDashboardController::class, 'show']);
         Route::apiResource('badges', BadgeController::class);
         // Campaign routes
         Route::apiResource('campaigns', CampaignController::class);

--- a/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
@@ -69,8 +69,11 @@ class AdminDashboardControllerIntegrationTest extends TestCase
             'id',
             'user_id',
             'user_name',
-            'submitted_at',
             'paid_at',
+            'submitted_at',
+            'manual_validation_started_at',
+            'paid',
+            'review_status',
         ], array_keys($rows[0]));
 
         $submittedAts = collect($rows)->pluck('submitted_at')->all();
@@ -131,10 +134,14 @@ class AdminDashboardControllerIntegrationTest extends TestCase
         $this->assertSame([
             'id',
             'user_id',
-            'user_name',
+            'user',
             'subject',
+            'type',
+            'priority',
             'status',
+            'created_at',
             'updated_at',
+            'unread_for_admin',
         ], array_keys($rows[0]));
 
         $updatedAts = collect($rows)->pluck('updated_at')->all();

--- a/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
@@ -143,4 +143,17 @@ class AdminDashboardControllerIntegrationTest extends TestCase
         $this->assertSame($sorted, $updatedAts);
         $this->assertSame($tickets[0]->id, $rows[0]['id']);
     }
+
+    public function test_show_returns_empty_arrays_when_nothing_needs_attention(): void
+    {
+        $admin = $this->admin();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $data = $this->getJson('api/admin/dashboard')->assertOk()->json('data');
+
+        $this->assertSame([], $data['manual_identity_validations']);
+        $this->assertSame([], $data['support_tickets']);
+    }
 }

--- a/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Carbon\Carbon;
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\ManualIdentityValidation;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminDashboardControllerIntegrationTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_show_returns_oldest_ten_manual_validations_ready_for_admin_review(): void
+    {
+        Carbon::setTestNow('2026-06-18 12:00:00');
+
+        $admin = $this->admin();
+        $users = User::factory()->count(12)->create();
+
+        foreach ($users as $index => $user) {
+            ManualIdentityValidation::create([
+                'user_id' => $user->id,
+                'paid' => true,
+                'paid_at' => Carbon::parse('2026-06-01 10:00:00')->addDays($index),
+                'submitted_at' => Carbon::parse('2026-06-02 10:00:00')->addDays($index),
+                'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+            ]);
+        }
+
+        ManualIdentityValidation::create([
+            'user_id' => User::factory()->create()->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        ManualIdentityValidation::create([
+            'user_id' => User::factory()->create()->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => null,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        ManualIdentityValidation::create([
+            'user_id' => User::factory()->create()->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/dashboard')->assertOk();
+        $rows = $response->json('data.manual_identity_validations');
+
+        $this->assertCount(10, $rows);
+        $this->assertSame([
+            'id',
+            'user_id',
+            'user_name',
+            'submitted_at',
+            'paid_at',
+        ], array_keys($rows[0]));
+
+        $submittedAts = collect($rows)->pluck('submitted_at')->all();
+        $sorted = $submittedAts;
+        sort($sorted);
+        $this->assertSame($sorted, $submittedAts);
+    }
+}

--- a/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminDashboardControllerIntegrationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Http;
 use Carbon\Carbon;
 use STS\Http\Middleware\UserAdmin;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\SupportTicket;
 use STS\Models\User;
 use Tests\TestCase;
 
@@ -76,5 +77,70 @@ class AdminDashboardControllerIntegrationTest extends TestCase
         $sorted = $submittedAts;
         sort($sorted);
         $this->assertSame($sorted, $submittedAts);
+    }
+
+    public function test_show_returns_oldest_ten_support_tickets_needing_admin_attention(): void
+    {
+        Carbon::setTestNow('2026-06-18 12:00:00');
+
+        $admin = $this->admin();
+        $owner = User::factory()->create();
+
+        $tickets = [];
+        for ($index = 0; $index < 12; $index++) {
+            $tickets[] = SupportTicket::create([
+                'user_id' => $owner->id,
+                'type' => 'feedback',
+                'subject' => 'Ticket '.$index,
+                'status' => 'Open',
+                'priority' => 'normal',
+                'unread_for_user' => 0,
+                'unread_for_admin' => 0,
+                'updated_at' => Carbon::parse('2026-06-01 10:00:00')->addDays($index),
+                'created_at' => Carbon::parse('2026-06-01 10:00:00')->addDays($index),
+            ]);
+        }
+
+        SupportTicket::create([
+            'user_id' => $owner->id,
+            'type' => 'feedback',
+            'subject' => 'Resolved ticket',
+            'status' => 'Resuelto',
+            'priority' => 'normal',
+            'unread_for_user' => 0,
+            'unread_for_admin' => 1,
+        ]);
+
+        SupportTicket::create([
+            'user_id' => $owner->id,
+            'type' => 'feedback',
+            'subject' => 'Waiting on user',
+            'status' => 'Esperando respuesta',
+            'priority' => 'normal',
+            'unread_for_user' => 0,
+            'unread_for_admin' => 0,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/dashboard')->assertOk();
+        $rows = $response->json('data.support_tickets');
+
+        $this->assertCount(10, $rows);
+        $this->assertSame([
+            'id',
+            'user_id',
+            'user_name',
+            'subject',
+            'status',
+            'updated_at',
+        ], array_keys($rows[0]));
+
+        $updatedAts = collect($rows)->pluck('updated_at')->all();
+        $sorted = $updatedAts;
+        sort($sorted);
+        $this->assertSame($sorted, $updatedAts);
+        $this->assertSame($tickets[0]->id, $rows[0]['id']);
     }
 }

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -169,4 +169,42 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertNotNull($row->reviewed_at);
         $this->assertNotNull($row->manual_validation_started_at);
     }
+
+    public function test_ready_for_admin_review_scope_includes_only_paid_pending_submitted_rows(): void
+    {
+        $user = User::factory()->create();
+
+        $ready = $this->makeRow($user, [
+            'paid' => true,
+            'paid_at' => '2026-06-01 10:00:00',
+            'submitted_at' => '2026-06-02 10:00:00',
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $unpaid = $this->makeRow($user, [
+            'paid' => false,
+            'submitted_at' => '2026-06-02 10:00:00',
+        ]);
+        $missingDocs = $this->makeRow($user, [
+            'paid' => true,
+            'paid_at' => '2026-06-01 10:00:00',
+            'submitted_at' => null,
+        ]);
+        $resolved = $this->makeRow($user, [
+            'paid' => true,
+            'paid_at' => '2026-06-01 10:00:00',
+            'submitted_at' => '2026-06-02 10:00:00',
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+        ]);
+
+        $ids = ManualIdentityValidation::query()
+            ->readyForAdminReview()
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertSame([$ready->id], $ids);
+        $this->assertNotContains($unpaid->id, $ids);
+        $this->assertNotContains($missingDocs->id, $ids);
+        $this->assertNotContains($resolved->id, $ids);
+    }
 }


### PR DESCRIPTION
## Summary

Adds an admin **Tablero** dashboard as the default admin landing page (`/admin`), surfacing the two highest-priority admin action queues: pending manual identity verifications and support tickets needing attention.

### Backend (`carpoolear_backend`)

**Cause:** Admins had no single entry point for pending work — they had to navigate to separate list pages to discover what needed action.

**Fix:**
- New `GET /api/admin/dashboard` endpoint returning up to 10 items per queue:
  - **Manual verifications:** `paid` + `pending` + `submitted_at` set, ordered oldest wait first (`readyForAdminReview` scope)
  - **Support tickets:** `adminNeedsAttention()` scope, ordered by `updated_at` ASC (longest wait first)
- Added `ManualIdentityValidation::scopeReadyForAdminReview()` for reusable filtering

**TDD commits:** failing integration test → endpoint implementation → scope unit test → support tickets test/implement → empty-state test

## Test plan

- [ ] Log in as admin → `/admin` shows Tablero with both cards
- [ ] Manual verification rows link to individual review pages
- [ ] "Ver más" on verifications card goes to `/admin/manual-identity-validations`
- [ ] Support ticket rows link to ticket detail
- [ ] "Ver más" on tickets card goes to `/admin/support-tickets?needs_reply=1`
- [ ] Nav "Gráficos" still opens charts at `/admin/graficos`
- [ ] Empty states show when no pending items exist