### PR TITLE
Fix QR payment

### DIFF
--- a/app/Services/MercadoPagoService.php
+++ b/app/Services/MercadoPagoService.php
@@ -33,7 +33,14 @@ class MercadoPagoService
         }
         MercadoPagoConfig::setAccessToken($this->accessToken);
         $this->client = new PreferenceClient;
-        $this->orderClient = new OrderClient;
+        $this->ensureOrderClient();
+    }
+
+    private function ensureOrderClient(): void
+    {
+        if ($this->orderClient === null) {
+            $this->orderClient = new OrderClient;
+        }
     }
 
     /**
@@ -304,9 +311,7 @@ class MercadoPagoService
             'x-idempotency-key' => 'manual_qr_'.$requestId.'_'.uniqid('', true),
         ]);
 
-        if ($this->orderClient === null) {
-            $this->orderClient = new OrderClient;
-        }
+        $this->ensureOrderClient();
 
         try {
             $order = $this->orderClient->create($orderPayload, $requestOptions);

--- a/app/Services/MercadoPagoService.php
+++ b/app/Services/MercadoPagoService.php
@@ -304,6 +304,10 @@ class MercadoPagoService
             'x-idempotency-key' => 'manual_qr_'.$requestId.'_'.uniqid('', true),
         ]);
 
+        if ($this->orderClient === null) {
+            $this->orderClient = new OrderClient;
+        }
+
         try {
             $order = $this->orderClient->create($orderPayload, $requestOptions);
         } catch (MPApiException $e) {

--- a/tests/Unit/Services/MercadoPagoServiceTest.php
+++ b/tests/Unit/Services/MercadoPagoServiceTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Unit\Services;
 
 use InvalidArgumentException;
+use MercadoPago\Client\Common\RequestOptions;
+use MercadoPago\Net\MPResponse;
+use MercadoPago\Resources\Order;
 use MercadoPago\Resources\Preference;
 use ReflectionProperty;
 use STS\Models\Campaign;
@@ -107,6 +110,39 @@ class MercadoPagoServiceTest extends TestCase
         }
 
         $this->assertNotNull($orderClientRef->getValue($service));
+    }
+
+    public function test_create_qr_order_for_manual_validation_returns_qr_data_from_order_client(): void
+    {
+        config([
+            'services.mercadopago.qr_payment_access_token' => 'qr-token',
+            'carpoolear.qr_payment_pos_external_id' => 'POS-1',
+        ]);
+
+        $service = new MercadoPagoService;
+        $orderClientRef = new ReflectionProperty(MercadoPagoService::class, 'orderClient');
+        $orderClientRef->setAccessible(true);
+        $orderClientRef->setValue($service, new class
+        {
+            public function create(array $request, ?RequestOptions $requestOptions = null): Order
+            {
+                $order = new Order;
+                $order->id = 'ORD-123';
+                $order->transactions = (object) ['payments' => [(object) ['id' => 'PAY-456']]];
+                $order->setResponse(new MPResponse(200, [
+                    'type_response' => ['qr_data' => 'EMV_QR_DATA'],
+                ]));
+
+                return $order;
+            }
+        });
+
+        $result = $service->createQrOrderForManualValidation(42, 1500);
+
+        $this->assertSame(42, $result['request_id']);
+        $this->assertSame('ORD-123', $result['order_id']);
+        $this->assertSame('EMV_QR_DATA', $result['qr_data']);
+        $this->assertSame('PAY-456', $result['payment_id']);
     }
 
     public function test_sellado_trims_trailing_slash_on_frontend_url_for_back_urls(): void

--- a/tests/Unit/Services/MercadoPagoServiceTest.php
+++ b/tests/Unit/Services/MercadoPagoServiceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Services;
 
 use InvalidArgumentException;
 use MercadoPago\Resources\Preference;
+use ReflectionProperty;
 use STS\Models\Campaign;
 use STS\Models\Trip;
 use STS\Services\MercadoPagoService;
@@ -83,6 +84,29 @@ class MercadoPagoServiceTest extends TestCase
         $this->expectExceptionMessage('Mercado Pago QR orders require amount >= 15.00');
 
         $service->createQrOrderForManualValidation(10, 1400);
+    }
+
+    public function test_create_qr_order_for_manual_validation_initializes_order_client_before_api_call(): void
+    {
+        config([
+            'services.mercadopago.qr_payment_access_token' => 'qr-token',
+            'carpoolear.qr_payment_pos_external_id' => 'POS-1',
+        ]);
+
+        $service = new MercadoPagoService;
+        $orderClientRef = new ReflectionProperty(MercadoPagoService::class, 'orderClient');
+        $orderClientRef->setAccessible(true);
+        $this->assertNull($orderClientRef->getValue($service));
+
+        try {
+            $service->createQrOrderForManualValidation(42, 1500);
+        } catch (\Error $e) {
+            $this->fail('OrderClient was not initialized: '.$e->getMessage());
+        } catch (\Throwable $e) {
+            // Mercado Pago API errors are acceptable once OrderClient exists.
+        }
+
+        $this->assertNotNull($orderClientRef->getValue($service));
     }
 
     public function test_sellado_trims_trailing_slash_on_frontend_url_for_back_urls(): void


### PR DESCRIPTION
## Summary
Fixes a production crash when creating a Mercado Pago QR order for manual identity validation (`POST /api/users/manual-identity-validation/qr-order`).
## Cause
`MercadoPagoService::createQrOrderForManualValidation()` called `$this->orderClient->create()` without ever initializing `$this->orderClient`. The property was only set inside `ensureConfigured()`, which is used by preference-based flows but not by the QR order flow.
Production error:
Call to a member function create() on null at MercadoPagoService.php:308

## Fix (backend)

- Lazily initialize `OrderClient` before creating a QR order via new `ensureOrderClient()` helper.
- Reuse the same helper from `ensureConfigured()` for preference flows.
- Add unit tests to:
  - Assert `OrderClient` is initialized before the MP API call.
  - Assert `order_id`, `qr_data`, and `payment_id` are parsed from the order response.

## Test plan

- [x] `php artisan test --filter=MercadoPagoServiceTest`
- [x] Full backend suite (`3226` tests passing)
- [x] Frontend lint (`npm run lint`)
- [ ] Manual: `POST /api/users/manual-identity-validation/qr-order` returns `request_id`, `qr_data`, and `order_id` in production/staging