### PR TITLE
Notifications improvements

### DIFF
--- a/app/Repository/NotificationRepository.php
+++ b/app/Repository/NotificationRepository.php
@@ -3,6 +3,7 @@
 namespace STS\Repository;
 
 use Carbon\Carbon;
+use STS\Support\NotificationCountCache;
 
 class NotificationRepository
 {
@@ -30,6 +31,7 @@ class NotificationRepository
         if ($notification) {
             $notification->read_at = Carbon::now();
             $notification->save();
+            NotificationCountCache::forget($notification->user_id);
         } else {
             $user->unreadNotifications()->update(['read_at' => Carbon::now()]);
         }
@@ -39,6 +41,7 @@ class NotificationRepository
     {
         $notification->deleted_at = Carbon::now();
         $notification->save();
+        NotificationCountCache::forget($notification->user_id);
     }
 
     public function find($user, $id)

--- a/app/Repository/NotificationRepository.php
+++ b/app/Repository/NotificationRepository.php
@@ -31,7 +31,7 @@ class NotificationRepository
         if ($notification) {
             $notification->read_at = Carbon::now();
             $notification->save();
-            NotificationCountCache::forget($notification->user_id);
+            NotificationCountCache::forget((int) $notification->user_id);
         } else {
             $user->unreadNotifications()->update(['read_at' => Carbon::now()]);
         }
@@ -41,7 +41,7 @@ class NotificationRepository
     {
         $notification->deleted_at = Carbon::now();
         $notification->save();
-        NotificationCountCache::forget($notification->user_id);
+        NotificationCountCache::forget((int) $notification->user_id);
     }
 
     public function find($user, $id)

--- a/app/Repository/NotificationRepository.php
+++ b/app/Repository/NotificationRepository.php
@@ -20,6 +20,11 @@ class NotificationRepository
         return $query->get();
     }
 
+    public function countUnreadNotifications($user): int
+    {
+        return $user->unreadNotifications()->count();
+    }
+
     public function markAsRead($notification = null)
     {
         if ($notification) {

--- a/app/Services/Logic/NotificationManager.php
+++ b/app/Services/Logic/NotificationManager.php
@@ -53,7 +53,7 @@ class NotificationManager
 
     public function getUnreadCount($user)
     {
-        return $this->repo->getNotifications($user, true)->count();
+        return $this->repo->countUnreadNotifications($user);
     }
 
     public function delete($user, $id)

--- a/app/Services/Logic/NotificationManager.php
+++ b/app/Services/Logic/NotificationManager.php
@@ -3,6 +3,7 @@
 namespace STS\Services\Logic;
 
 use STS\Repository\NotificationRepository;
+use STS\Support\NotificationCountCache;
 
 class NotificationManager
 {
@@ -53,7 +54,9 @@ class NotificationManager
 
     public function getUnreadCount($user)
     {
-        return $this->repo->countUnreadNotifications($user);
+        return NotificationCountCache::remember($user->id, function () use ($user) {
+            return $this->repo->countUnreadNotifications($user);
+        });
     }
 
     public function delete($user, $id)

--- a/app/Services/Logic/NotificationManager.php
+++ b/app/Services/Logic/NotificationManager.php
@@ -54,7 +54,7 @@ class NotificationManager
 
     public function getUnreadCount($user)
     {
-        return NotificationCountCache::remember($user->id, function () use ($user) {
+        return NotificationCountCache::remember((int) $user->id, function () use ($user) {
             return $this->repo->countUnreadNotifications($user);
         });
     }

--- a/app/Services/Notifications/Channels/DatabaseChannel.php
+++ b/app/Services/Notifications/Channels/DatabaseChannel.php
@@ -32,6 +32,6 @@ class DatabaseChannel
             }
         }
 
-        NotificationCountCache::forget($user->id);
+        NotificationCountCache::forget((int) $user->id);
     }
 }

--- a/app/Services/Notifications/Channels/DatabaseChannel.php
+++ b/app/Services/Notifications/Channels/DatabaseChannel.php
@@ -3,18 +3,17 @@
 namespace STS\Services\Notifications\Channels;
 
 use Illuminate\Database\Eloquent\Model;
-use STS\Services\Notifications\Models\ValueNotification;
 use STS\Services\Notifications\Models\DatabaseNotification;
+use STS\Services\Notifications\Models\ValueNotification;
+use STS\Support\NotificationCountCache;
 
 class DatabaseChannel
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function send($notification, $user)
     {
-        $n = new DatabaseNotification();
+        $n = new DatabaseNotification;
         $n->user_id = $user->id;
         $n->type = $notification->getType();
         $n->save();
@@ -22,7 +21,7 @@ class DatabaseChannel
         foreach ($notification->keys() as $key) {
             $value = $notification->getAttribute($key);
             if ($value) {
-                $v = new ValueNotification();
+                $v = new ValueNotification;
                 $v->key = $key;
                 if ($value instanceof Model) {
                     $v->value()->associate($value);
@@ -32,5 +31,7 @@ class DatabaseChannel
                 $n->plain_values()->save($v);
             }
         }
+
+        NotificationCountCache::forget($user->id);
     }
 }

--- a/app/Support/NotificationCountCache.php
+++ b/app/Support/NotificationCountCache.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace STS\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+class NotificationCountCache
+{
+    public static function key(int $userId): string
+    {
+        return "user:{$userId}:notification_unread_count";
+    }
+
+    public static function remember(int $userId, callable $callback): int
+    {
+        return (int) Cache::rememberForever(self::key($userId), $callback);
+    }
+
+    public static function forget(int $userId): void
+    {
+        Cache::forget(self::key($userId));
+    }
+}

--- a/tests/Unit/Repository/NotificationRepositoryTest.php
+++ b/tests/Unit/Repository/NotificationRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Repository;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 use Mockery;
 use STS\Models\User;
 use STS\Repository\NotificationRepository;
@@ -189,5 +190,33 @@ class NotificationRepositoryTest extends TestCase
         $repo = new NotificationRepository;
 
         $this->assertNull($repo->find($user, 4_294_967_295));
+    }
+
+    public function test_count_unread_notifications_returns_expected_count(): void
+    {
+        $user = User::factory()->create();
+        $repo = new NotificationRepository;
+
+        $this->insert_notification($user, '2026-04-01 12:00:00', '2026-04-01 09:00:00');
+        $this->insert_notification($user, null, '2026-04-02 09:00:00');
+        $this->insert_notification($user, null, '2026-04-03 09:00:00');
+
+        $this->assertSame(2, $repo->countUnreadNotifications($user));
+    }
+
+    public function test_count_unread_notifications_uses_aggregate_query(): void
+    {
+        $user = User::factory()->create();
+        $repo = new NotificationRepository;
+
+        $this->insert_notification($user, null, '2026-04-02 09:00:00');
+
+        DB::enableQueryLog();
+        $repo->countUnreadNotifications($user);
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $this->assertCount(1, $queries);
+        $this->assertStringContainsString('count', strtolower($queries[0]['query']));
     }
 }

--- a/tests/Unit/Services/Logic/NotificationManagerTest.php
+++ b/tests/Unit/Services/Logic/NotificationManagerTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Unit\Services\Logic;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
 use STS\Models\User;
 use STS\Notifications\DummyNotification;
 use STS\Repository\NotificationRepository;
 use STS\Services\Logic\NotificationManager;
+use STS\Support\NotificationCountCache;
 use Tests\TestCase;
 
 class NotificationManagerTest extends TestCase
@@ -263,5 +265,65 @@ class NotificationManagerTest extends TestCase
         $result = $this->manager()->delete($user, 999999);
 
         $this->assertFalse($result);
+    }
+
+    public function test_get_unread_count_caches_result_between_requests(): void
+    {
+        Cache::flush();
+        $user = User::factory()->create();
+        $this->sendDummy($user, 'cached');
+
+        $manager = $this->manager();
+        $this->assertSame(1, $manager->getUnreadCount($user));
+        $this->assertTrue(Cache::has(NotificationCountCache::key($user->id)));
+
+        $this->assertSame(1, $manager->getUnreadCount($user));
+    }
+
+    public function test_get_unread_count_cache_invalidated_when_notifications_marked_read(): void
+    {
+        Cache::flush();
+        $user = User::factory()->create();
+        $this->sendDummy($user, 'read-me');
+
+        $manager = $this->manager();
+        $this->assertSame(1, $manager->getUnreadCount($user));
+
+        $manager->getNotifications($user, ['mark' => true]);
+
+        $this->assertFalse(Cache::has(NotificationCountCache::key($user->id)));
+        $this->assertSame(0, $manager->getUnreadCount($user));
+    }
+
+    public function test_get_unread_count_cache_invalidated_when_notification_deleted(): void
+    {
+        Cache::flush();
+        $user = User::factory()->create();
+        $this->sendDummy($user, 'delete-me');
+
+        $manager = $this->manager();
+        $rows = $manager->getNotifications($user, []);
+        $id = (int) $rows[0]['id'];
+
+        $this->assertSame(1, $manager->getUnreadCount($user));
+        $manager->delete($user, $id);
+
+        $this->assertFalse(Cache::has(NotificationCountCache::key($user->id)));
+        $this->assertSame(0, $manager->getUnreadCount($user));
+    }
+
+    public function test_get_unread_count_cache_invalidated_when_notification_created(): void
+    {
+        Cache::flush();
+        $user = User::factory()->create();
+        $manager = $this->manager();
+
+        $this->assertSame(0, $manager->getUnreadCount($user));
+        $this->assertTrue(Cache::has(NotificationCountCache::key($user->id)));
+
+        $this->sendDummy($user, 'fresh');
+
+        $this->assertFalse(Cache::has(NotificationCountCache::key($user->id)));
+        $this->assertSame(1, $manager->getUnreadCount($user));
     }
 }


### PR DESCRIPTION
## Summary

Reduce VPS load from `/api/notifications/count` by stopping per-navigation requests on the frontend and making the backend count endpoint cheap to serve via SQL `COUNT(*)` plus cache invalidation on writes.

## Cause

- The frontend called `/api/notifications/count` on **every route name/param change** for logged-in users, on top of 30s polling.
- That amplified PHP-FPM worker usage and contributed to `MaxRequestWorkers` exhaustion.
- The backend loaded **all unread notification rows** into PHP before counting (`get()->count()`), adding unnecessary DB and memory cost per request.

## Backend fix (`carpoolear_backend`)

- Add `NotificationRepository::countUnreadNotifications()` using `$user->unreadNotifications()->count()` (SQL aggregate).
- Add `NotificationCountCache` and cache unread counts in `NotificationManager::getUnreadCount()`.
- Invalidate cache when notifications are **created** (`DatabaseChannel`), **marked read** (`NotificationRepository::markAsRead`), or **deleted** (`NotificationRepository::delete`).

## Test plan

- [ ] Log in and navigate between several routes — confirm `/api/notifications/count` is **not** called on each navigation (only on login + polling/push).
- [ ] With web push enabled, confirm badge shows correct count after login.
- [ ] Without web push, confirm badge updates within ~30s polling interval.
- [ ] Create a notification (e.g. message/trip request) — badge increments on next fetch/push.
- [ ] Open notifications list (`mark=true`) — count drops after next fetch (cache invalidated server-side).
- [ ] Delete a notification — count updates on next fetch.
- [ ] Confirm production uses `CACHE_STORE=redis` for notification count caching.