### PR TITLE
Avoid emtpy ticket

### DIFF
--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -55,11 +55,7 @@ class SupportTicketController extends Controller
                 'required',
                 'string',
                 'min:1',
-                function (string $attribute, mixed $value, \Closure $fail): void {
-                    if (! SupportTicketMessage::hasUserContent((string) $value)) {
-                        $fail('The message markdown field is required.');
-                    }
-                },
+                SupportTicketMessage::userContentValidationRule(),
             ],
             'attachments' => 'nullable|array|max:3',
             'attachments.*' => ImageAttachmentRules::FILE,

--- a/app/Http/Controllers/Api/v1/SupportTicketController.php
+++ b/app/Http/Controllers/Api/v1/SupportTicketController.php
@@ -13,6 +13,7 @@ use STS\Models\User;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
 use STS\Support\ImageAttachmentRules;
+use STS\Support\SupportTicketMessage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SupportTicketController extends Controller
@@ -50,7 +51,16 @@ class SupportTicketController extends Controller
         $validated = $request->validate([
             'type' => SupportTicket::typeValidationRule(),
             'subject' => 'required|string|min:3|max:160',
-            'message_markdown' => 'required|string|min:1',
+            'message_markdown' => [
+                'required',
+                'string',
+                'min:1',
+                function (string $attribute, mixed $value, \Closure $fail): void {
+                    if (! SupportTicketMessage::hasUserContent((string) $value)) {
+                        $fail('The message markdown field is required.');
+                    }
+                },
+            ],
             'attachments' => 'nullable|array|max:3',
             'attachments.*' => ImageAttachmentRules::FILE,
         ]);

--- a/app/Support/SupportTicketMessage.php
+++ b/app/Support/SupportTicketMessage.php
@@ -20,4 +20,13 @@ final class SupportTicketMessage
     {
         return self::stripSupportInfo($message) !== '';
     }
+
+    public static function userContentValidationRule(): \Closure
+    {
+        return function (string $attribute, mixed $value, \Closure $fail): void {
+            if (! self::hasUserContent((string) $value)) {
+                $fail('The message markdown field is required.');
+            }
+        };
+    }
 }

--- a/app/Support/SupportTicketMessage.php
+++ b/app/Support/SupportTicketMessage.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace STS\Support;
+
+final class SupportTicketMessage
+{
+    public const SUPPORT_INFO_SECTION_HEADER = '--- Información del dispositivo ---';
+
+    public static function stripSupportInfo(string $message): string
+    {
+        $headerIndex = strpos($message, self::SUPPORT_INFO_SECTION_HEADER);
+        if ($headerIndex === false) {
+            return trim($message);
+        }
+
+        return trim(substr($message, 0, $headerIndex));
+    }
+
+    public static function hasUserContent(string $message): bool
+    {
+        return self::stripSupportInfo($message) !== '';
+    }
+}

--- a/tests/Feature/Http/SupportTicketApiTest.php
+++ b/tests/Feature/Http/SupportTicketApiTest.php
@@ -409,6 +409,22 @@ class SupportTicketApiTest extends TestCase
         ])->assertStatus(422);
     }
 
+    public function test_create_rejects_message_markdown_that_contains_only_support_info(): void
+    {
+        $user = $this->createUser();
+        $this->actingAs($user, 'api');
+
+        $this->postJson('api/support/tickets', [
+            'type' => 'contact',
+            'subject' => 'Device info only',
+            'message_markdown' => "--- Información del dispositivo ---\nApp Version: 120\nPlatform: web",
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['message_markdown']);
+
+        $this->assertSame(0, SupportTicket::query()->count());
+    }
+
     public function test_create_returns_existing_ticket_when_subject_and_opening_message_duplicate(): void
     {
         $user = $this->createUser();

--- a/tests/Unit/Support/SupportTicketMessageTest.php
+++ b/tests/Unit/Support/SupportTicketMessageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use STS\Support\SupportTicketMessage;
+use Tests\TestCase;
+
+class SupportTicketMessageTest extends TestCase
+{
+    public function test_strip_support_info_returns_user_content_before_device_section(): void
+    {
+        $message = "Need help with login\n\n".SupportTicketMessage::SUPPORT_INFO_SECTION_HEADER."\nApp Version: 120";
+
+        $this->assertSame('Need help with login', SupportTicketMessage::stripSupportInfo($message));
+    }
+
+    public function test_strip_support_info_returns_empty_string_when_only_device_section_is_present(): void
+    {
+        $message = SupportTicketMessage::SUPPORT_INFO_SECTION_HEADER."\nApp Version: 120\nPlatform: web";
+
+        $this->assertSame('', SupportTicketMessage::stripSupportInfo($message));
+    }
+
+    public function test_has_user_content_rejects_support_info_only_messages(): void
+    {
+        $message = SupportTicketMessage::SUPPORT_INFO_SECTION_HEADER."\nApp Version: 120";
+
+        $this->assertFalse(SupportTicketMessage::hasUserContent($message));
+    }
+
+    public function test_has_user_content_accepts_messages_with_user_text(): void
+    {
+        $message = "Need help\n\n".SupportTicketMessage::SUPPORT_INFO_SECTION_HEADER."\nApp Version: 120";
+
+        $this->assertTrue(SupportTicketMessage::hasUserContent($message));
+    }
+}


### PR DESCRIPTION
## Summary

Prevent users from submitting support tickets without a real message. After device info started being appended automatically, an empty editor still produced a non-empty payload, so tickets could be created with only metadata. This branch adds frontend validation with clearer UX and backend validation as a safety net.

## Cause

When creating a ticket, the frontend appends a device info block via `appendSupportInfoToMessage()`. If the user leaves the message empty, the API still receives a non-empty `message_markdown` (only `--- Información del dispositivo ---` and metadata), which passed existing `required|min:1` validation.

## Fix

### Backend
- Added `SupportTicketMessage` helper to strip the device info section and verify user-provided content.
- `SupportTicketController::create` rejects `message_markdown` values that contain only the device info block (422 validation error).
- Unit and API integration tests cover support-info-only rejection.

## Test plan

- [ ] Try creating a ticket with an empty message → should show the specific error toast, no ticket created
- [ ] Confirm the message editor shows the detailed placeholder text
- [ ] Create a ticket with a real message → should succeed and still include device info
- [ ] Direct API call with only device info block → should return 422
- [ ] Existing ticket creation/reply flows still work