### PR TITLE
Fix QR payments

### DIFF
--- a/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
@@ -3,6 +3,7 @@
 namespace STS\Http\Controllers\Api\v1;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
 use Log;
 use MercadoPago\Client\Payment\PaymentClient;
 use MercadoPago\MercadoPagoConfig;
@@ -38,7 +39,32 @@ class MercadoPagoWebhookController extends Controller
     {
         // Handle order.processed (QR/Orders API) - sent when QR order is paid
         if ($request->input('action') === 'order.processed') {
-            return $this->handleOrderProcessed($request);
+            try {
+                return $this->handleOrderProcessed($request);
+            } catch (\Throwable $e) {
+                Log::error('MercadoPago order.processed webhook failed', [
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+
+                return response()->json(['error' => 'Internal error'], 500);
+            }
+        }
+
+        $webhookType = $request->query('type') ?? $request->input('type');
+        if ($webhookType === 'topic_merchant_order_wh') {
+            try {
+                return $this->handleMerchantOrderWebhook($request);
+            } catch (\Throwable $e) {
+                Log::error('MercadoPago merchant order webhook failed', [
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+
+                return response()->json(['error' => 'Internal error'], 500);
+            }
         }
 
         // Only process payment.created (Payments API / Checkout Pro)
@@ -138,8 +164,9 @@ class MercadoPagoWebhookController extends Controller
      *
      * @param  bool  $isOrderWebhook  True for Orders API (QR), false for Payments API (Checkout Pro / Sellado).
      *                                Orders API uses data.id in query (lowercased); Payments API uses data_id.
+     * @param  array<int, string>|null  $secretCandidates  Secrets to try, in order. Defaults from webhook type.
      */
-    protected function verifyMercadoPagoRequest(Request $request, bool $isOrderWebhook = false)
+    protected function verifyMercadoPagoRequest(Request $request, bool $isOrderWebhook = false, ?array $secretCandidates = null)
     {
         $xSignature = $request->header('x-signature');
         $xRequestId = $request->header('x-request-id');
@@ -189,33 +216,81 @@ class MercadoPagoWebhookController extends Controller
             return false;
         }
 
-        // Get the secret key from config (QR/Orders API uses separate secret)
-        $secret = $isOrderWebhook
-            ? config('services.mercadopago.webhook_secret_qr_payment')
-            : config('services.mercadopago.webhook_secret');
-        if (! $secret) {
+        // Generate the manifest string
+        $manifest = "id:{$dataId};request-id:{$xRequestId};ts:{$ts};";
+
+        if ($secretCandidates === null) {
+            $secretCandidates = $this->webhookSecretCandidatesForRequest($request, $isOrderWebhook);
+        }
+        $secretCandidates = array_values(array_filter($secretCandidates));
+
+        if ($secretCandidates === []) {
             Log::error('Mercado Pago webhook secret not configured');
 
             return false;
         }
 
-        // Generate the manifest string
-        $manifest = "id:{$dataId};request-id:{$xRequestId};ts:{$ts};";
+        $lastCalculatedHash = null;
+        foreach ($secretCandidates as $secret) {
+            $calculatedHash = hash_hmac('sha256', $manifest, $secret);
+            $lastCalculatedHash = $calculatedHash;
+            if (hash_equals($calculatedHash, $hash)) {
+                return true;
+            }
+        }
 
-        // Generate HMAC signature
-        $calculatedHash = hash_hmac('sha256', $manifest, $secret);
+        Log::error('Invalid webhook signature', [
+            'calculated' => $lastCalculatedHash,
+            'received' => $hash,
+        ]);
 
-        // Compare signatures
-        if (! hash_equals($calculatedHash, $hash)) {
-            Log::error('Invalid webhook signature', [
-                'calculated' => $calculatedHash,
-                'received' => $hash,
-            ]);
+        return false;
+    }
 
+    /**
+     * @return array<int, string>
+     */
+    protected function webhookSecretCandidatesForRequest(Request $request, bool $isOrderWebhook): array
+    {
+        $standard = config('services.mercadopago.webhook_secret');
+        $qr = config('services.mercadopago.webhook_secret_qr_payment');
+
+        if ($isOrderWebhook) {
+            return array_values(array_filter([$qr]));
+        }
+
+        if ($this->isQrPaymentApplicationWebhook($request)) {
+            return array_values(array_filter(array_unique([$qr, $standard])));
+        }
+
+        return array_values(array_filter(array_unique([$standard, $qr])));
+    }
+
+    /**
+     * QR manual-validation payments use a separate MP application.
+     * Webhook body includes application_id which matches MERCADO_PAGO_QR_PAYMENT_CLIENT_ID
+     * (or MERCADO_PAGO_QR_PAYMENT_APPLICATION_ID when set).
+     */
+    protected function isQrPaymentApplicationWebhook(Request $request): bool
+    {
+        $applicationId = (string) ($request->input('application_id') ?? '');
+        if ($applicationId === '') {
             return false;
         }
 
-        return true;
+        $qrApplicationId = (string) (
+            config('services.mercadopago.qr_payment_application_id')
+            ?: config('services.mercadopago.qr_payment_client_id')
+            ?: ''
+        );
+
+        return $qrApplicationId !== '' && $applicationId === $qrApplicationId;
+    }
+
+    protected function isManualValidationExternalReference(string $externalReference): bool
+    {
+        return strpos($externalReference, 'manual_validation:') === 0
+            || strpos($externalReference, 'manual_validation_') === 0;
     }
 
     protected function getMercadoPagoPayment($paymentId)
@@ -453,7 +528,7 @@ class MercadoPagoWebhookController extends Controller
         }
 
         $orderData = $request->input('data');
-        if (! $orderData || ! isset($orderData['external_reference'])) {
+        if (! is_array($orderData) || ! isset($orderData['external_reference'])) {
             Log::error('Invalid order.processed webhook: missing data or external_reference');
 
             return response()->json(['error' => 'Invalid payload'], 400);
@@ -462,32 +537,140 @@ class MercadoPagoWebhookController extends Controller
         $externalReference = $orderData['external_reference'] ?? '';
         $orderStatus = $orderData['status'] ?? '';
         $orderStatusDetail = $orderData['status_detail'] ?? '';
+        $payments = $this->extractOrderPayments($orderData);
 
         // Only process when order is fully paid (processed + accredited)
         if ($orderStatus !== 'processed' || $orderStatusDetail !== 'accredited') {
             return response()->json(['status' => 'success']);
         }
 
-        // manual_validation:requestId (Checkout Pro) or manual_validation_requestId (QR)
-        if (strpos($externalReference, 'manual_validation:') !== 0 && strpos($externalReference, 'manual_validation_') !== 0) {
+        if (! $this->isManualValidationExternalReference($externalReference)) {
             return response()->json(['status' => 'success']);
         }
 
-        // Get payment ID from first payment in transactions
         $paymentId = null;
-        $payments = $orderData['transactions']['payments'] ?? [];
         if (! empty($payments) && isset($payments[0]['id'])) {
             $paymentId = $payments[0]['id'];
         }
 
-        $mpPayment = [
+        return $this->handleManualValidationPayment([
             'id' => $paymentId,
             'status' => 'approved',
             'status_detail' => $orderStatusDetail,
             'external_reference' => $externalReference,
-        ];
+        ]);
+    }
 
-        return $this->handleManualValidationPayment($mpPayment);
+    /**
+     * @param  array<string, mixed>  $orderData
+     * @return array<int, array<string, mixed>>
+     */
+    protected function extractOrderPayments(array $orderData): array
+    {
+        $transactions = $orderData['transactions'] ?? null;
+        if (! is_array($transactions)) {
+            return [];
+        }
+
+        $payments = $transactions['payments'] ?? null;
+
+        return is_array($payments) ? $payments : [];
+    }
+
+    /**
+     * Handle topic_merchant_order_wh (legacy commercial order notifications).
+     * MP may send these for QR payments instead of order.processed depending on integration config.
+     * When status is closed, fetch the merchant order and mark manual validation as paid.
+     */
+    protected function handleMerchantOrderWebhook(Request $request)
+    {
+        $action = $request->input('action');
+        $status = $request->input('status') ?? ($request->input('data.status') ?? null);
+        $merchantOrderId = $request->query('data_id') ?? $request->input('data_id');
+
+        if ($action !== 'update' || $status !== 'closed') {
+            return response()->json(['status' => 'success']);
+        }
+
+        if (! $this->verifyMercadoPagoRequest($request, false)) {
+            Log::error('Invalid MercadoPago merchant order webhook request');
+
+            return response()->json(['error' => 'Invalid request'], 400);
+        }
+
+        if (! $merchantOrderId) {
+            return response()->json(['error' => 'No merchant order ID'], 400);
+        }
+
+        $merchantOrder = $this->getMercadoPagoMerchantOrder($merchantOrderId);
+        if (! $merchantOrder) {
+            return response()->json(['error' => 'Could not fetch merchant order'], 500);
+        }
+
+        $externalReference = $merchantOrder['external_reference'] ?? '';
+        if (! $this->isManualValidationExternalReference($externalReference)) {
+            return response()->json(['status' => 'success']);
+        }
+
+        $paymentId = null;
+        $payments = $merchantOrder['payments'] ?? [];
+        if (is_array($payments)) {
+            foreach ($payments as $payment) {
+                if (is_array($payment) && ($payment['status'] ?? '') === 'approved' && isset($payment['id'])) {
+                    $paymentId = $payment['id'];
+                    break;
+                }
+            }
+            if ($paymentId === null && isset($payments[0]['id'])) {
+                $paymentId = $payments[0]['id'];
+            }
+        }
+
+        return $this->handleManualValidationPayment([
+            'id' => $paymentId,
+            'status' => 'approved',
+            'status_detail' => 'accredited',
+            'external_reference' => $externalReference,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function getMercadoPagoMerchantOrder($merchantOrderId): ?array
+    {
+        $tokens = array_values(array_filter(array_unique([
+            config('services.mercadopago.qr_payment_access_token'),
+            config('services.mercadopago.access_token'),
+        ])));
+
+        if ($tokens === []) {
+            Log::error('No Mercado Pago access token configured for merchant order fetch');
+
+            return null;
+        }
+
+        foreach ($tokens as $token) {
+            try {
+                $response = Http::timeout(15)
+                    ->withToken($token)
+                    ->get('https://api.mercadopago.com/merchant_orders/'.$merchantOrderId);
+
+                if ($response->successful()) {
+                    $body = $response->json();
+                    if (is_array($body)) {
+                        return $body;
+                    }
+                }
+            } catch (\Throwable $e) {
+                Log::error('Error fetching MercadoPago merchant order', [
+                    'merchant_order_id' => $merchantOrderId,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -522,7 +705,6 @@ class MercadoPagoWebhookController extends Controller
                 $validationRequest->paid_at = now();
                 $validationRequest->payment_id = (string) $mpPayment['id'];
                 $validationRequest->save();
-
             }
         }
 

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,8 @@ return [
         'qr_payment_access_token' => env('MERCADO_PAGO_QR_PAYMENT_ACCESS_TOKEN'),
         'qr_payment_client_id' => env('MERCADO_PAGO_QR_PAYMENT_CLIENT_ID'),
         'qr_payment_client_secret' => env('MERCADO_PAGO_QR_PAYMENT_CLIENT_SECRET'),
+        // Webhook application_id for the QR app (defaults to qr_payment_client_id when unset).
+        'qr_payment_application_id' => env('MERCADO_PAGO_QR_PAYMENT_APPLICATION_ID'),
         'webhook_secret' => env('MERCADO_PAGO_WEBHOOK_SECRET'),
         'webhook_secret_qr_payment' => env('MERCADO_PAGO_WEBHOOK_SECRET_QR_PAYMENT'),
         'reference_salt' => env('MERCADO_PAGO_REFERENCE_SALT', 'carpoolear_2024_secure_salt'),

--- a/tests/Feature/Http/MercadoPagoWebhookTest.php
+++ b/tests/Feature/Http/MercadoPagoWebhookTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Http;
 
+use Illuminate\Support\Facades\Http;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
 use MercadoPago\Net\MPHttpClient;
@@ -500,5 +501,165 @@ class MercadoPagoWebhookTest extends TestCase
         $this->assertArrayHasKey('date_created', $attempt->payment_data);
         $this->assertArrayHasKey('date_approved', $attempt->payment_data);
         $this->assertArrayHasKey('date_last_updated', $attempt->payment_data);
+    }
+
+    public function test_merchant_order_closed_marks_manual_validation_paid_when_signed_with_qr_secret(): void
+    {
+        config([
+            'services.mercadopago.webhook_secret' => 'wh-secret-checkout',
+            'services.mercadopago.webhook_secret_qr_payment' => 'wh-secret-qr',
+            'services.mercadopago.qr_payment_client_id' => '2333034981366591',
+            'services.mercadopago.access_token' => 'test-access-token',
+        ]);
+
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $merchantOrderId = 42085488043;
+        $headers = $this->paymentCreatedSignatureHeaders((string) $merchantOrderId, 'req-merchant-order-qr-secret', 'wh-secret-qr');
+
+        Http::fake([
+            'api.mercadopago.com/merchant_orders/'.$merchantOrderId => Http::response([
+                'id' => $merchantOrderId,
+                'status' => 'closed',
+                'external_reference' => 'manual_validation_'.$row->id,
+                'external_pos_id' => 'carpoolearmanualvalidationposprod1',
+                'payments' => [
+                    ['id' => 99112233, 'status' => 'approved'],
+                ],
+            ], 200),
+        ]);
+
+        $this->postJson('/webhooks/mercadopago?'.http_build_query([
+            'data_id' => $merchantOrderId,
+            'type' => 'topic_merchant_order_wh',
+        ]), [
+            'action' => 'update',
+            'status' => 'closed',
+            'application_id' => '2333034981366591',
+            'type' => 'topic_merchant_order_wh',
+            'data_id' => (string) $merchantOrderId,
+            'data' => ['status' => 'closed'],
+        ], $headers)
+            ->assertOk()
+            ->assertExactJson(['status' => 'success']);
+
+        $row->refresh();
+        $this->assertTrue($row->paid);
+        $this->assertSame('99112233', $row->payment_id);
+    }
+
+    public function test_merchant_order_closed_marks_manual_validation_paid_with_checkout_secret(): void
+    {
+        config([
+            'services.mercadopago.webhook_secret' => 'wh-secret-test',
+            'services.mercadopago.webhook_secret_qr_payment' => 'wh-secret-qr-unused',
+            'services.mercadopago.access_token' => 'test-access-token',
+        ]);
+
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $merchantOrderId = 42085488043;
+        $headers = $this->paymentCreatedSignatureHeaders((string) $merchantOrderId, 'req-merchant-order-closed', 'wh-secret-test');
+
+        Http::fake([
+            'api.mercadopago.com/merchant_orders/'.$merchantOrderId => Http::response([
+                'id' => $merchantOrderId,
+                'status' => 'closed',
+                'external_reference' => 'manual_validation_'.$row->id,
+                'payments' => [
+                    ['id' => 99112233, 'status' => 'approved'],
+                ],
+            ], 200),
+        ]);
+
+        $this->postJson('/webhooks/mercadopago?'.http_build_query([
+            'data_id' => $merchantOrderId,
+            'type' => 'topic_merchant_order_wh',
+        ]), [
+            'action' => 'update',
+            'status' => 'closed',
+            'type' => 'topic_merchant_order_wh',
+            'data_id' => (string) $merchantOrderId,
+            'data' => ['status' => 'closed'],
+        ], $headers)
+            ->assertOk()
+            ->assertExactJson(['status' => 'success']);
+
+        $row->refresh();
+        $this->assertTrue($row->paid);
+        $this->assertSame('99112233', $row->payment_id);
+    }
+
+    public function test_merchant_order_closed_rejects_signature_that_matches_neither_secret(): void
+    {
+        config([
+            'services.mercadopago.webhook_secret' => 'wh-secret-checkout',
+            'services.mercadopago.webhook_secret_qr_payment' => 'wh-secret-qr',
+            'services.mercadopago.qr_payment_client_id' => '2333034981366591',
+        ]);
+
+        $merchantOrderId = 42085488045;
+        $headers = $this->paymentCreatedSignatureHeaders((string) $merchantOrderId, 'req-merchant-order-wrong-secret', 'wh-secret-wrong');
+
+        Http::fake();
+
+        $this->postJson('/webhooks/mercadopago?'.http_build_query([
+            'data_id' => $merchantOrderId,
+            'type' => 'topic_merchant_order_wh',
+        ]), [
+            'action' => 'update',
+            'status' => 'closed',
+            'application_id' => '2333034981366591',
+            'type' => 'topic_merchant_order_wh',
+            'data_id' => (string) $merchantOrderId,
+            'data' => ['status' => 'closed'],
+        ], $headers)
+            ->assertStatus(400)
+            ->assertJson(['error' => 'Invalid request']);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_merchant_order_opened_does_not_mark_manual_validation_paid(): void
+    {
+        config(['services.mercadopago.webhook_secret' => 'wh-secret-test']);
+
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $merchantOrderId = 42085488044;
+        $headers = $this->paymentCreatedSignatureHeaders((string) $merchantOrderId, 'req-merchant-order-opened', 'wh-secret-test');
+
+        Http::fake();
+
+        $this->postJson('/webhooks/mercadopago?'.http_build_query([
+            'data_id' => $merchantOrderId,
+            'type' => 'topic_merchant_order_wh',
+        ]), [
+            'action' => 'create',
+            'status' => 'opened',
+            'type' => 'topic_merchant_order_wh',
+            'data_id' => (string) $merchantOrderId,
+            'data' => ['status' => 'opened'],
+        ], $headers)
+            ->assertOk()
+            ->assertExactJson(['status' => 'success']);
+
+        $this->assertFalse($row->fresh()->paid);
+        Http::assertNothingSent();
     }
 }


### PR DESCRIPTION
## Summary

Fixes manual identity validation QR payments not being marked as paid when Mercado Pago delivers `topic_merchant_order_wh` webhooks instead of `order.processed`.

## Cause

QR payments for manual validation can be notified via two different Mercado Pago webhook types:

1. **`order.processed`** (Orders API) — already handled
2. **`topic_merchant_order_wh`** with `action: update` and `status: closed` — was ignored

In production, QR payments were arriving only as merchant-order webhooks. Additionally, those webhooks are signed with the **QR app** webhook secret (`MERCADO_PAGO_WEBHOOK_SECRET_QR_PAYMENT`), not the Checkout Pro secret, so signature verification failed even when we started handling them.

QR payments are identifiable by:
- `application_id` in the webhook body matching `MERCADO_PAGO_QR_PAYMENT_CLIENT_ID`
- `external_reference` on the fetched merchant order matching `manual_validation_{requestId}`

## Fix

### Backend
- Handle `topic_merchant_order_wh` webhooks in `MercadoPagoWebhookController`
- On `update` + `closed`: verify signature, fetch `GET /merchant_orders/{id}`, mark validation request paid when `external_reference` is `manual_validation_*`
- Try **both** webhook secrets when the webhook comes from the QR app (`application_id` match); QR secret first
- Fetch merchant orders using QR access token first, then main MP token
- Add optional `MERCADO_PAGO_QR_PAYMENT_APPLICATION_ID` config (falls back to client ID)
- Add feature tests for merchant-order webhook flow

## Test plan

- [ ] Pay manual validation via QR in staging/production
- [ ] Confirm `manual_identity_validations.paid = 1` after payment
- [ ] Confirm webhook logs show no signature errors on `topic_merchant_order_wh` + `closed`
- [ ] Run `php artisan test --filter=MercadoPagoWebhookTest`