### PR TITLE
Fix payment url

### DIFF
--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -261,27 +261,35 @@ class TripRepository
                 } else {
                     $trip->state = Trip::STATE_AWAITING_PAYMENT;
 
+                    $paymentUrl = null;
                     // Only create payment preference if one doesn't exist
                     if (! $trip->payment_id) {
                         // Create MercadoPago payment preference
                         $preference = $this->mercadoPagoService->createPaymentPreferenceForSellado($trip, config('carpoolear.module_trip_creation_payment_amount_cents'));
                         $trip->payment_id = $preference->id;
-                        $trip->payment_url = $preference->init_point;
+                        $paymentUrl = $preference->init_point;
                     }
 
                     $trip->needs_sellado = true;
                     $trip->save();
+
+                    if ($paymentUrl !== null) {
+                        $trip->payment_url = $paymentUrl;
+                    }
                 }
             } elseif (config('carpoolear.module_trip_creation_payment_enabled') && ! $routeNeedsPayment) {
                 // Route was edited so it no longer needs Sellado (fewer than 2 points in paid zone)
                 $trip->needs_sellado = false;
                 $paymentStates = [Trip::STATE_AWAITING_PAYMENT, Trip::STATE_PENDING_PAYMENT, Trip::STATE_PAYMENT_FAILED];
-                if (in_array($trip->state, $paymentStates)) {
+                $wasInPaymentState = in_array($trip->state, $paymentStates);
+                if ($wasInPaymentState) {
                     $trip->payment_id = null;
-                    $trip->payment_url = null;
                     $trip->state = Trip::STATE_READY;
                 }
                 $trip->save();
+                if ($wasInPaymentState) {
+                    $trip->payment_url = null;
+                }
             }
         }
 

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -223,77 +223,79 @@ class TripRepository
             }
         }
 
-        $trip->update($data);
+        return DB::transaction(function () use ($trip, $data, $points, $tripInfo, $oldRouteNeedsPayment) {
+            $trip->update($data);
 
-        // Save recommended trip price if available from trip info
-        if ($tripInfo && $tripInfo['status'] && isset($tripInfo['data']['recommended_trip_price_cents'])) {
-            $trip->recommended_trip_price_cents = $tripInfo['data']['recommended_trip_price_cents'];
-            $trip->save();
-        }
-
-        if ($points) {
-            $this->deletePoints($trip);
-            $this->addPoints($trip, $points);
-            $this->generateTripPath($trip);
-
-            // Check if the updated route needs payment (2+ stops in paid zones)
-            $allPointsToCheck = array_map(fn ($p) => [$p['lat'], $p['lng']], $points);
-            $routeNeedsPayment = $this->geoService->doStopsRequireSellado($allPointsToCheck);
-
-            $tripsCreatedByUser = Trip::where('user_id', $trip->user_id)->count();
-
-            // Check if route changed from non-paid to paid route and trip wasn't already awaiting payment
-            if (config('carpoolear.module_trip_creation_payment_enabled') &&
-                $routeNeedsPayment &&
-                ! $oldRouteNeedsPayment &&
-                $tripsCreatedByUser >= config('carpoolear.module_trip_creation_payment_trips_threshold') &&
-                $trip->state !== Trip::STATE_AWAITING_PAYMENT) {
-
-                // User already paid Sellado for this trip (check payment record, not just state + payment_id)
-                $selladoAlreadyPaid = PaymentAttempt::where('trip_id', $trip->id)
-                    ->where('payment_status', PaymentAttempt::STATUS_COMPLETED)
-                    ->exists();
-
-                if ($selladoAlreadyPaid) {
-                    // Just mark that route needs Sellado again; do not charge again
-                    $trip->needs_sellado = true;
-                    $trip->save();
-                } else {
-                    $trip->state = Trip::STATE_AWAITING_PAYMENT;
-
-                    $paymentUrl = null;
-                    // Only create payment preference if one doesn't exist
-                    if (! $trip->payment_id) {
-                        // Create MercadoPago payment preference
-                        $preference = $this->mercadoPagoService->createPaymentPreferenceForSellado($trip, config('carpoolear.module_trip_creation_payment_amount_cents'));
-                        $trip->payment_id = $preference->id;
-                        $paymentUrl = $preference->init_point;
-                    }
-
-                    $trip->needs_sellado = true;
-                    $trip->save();
-
-                    if ($paymentUrl !== null) {
-                        $trip->payment_url = $paymentUrl;
-                    }
-                }
-            } elseif (config('carpoolear.module_trip_creation_payment_enabled') && ! $routeNeedsPayment) {
-                // Route was edited so it no longer needs Sellado (fewer than 2 points in paid zone)
-                $trip->needs_sellado = false;
-                $paymentStates = [Trip::STATE_AWAITING_PAYMENT, Trip::STATE_PENDING_PAYMENT, Trip::STATE_PAYMENT_FAILED];
-                $wasInPaymentState = in_array($trip->state, $paymentStates);
-                if ($wasInPaymentState) {
-                    $trip->payment_id = null;
-                    $trip->state = Trip::STATE_READY;
-                }
+            // Save recommended trip price if available from trip info
+            if ($tripInfo && $tripInfo['status'] && isset($tripInfo['data']['recommended_trip_price_cents'])) {
+                $trip->recommended_trip_price_cents = $tripInfo['data']['recommended_trip_price_cents'];
                 $trip->save();
-                if ($wasInPaymentState) {
-                    $trip->payment_url = null;
+            }
+
+            if ($points) {
+                $this->deletePoints($trip);
+                $this->addPoints($trip, $points);
+                $this->generateTripPath($trip);
+
+                // Check if the updated route needs payment (2+ stops in paid zones)
+                $allPointsToCheck = array_map(fn ($p) => [$p['lat'], $p['lng']], $points);
+                $routeNeedsPayment = $this->geoService->doStopsRequireSellado($allPointsToCheck);
+
+                $tripsCreatedByUser = Trip::where('user_id', $trip->user_id)->count();
+
+                // Check if route changed from non-paid to paid route and trip wasn't already awaiting payment
+                if (config('carpoolear.module_trip_creation_payment_enabled') &&
+                    $routeNeedsPayment &&
+                    ! $oldRouteNeedsPayment &&
+                    $tripsCreatedByUser >= config('carpoolear.module_trip_creation_payment_trips_threshold') &&
+                    $trip->state !== Trip::STATE_AWAITING_PAYMENT) {
+
+                    // User already paid Sellado for this trip (check payment record, not just state + payment_id)
+                    $selladoAlreadyPaid = PaymentAttempt::where('trip_id', $trip->id)
+                        ->where('payment_status', PaymentAttempt::STATUS_COMPLETED)
+                        ->exists();
+
+                    if ($selladoAlreadyPaid) {
+                        // Just mark that route needs Sellado again; do not charge again
+                        $trip->needs_sellado = true;
+                        $trip->save();
+                    } else {
+                        $trip->state = Trip::STATE_AWAITING_PAYMENT;
+
+                        $paymentUrl = null;
+                        // Only create payment preference if one doesn't exist
+                        if (! $trip->payment_id) {
+                            // Create MercadoPago payment preference
+                            $preference = $this->mercadoPagoService->createPaymentPreferenceForSellado($trip, config('carpoolear.module_trip_creation_payment_amount_cents'));
+                            $trip->payment_id = $preference->id;
+                            $paymentUrl = $preference->init_point;
+                        }
+
+                        $trip->needs_sellado = true;
+                        $trip->save();
+
+                        if ($paymentUrl !== null) {
+                            $trip->payment_url = $paymentUrl;
+                        }
+                    }
+                } elseif (config('carpoolear.module_trip_creation_payment_enabled') && ! $routeNeedsPayment) {
+                    // Route was edited so it no longer needs Sellado (fewer than 2 points in paid zone)
+                    $trip->needs_sellado = false;
+                    $paymentStates = [Trip::STATE_AWAITING_PAYMENT, Trip::STATE_PENDING_PAYMENT, Trip::STATE_PAYMENT_FAILED];
+                    $wasInPaymentState = in_array($trip->state, $paymentStates);
+                    if ($wasInPaymentState) {
+                        $trip->payment_id = null;
+                        $trip->state = Trip::STATE_READY;
+                    }
+                    $trip->save();
+                    if ($wasInPaymentState) {
+                        $trip->payment_url = null;
+                    }
                 }
             }
-        }
 
-        return $trip;
+            return $trip;
+        });
     }
 
     public function generateTripPath($trip)

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -3777,11 +3777,6 @@ class TripRepositoryTest extends TestCase
         Config::set('carpoolear.module_trip_creation_payment_enabled', true);
         Config::set('carpoolear.module_trip_creation_payment_trips_threshold', 1);
         Config::set('carpoolear.module_max_price_enabled', false);
-        if (! Schema::hasColumn('trips', 'payment_url')) {
-            Schema::table('trips', function (Blueprint $table): void {
-                $table->string('payment_url')->nullable();
-            });
-        }
 
         $geoService = Mockery::mock(GeoService::class);
         $geoService->shouldReceive('getPaidRegions')->andReturn([]);

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -3594,6 +3594,70 @@ class TripRepositoryTest extends TestCase
         $this->assertTrue((bool) $updated->needs_sellado);
     }
 
+    public function test_update_creates_sellado_preference_and_ephemeral_payment_url_without_payment_url_column(): void
+    {
+        if (Schema::hasColumn('trips', 'payment_url')) {
+            Schema::table('trips', function (Blueprint $table): void {
+                $table->dropColumn('payment_url');
+            });
+        }
+        $this->assertFalse(Schema::hasColumn('trips', 'payment_url'));
+
+        Config::set('carpoolear.module_trip_creation_payment_enabled', true);
+        Config::set('carpoolear.module_trip_creation_payment_trips_threshold', 2);
+        Config::set('carpoolear.module_trip_creation_payment_amount_cents', 1800);
+        Config::set('carpoolear.module_max_price_enabled', false);
+
+        $geoService = Mockery::mock(GeoService::class);
+        $geoService->shouldReceive('getPaidRegions')->andReturn([]);
+        $geoService->shouldReceive('doStopsRequireSellado')->twice()->andReturn(false, true);
+
+        $mercadoPagoService = Mockery::mock(MercadoPagoService::class);
+        $mercadoPagoService->shouldReceive('createPaymentPreferenceForSellado')
+            ->once()
+            ->andReturn((object) [
+                'id' => 'pref_new_456',
+                'init_point' => 'https://pay.test/pref_new_456',
+            ]);
+
+        $mapboxService = Mockery::mock(MapboxDirectionsRouteService::class);
+
+        /** @var TripRepository $repo */
+        $repo = Mockery::mock(
+            TripRepository::class,
+            [$geoService, $mercadoPagoService, $mapboxService]
+        )->makePartial();
+        $repo->shouldReceive('getTripInfo')->andReturn(['status' => false]);
+
+        $user = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $user->id,
+            'state' => Trip::STATE_READY,
+            'payment_id' => null,
+            'needs_sellado' => false,
+        ]);
+        Trip::factory()->create(['user_id' => $user->id]);
+
+        $repo->addPoints($trip, [
+            ['lat' => -34.60, 'lng' => -58.40, 'json_address' => ['id' => 1201, 'ciudad' => 'OldA']],
+            ['lat' => -34.59, 'lng' => -58.39, 'json_address' => ['id' => 1202, 'ciudad' => 'OldB']],
+        ]);
+
+        $updated = $repo->update($trip, [
+            'points' => [
+                ['lat' => -34.50, 'lng' => -58.30, 'json_address' => ['id' => 1203, 'ciudad' => 'NewA']],
+                ['lat' => -34.49, 'lng' => -58.29, 'json_address' => ['id' => 1204, 'ciudad' => 'NewB']],
+            ],
+        ]);
+
+        $this->assertSame('https://pay.test/pref_new_456', $updated->payment_url);
+
+        $updated->refresh();
+        $this->assertSame(Trip::STATE_AWAITING_PAYMENT, $updated->state);
+        $this->assertSame('pref_new_456', $updated->payment_id);
+        $this->assertTrue((bool) $updated->needs_sellado);
+    }
+
     public function test_update_does_not_trigger_sellado_when_module_disabled_even_if_route_changes_to_paid(): void
     {
         // Mutation intent: prevent relaxed boolean OR gates in update sellado trigger condition.


### PR DESCRIPTION
## Summary

Fixes a 500 error when editing a trip from a non-Sellado route to a paid route (e.g. Rosario → Buenos Aires) after the user has passed the free-trip threshold.

## Cause

When a trip update triggered Sellado payment (`TripRepository::update()`), the code set `payment_url` **before** `save()`. Eloquent included it in the `UPDATE`, but `payment_url` is **not** a `trips` table column — only `payment_id` is persisted. MySQL raised:

`SQLSTATE[42S22]: Unknown column 'payment_url' in 'field list'`

On **create**, the same URL was already handled correctly: saved first, then assigned in memory for the response. **Update** did the opposite.

The update path also had no DB transaction, so a failed save could leave the trip with the new route saved but sellado/payment state not updated.

## Fix (backend)

- Set `payment_url` **after** `save()` on update (same pattern as create), for both the new-preference and clear-payment paths.
- Wrap trip update persistence (fields, points, path, sellado/payment state) in `DB::transaction()`.
- Add a regression test that runs without a `payment_url` column; remove the test-only column workaround.


## Test plan

- [ ] Edit a trip from a non-Sellado route to Rosario → Buenos Aires (user past free-trip threshold) — update succeeds, trip moves to `awaiting_payment`, MercadoPago redirect URL is returned.
- [ ] Edit a paid-route trip back to a non-Sellado route — payment state clears without error.
- [ ] Create a new Sellado-required trip — still works as before.