### PR TITLE
Undo needs revision

### DIFF
--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -226,6 +226,15 @@ class SupportTicketController extends Controller
 
     public function markNeedsReview(int $id, Request $request): JsonResponse
     {
+        $admin = auth()->user();
+        $ticket = SupportTicket::findOrFail($id);
+
+        if ($ticket->status === SupportTicket::STATUS_NEEDS_REVIEW) {
+            $this->supportTicketService->undoNeedsReviewTicket($ticket, $admin->id);
+
+            return response()->json(['data' => $ticket->fresh()]);
+        }
+
         return $this->applyActionStatus($id, $request, SupportTicket::STATUS_NEEDS_REVIEW);
     }
 

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -159,6 +159,13 @@ class SupportTicketService
         $ticket->save();
     }
 
+    public function undoNeedsReviewTicket(SupportTicket $ticket, int $adminUserId): void
+    {
+        $ticket->status = $this->statusAfterUndoResolve($ticket);
+        $ticket->updated_by = $adminUserId;
+        $ticket->save();
+    }
+
     public function ticketAcceptsReplies(SupportTicket $ticket): bool
     {
         return ! in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true);

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -137,7 +137,8 @@ class SupportTicketService
     }
 
     /**
-     * Status to restore when undoing "Resuelto", based on who sent the latest reply.
+     * Status to restore when undoing admin-set statuses (Resuelto, Necesita revisión),
+     * based on who sent the latest reply.
      */
     public function statusAfterUndoResolve(SupportTicket $ticket): string
     {
@@ -154,12 +155,15 @@ class SupportTicketService
 
     public function unresolveTicket(SupportTicket $ticket, int $adminUserId): void
     {
-        $ticket->status = $this->statusAfterUndoResolve($ticket);
-        $ticket->updated_by = $adminUserId;
-        $ticket->save();
+        $this->restoreStatusFromLastReply($ticket, $adminUserId);
     }
 
     public function undoNeedsReviewTicket(SupportTicket $ticket, int $adminUserId): void
+    {
+        $this->restoreStatusFromLastReply($ticket, $adminUserId);
+    }
+
+    private function restoreStatusFromLastReply(SupportTicket $ticket, int $adminUserId): void
     {
         $ticket->status = $this->statusAfterUndoResolve($ticket);
         $ticket->updated_by = $adminUserId;

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -762,6 +762,65 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertSame($before, SupportTicketReply::where('ticket_id', $ticket->id)->count());
     }
 
+    public function test_needs_review_toggle_undoes_when_already_marked_and_last_reply_is_admin(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => SupportTicket::STATUS_NEEDS_REVIEW]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User message',
+            'created_by' => $owner->id,
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin reply',
+            'created_by' => $admin->id,
+        ]);
+        $before = SupportTicketReply::where('ticket_id', $ticket->id)->count();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/needs-review', [])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'Esperando respuesta');
+
+        $this->assertSame($before, SupportTicketReply::where('ticket_id', $ticket->id)->count());
+    }
+
+    public function test_needs_review_toggle_undoes_when_already_marked_and_last_reply_is_user(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => SupportTicket::STATUS_NEEDS_REVIEW]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin reply',
+            'created_by' => $admin->id,
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User follow-up',
+            'created_by' => $owner->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/needs-review', [])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'En revision');
+    }
+
     public function test_reply_with_image_stores_file_on_local_support_tickets_disk(): void
     {
         Storage::fake('local');

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -377,6 +377,65 @@ class SupportTicketServiceTest extends TestCase
         $this->assertSame($admin->id, (int) $ticket->fresh()->updated_by);
     }
 
+    public function test_undo_needs_review_restores_esperando_respuesta_when_last_reply_is_admin(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => 1]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => SupportTicket::STATUS_NEEDS_REVIEW,
+            'priority' => 'normal',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User message',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin reply',
+        ]);
+
+        $this->service()->undoNeedsReviewTicket($ticket, $admin->id);
+
+        $this->assertSame('Esperando respuesta', $ticket->fresh()->status);
+        $this->assertSame($admin->id, (int) $ticket->fresh()->updated_by);
+    }
+
+    public function test_undo_needs_review_restores_en_revision_when_last_reply_is_user(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => 1]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => SupportTicket::STATUS_NEEDS_REVIEW,
+            'priority' => 'normal',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $admin->id,
+            'is_admin' => true,
+            'message_markdown' => 'Admin reply',
+        ]);
+        SupportTicketReply::query()->create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $owner->id,
+            'is_admin' => false,
+            'message_markdown' => 'User follow-up',
+        ]);
+
+        $this->service()->undoNeedsReviewTicket($ticket, $admin->id);
+
+        $this->assertSame('En revision', $ticket->fresh()->status);
+    }
+
     public function test_ticket_accepts_replies_is_false_for_resolved_and_closed(): void
     {
         $service = $this->service();


### PR DESCRIPTION
## Summary

Allow admins to undo "Necesita revisión" on support tickets using the same button that marks it. When undone, the ticket status is restored based on who sent the last reply (same logic as unresolving a ticket).

## Cause

The "Marcar necesita revisión" action was one-way: once marked, the button disappeared and there was no way to revert without manually changing status.

## Fix

### Backend
- Added `undoNeedsReviewTicket()` in `SupportTicketService`, reusing the existing last-reply status logic (`Esperando respuesta` if admin replied last, `En revision` if user replied last).
- Refactored shared restore logic into `restoreStatusFromLastReply()` (also used by `unresolveTicket`).
- `POST /api/admin/support/tickets/{id}/needs-review` now toggles: marks when not in "Necesita revisión", undoes when already marked (no new reply created on undo).

## Test plan

- [ ] Open an admin support ticket with admin as last replier → mark as needs review → click again to undo → status returns to "Esperando respuesta"
- [ ] Open a ticket with user as last replier → mark as needs review → click again to undo → status returns to "En revision"
- [ ] Marking with a message in the reply editor still creates an admin reply
- [ ] Undoing does not create a new reply
- [ ] Button hidden for resolved/closed tickets (unchanged behavior)