### PR TITLE
Manual verification changes

### DIFF
--- a/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
@@ -11,6 +11,7 @@ use STS\Http\ExceptionWithErrors;
 use STS\Models\ManualIdentityValidation;
 use STS\Services\HeicToJpegConverter;
 use STS\Services\ImageUploadValidator;
+use STS\Services\ManualIdentityValidationResubmitPolicy;
 use STS\Services\MercadoPagoService;
 use STS\Support\ImageAttachmentRules;
 
@@ -40,51 +41,23 @@ class ManualIdentityValidationController extends Controller
     /**
      * GET /api/users/manual-identity-validation - current user's latest submission status
      */
-    public function status()
+    public function status(ManualIdentityValidationResubmitPolicy $resubmitPolicy)
     {
         if (! config('carpoolear.identity_validation_enabled', false)) {
-            return response()->json([
-                'has_submission' => false,
-                'request_id' => null,
-                'paid' => null,
-                'paid_at' => null,
-                'review_status' => null,
-                'submitted_at' => null,
-                'review_note' => null,
-            ]);
+            return response()->json($resubmitPolicy->statusPayload(null));
         }
         $user = auth()->user();
         $latest = ManualIdentityValidation::where('user_id', $user->id)
             ->orderBy('created_at', 'desc')
             ->first();
 
-        if (! $latest) {
-            return response()->json([
-                'has_submission' => false,
-                'request_id' => null,
-                'paid' => null,
-                'paid_at' => null,
-                'review_status' => null,
-                'submitted_at' => null,
-                'review_note' => null,
-            ]);
-        }
-
-        return response()->json([
-            'has_submission' => true,
-            'request_id' => $latest->id,
-            'paid' => $latest->paid,
-            'paid_at' => $latest->paid_at ? $latest->paid_at->toDateTimeString() : null,
-            'review_status' => $latest->review_status,
-            'submitted_at' => $latest->submitted_at ? $latest->submitted_at->toDateTimeString() : null,
-            'review_note' => $latest->review_note,
-        ]);
+        return response()->json($resubmitPolicy->statusPayload($latest));
     }
 
     /**
      * POST /api/users/manual-identity-validation/preference - create MP payment preference and request record
      */
-    public function createPreference(Request $request, MercadoPagoService $mpService)
+    public function createPreference(Request $request, MercadoPagoService $mpService, ManualIdentityValidationResubmitPolicy $resubmitPolicy)
     {
         $user = auth()->user();
         if (! config('carpoolear.identity_validation_enabled', false)) {
@@ -96,6 +69,13 @@ class ManualIdentityValidationController extends Controller
         $costCents = config('carpoolear.manual_identity_validation_cost_cents', 0);
         if ($costCents <= 0) {
             throw new ExceptionWithErrors('Manual identity validation is not available.', []);
+        }
+
+        $latest = ManualIdentityValidation::where('user_id', $user->id)
+            ->orderBy('created_at', 'desc')
+            ->first();
+        if ($latest && $resubmitPolicy->canResubmitWithoutPayment($latest)) {
+            throw new ExceptionWithErrors('You can resubmit your documents without paying again.', []);
         }
 
         // Reuse existing unpaid request so user can complete payment
@@ -140,7 +120,7 @@ class ManualIdentityValidationController extends Controller
      * Returns request_id, qr_data (string to render as QR), order_id. Frontend displays QR; user scans with MP app.
      * Payment confirmation is via webhook; frontend can poll status until paid.
      */
-    public function createQrOrder(Request $request, MercadoPagoService $mpService)
+    public function createQrOrder(Request $request, MercadoPagoService $mpService, ManualIdentityValidationResubmitPolicy $resubmitPolicy)
     {
         $user = auth()->user();
         if (! config('carpoolear.identity_validation_enabled', false)) {
@@ -159,6 +139,13 @@ class ManualIdentityValidationController extends Controller
         $costCents = config('carpoolear.manual_identity_validation_cost_cents', 0);
         if ($costCents <= 0) {
             throw new ExceptionWithErrors('Manual identity validation is not available.', []);
+        }
+
+        $latest = ManualIdentityValidation::where('user_id', $user->id)
+            ->orderBy('created_at', 'desc')
+            ->first();
+        if ($latest && $resubmitPolicy->canResubmitWithoutPayment($latest)) {
+            throw new ExceptionWithErrors('You can resubmit your documents without paying again.', []);
         }
 
         $validationRequest = ManualIdentityValidation::where('user_id', $user->id)
@@ -200,7 +187,7 @@ class ManualIdentityValidationController extends Controller
     /**
      * POST /api/users/manual-identity-validation - submit 3 images (request_id + front, back, selfie)
      */
-    public function submit(Request $request)
+    public function submit(Request $request, ManualIdentityValidationResubmitPolicy $resubmitPolicy)
     {
         $user = auth()->user();
         $requestId = $request->input('request_id');
@@ -222,6 +209,15 @@ class ManualIdentityValidationController extends Controller
 
         if (! $validationRequest->paid) {
             throw new ExceptionWithErrors('Payment is required before submitting images.', [], 422);
+        }
+
+        $isResubmit = $validationRequest->review_status === ManualIdentityValidation::REVIEW_STATUS_REJECTED;
+        if ($isResubmit) {
+            if (! $resubmitPolicy->canResubmitWithoutPayment($validationRequest)) {
+                throw new ExceptionWithErrors('Submission limit reached. Payment is required to try again.', [], 422);
+            }
+        } elseif ($validationRequest->submitted_at !== null) {
+            throw new ExceptionWithErrors('Documents were already submitted for this request.', [], 422);
         }
 
         $front = $request->file('front_image');
@@ -272,6 +268,11 @@ class ManualIdentityValidationController extends Controller
         $validationRequest->selfie_image_path = $selfiePath;
         $validationRequest->submitted_at = now();
         $validationRequest->images_purged_at = null;
+        $validationRequest->submission_count = (int) $validationRequest->submission_count + 1;
+        $validationRequest->review_status = ManualIdentityValidation::REVIEW_STATUS_PENDING;
+        $validationRequest->reviewed_by = null;
+        $validationRequest->reviewed_at = null;
+        $validationRequest->review_note = '';
         $validationRequest->save();
 
         return response()->json([

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -18,6 +18,7 @@ class ManualIdentityValidation extends Model
     protected $fillable = [
         'user_id',
         'submitted_at',
+        'submission_count',
         'front_image_path',
         'back_image_path',
         'selfie_image_path',
@@ -37,6 +38,7 @@ class ManualIdentityValidation extends Model
     {
         return [
             'paid' => 'boolean',
+            'submission_count' => 'integer',
             'submitted_at' => 'datetime',
             'paid_at' => 'datetime',
             'reviewed_at' => 'datetime',

--- a/app/Services/ManualIdentityValidationResubmitPolicy.php
+++ b/app/Services/ManualIdentityValidationResubmitPolicy.php
@@ -33,4 +33,40 @@ class ManualIdentityValidationResubmitPolicy
         return $latest->review_status === ManualIdentityValidation::REVIEW_STATUS_REJECTED
             && (int) ($latest->submission_count ?? 0) >= $this->maxSubmissions();
     }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function statusPayload(?ManualIdentityValidation $latest): array
+    {
+        $maxSubmissions = $this->maxSubmissions();
+
+        if (! $latest) {
+            return [
+                'has_submission' => false,
+                'request_id' => null,
+                'paid' => null,
+                'paid_at' => null,
+                'review_status' => null,
+                'submitted_at' => null,
+                'review_note' => null,
+                'submission_count' => null,
+                'max_submissions' => $maxSubmissions,
+                'can_resubmit_without_payment' => false,
+            ];
+        }
+
+        return [
+            'has_submission' => true,
+            'request_id' => $latest->id,
+            'paid' => $latest->paid,
+            'paid_at' => $latest->paid_at ? $latest->paid_at->toDateTimeString() : null,
+            'review_status' => $latest->review_status,
+            'submitted_at' => $latest->submitted_at ? $latest->submitted_at->toDateTimeString() : null,
+            'review_note' => $latest->review_note,
+            'submission_count' => (int) $latest->submission_count,
+            'max_submissions' => $maxSubmissions,
+            'can_resubmit_without_payment' => $this->canResubmitWithoutPayment($latest),
+        ];
+    }
 }

--- a/app/Services/ManualIdentityValidationResubmitPolicy.php
+++ b/app/Services/ManualIdentityValidationResubmitPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\ManualIdentityValidation;
+
+class ManualIdentityValidationResubmitPolicy
+{
+    public function maxSubmissions(): int
+    {
+        return (int) config('carpoolear.manual_identity_validation_max_submissions', 3);
+    }
+
+    public function canResubmitWithoutPayment(ManualIdentityValidation $row): bool
+    {
+        if (! $row->paid) {
+            return false;
+        }
+
+        if ($row->review_status !== ManualIdentityValidation::REVIEW_STATUS_REJECTED) {
+            return false;
+        }
+
+        return (int) ($row->submission_count ?? 0) < $this->maxSubmissions();
+    }
+
+    public function requiresNewPayment(?ManualIdentityValidation $latest): bool
+    {
+        if (! $latest || ! $latest->paid) {
+            return false;
+        }
+
+        return $latest->review_status === ManualIdentityValidation::REVIEW_STATUS_REJECTED
+            && (int) ($latest->submission_count ?? 0) >= $this->maxSubmissions();
+    }
+}

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -45,6 +45,8 @@ return [
     'module_max_price_kilometer_by_liter' => (float) env('MODULE_MAX_PRICE_KILOMETER_BY_LITER', 10),
 
     'manual_identity_validation_cost_cents' => (int) env('MANUAL_IDENTITY_VALIDATION_COST_CENTS', 0),
+    // Max document submissions per paid manual validation request (including the first upload).
+    'manual_identity_validation_max_submissions' => (int) env('MANUAL_IDENTITY_VALIDATION_MAX_SUBMISSIONS', 3),
 
     // Master switch: when false, hide identity validation UI and do not enforce (except admin flows).
     'identity_validation_enabled' => filter_var(env('IDENTITY_VALIDATION_ENABLED', false), FILTER_VALIDATE_BOOLEAN),

--- a/database/migrations/2026_06_19_120000_add_submission_count_to_manual_identity_validations.php
+++ b/database/migrations/2026_06_19_120000_add_submission_count_to_manual_identity_validations.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->unsignedTinyInteger('submission_count')->default(0)->after('submitted_at');
+        });
+
+        DB::table('manual_identity_validations')
+            ->whereNotNull('submitted_at')
+            ->update(['submission_count' => 1]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->dropColumn('submission_count');
+        });
+    }
+};

--- a/tests/Feature/Http/ManualIdentityValidationApiTest.php
+++ b/tests/Feature/Http/ManualIdentityValidationApiTest.php
@@ -30,6 +30,7 @@ class ManualIdentityValidationApiTest extends TestCase
         config([
             'carpoolear.identity_validation_enabled' => true,
             'carpoolear.identity_validation_manual_enabled' => true,
+            'carpoolear.manual_identity_validation_max_submissions' => 3,
         ]);
     }
 
@@ -72,6 +73,9 @@ class ManualIdentityValidationApiTest extends TestCase
             'review_status' => null,
             'submitted_at' => null,
             'review_note' => null,
+            'submission_count' => null,
+            'max_submissions' => 3,
+            'can_resubmit_without_payment' => false,
         ];
     }
 
@@ -90,6 +94,11 @@ class ManualIdentityValidationApiTest extends TestCase
             'review_status' => $latest->review_status,
             'submitted_at' => $latest->submitted_at?->toDateTimeString(),
             'review_note' => $latest->review_note,
+            'submission_count' => (int) $latest->submission_count,
+            'max_submissions' => 3,
+            'can_resubmit_without_payment' => $latest->paid
+                && $latest->review_status === ManualIdentityValidation::REVIEW_STATUS_REJECTED
+                && (int) $latest->submission_count < 3,
         ];
     }
 
@@ -1440,5 +1449,120 @@ class ManualIdentityValidationApiTest extends TestCase
             ->assertJsonPath('errors.back_image', ['Invalid image type.']);
 
         $this->assertNull($validationRequest->fresh()->submitted_at);
+    }
+
+    public function test_status_reports_can_resubmit_without_payment_for_rejected_request_with_attempts_left(): void
+    {
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submitted_at' => now()->subDay(),
+            'submission_count' => 1,
+            'review_note' => 'Unreadable photo',
+        ]);
+
+        $this->actingAs($user, 'api')
+            ->getJson('api/users/manual-identity-validation')
+            ->assertOk()
+            ->assertExactJson($this->expectedPopulatedStatusPayload($row));
+    }
+
+    public function test_submit_on_rejected_request_resets_review_and_increments_submission_count(): void
+    {
+        $user = User::factory()->create();
+        $validationRequest = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submitted_at' => now()->subDay(),
+            'submission_count' => 1,
+            'review_note' => 'Try again',
+            'reviewed_by' => User::factory()->create()->id,
+            'reviewed_at' => now()->subHours(2),
+        ]);
+
+        $front = UploadedFile::fake()->image('front.jpg', 100, 100)->size(500);
+        $back = UploadedFile::fake()->image('back.jpg', 100, 100)->size(500);
+        $selfie = UploadedFile::fake()->image('selfie.jpg', 100, 100)->size(500);
+
+        $this->actingAs($user, 'api')->post('api/users/manual-identity-validation', [
+            'request_id' => $validationRequest->id,
+            'front_image' => $front,
+            'back_image' => $back,
+            'selfie_image' => $selfie,
+        ])->assertStatus(201);
+
+        $validationRequest->refresh();
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $validationRequest->review_status);
+        $this->assertSame(2, $validationRequest->submission_count);
+        $this->assertNull($validationRequest->reviewed_at);
+        $this->assertNull($validationRequest->reviewed_by);
+        $this->assertSame('', $validationRequest->review_note);
+        $this->assertNotNull($validationRequest->submitted_at);
+    }
+
+    public function test_submit_on_rejected_request_returns_422_when_submission_limit_reached(): void
+    {
+        $user = User::factory()->create();
+        $validationRequest = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submitted_at' => now()->subDay(),
+            'submission_count' => 3,
+        ]);
+
+        $front = UploadedFile::fake()->image('front.jpg', 100, 100)->size(500);
+        $back = UploadedFile::fake()->image('back.jpg', 100, 100)->size(500);
+        $selfie = UploadedFile::fake()->image('selfie.jpg', 100, 100)->size(500);
+
+        $this->actingAs($user, 'api')->post('api/users/manual-identity-validation', [
+            'request_id' => $validationRequest->id,
+            'front_image' => $front,
+            'back_image' => $back,
+            'selfie_image' => $selfie,
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'Submission limit reached. Payment is required to try again.');
+    }
+
+    public function test_preference_creates_new_row_when_latest_rejected_and_submissions_exhausted(): void
+    {
+        config([
+            'carpoolear.manual_identity_validation_cost_cents' => 500,
+        ]);
+
+        $user = User::factory()->create();
+        ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submitted_at' => now()->subDay(),
+            'submission_count' => 3,
+        ]);
+
+        $this->mock(MercadoPagoService::class, function ($mock) {
+            $preference = new Preference;
+            $preference->init_point = 'https://checkout.example/retry-pay';
+            $preference->sandbox_init_point = null;
+
+            $mock->shouldReceive('createPaymentPreferenceForManualValidation')
+                ->once()
+                ->andReturn($preference);
+        });
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('api/users/manual-identity-validation/preference');
+
+        $this->assertSame(2, ManualIdentityValidation::where('user_id', $user->id)->count());
+        $newRow = ManualIdentityValidation::where('user_id', $user->id)->where('paid', false)->first();
+        $this->assertNotNull($newRow);
+        $response->assertOk()->assertJsonPath('request_id', $newRow->id);
     }
 }

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -119,6 +119,7 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertSame([
             'user_id',
             'submitted_at',
+            'submission_count',
             'front_image_path',
             'back_image_path',
             'selfie_image_path',

--- a/tests/Unit/Services/ManualIdentityValidationResubmitPolicyTest.php
+++ b/tests/Unit/Services/ManualIdentityValidationResubmitPolicyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use STS\Models\ManualIdentityValidation;
+use STS\Services\ManualIdentityValidationResubmitPolicy;
+use Tests\TestCase;
+
+class ManualIdentityValidationResubmitPolicyTest extends TestCase
+{
+    private ManualIdentityValidationResubmitPolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['carpoolear.manual_identity_validation_max_submissions' => 3]);
+        $this->policy = new ManualIdentityValidationResubmitPolicy;
+    }
+
+    public function test_max_submissions_reads_config_defaulting_to_three(): void
+    {
+        config(['carpoolear.manual_identity_validation_max_submissions' => 5]);
+
+        $this->assertSame(5, $this->policy->maxSubmissions());
+    }
+
+    public function test_can_resubmit_when_paid_rejected_and_under_max_submissions(): void
+    {
+        $row = new ManualIdentityValidation([
+            'paid' => true,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submission_count' => 1,
+        ]);
+
+        $this->assertTrue($this->policy->canResubmitWithoutPayment($row));
+    }
+
+    public function test_cannot_resubmit_when_submission_count_reached_max(): void
+    {
+        $row = new ManualIdentityValidation([
+            'paid' => true,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submission_count' => 3,
+        ]);
+
+        $this->assertFalse($this->policy->canResubmitWithoutPayment($row));
+    }
+
+    public function test_cannot_resubmit_when_review_is_not_rejected(): void
+    {
+        $row = new ManualIdentityValidation([
+            'paid' => true,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+            'submission_count' => 1,
+        ]);
+
+        $this->assertFalse($this->policy->canResubmitWithoutPayment($row));
+    }
+
+    public function test_requires_new_payment_when_latest_rejected_submissions_exhausted(): void
+    {
+        $row = new ManualIdentityValidation([
+            'paid' => true,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submission_count' => 3,
+        ]);
+
+        $this->assertTrue($this->policy->requiresNewPayment($row));
+    }
+
+    public function test_does_not_require_new_payment_when_rejected_but_resubmits_remain(): void
+    {
+        $row = new ManualIdentityValidation([
+            'paid' => true,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'submission_count' => 2,
+        ]);
+
+        $this->assertFalse($this->policy->requiresNewPayment($row));
+    }
+}


### PR DESCRIPTION
## Summary

Users who paid for manual identity verification and had their submission rejected can now resubmit documents without paying again, up to a configurable limit (default: 3 submissions per payment). After exhausting attempts, they can start a new paid manual verification flow.

## Cause

- Rejected manual verifications left users stuck: they had already paid but could not re-upload documents without paying again.
- The rejection card linked to Mesa de ayuda instead of the upload flow.
- After 3 rejections, visiting `/setting/identity-validation/manual` still showed “Documentación enviada” because `submitted_at` was set, blocking the payment restart screen.

## Frontend (`carpoolear`)

**Changes**
- Rejection card: when resubmit is allowed, show **“Click acá para subir los documentos nuevamente”** linking to the manual upload screen (replaces Mesa de ayuda link).
- `ManualIdentityValidation`: detect `can_resubmit_without_payment` from the status API and show the upload form without requiring a new payment.
- After exhausted rejections: show the payment screen again instead of “Documentación enviada”.
- Support `?restart=1` when restarting from the rejection choice card; manual verification button navigates with this param when payment is required again.

## Test plan

- [ ] Reject a paid manual submission → rejection card shows resubmit link (not Mesa de ayuda).
- [ ] Click resubmit link → lands on upload screen without payment.
- [ ] Resubmit documents → status returns to pending review.
- [ ] Repeat until 3 total submissions → resubmit link disappears; manual verification requires payment again.
- [ ] After 3 rejections, open `/setting/identity-validation/manual` → payment screen is shown (not “Documentación enviada”).
- [ ] Click “Solicitar verificación manual” after exhausted rejections → opens with `?restart=1` and payment flow works.
- [ ] Change `MANUAL_IDENTITY_VALIDATION_MAX_SUBMISSIONS` in backend config and verify the limit is respected.