### PR TITLE
Sellado tweaks

### DIFF
--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -499,15 +499,7 @@ class TripRepository
             $trips->whereUserId($data['user_id']);
         }
 
-        // In the list, unpaid sellado trips are visible only to their owner (including for admins)
-        $trips->where(function ($q) use ($user) {
-            if ($user) {
-                $q->where('user_id', $user->id);
-            }
-            $q->orWhere('needs_sellado', '=', 0)
-                ->orWhereNull('needs_sellado')
-                ->orWhere('state', '=', Trip::STATE_READY);
-        });
+        $this->applyUnpaidSelladoVisibilityFilter($trips, $user);
 
         if ($user && ! $user->is_admin) {
             $trips->where(function ($q) use ($user) {
@@ -620,6 +612,19 @@ class TripRepository
                 $q->where('id', DB::Raw('(select max(`id`) from trips_points where trip_id = `trips`.`id`)'));
             }
             $q->whereRaw('sin_lat * '.$sin_lat.' + cos_lat * '.$cos_lat.' *  (cos_lng * '.$cos_lng.' + sin_lng * '.$sin_lng.') > '.$dist);
+        });
+    }
+
+    private function applyUnpaidSelladoVisibilityFilter($trips, $user): void
+    {
+        // In the list, unpaid sellado trips are visible only to their owner (including for admins)
+        $trips->where(function ($q) use ($user) {
+            if ($user) {
+                $q->where('user_id', $user->id);
+            }
+            $q->orWhere('needs_sellado', '=', 0)
+                ->orWhereNull('needs_sellado')
+                ->orWhere('state', '=', Trip::STATE_READY);
         });
     }
 

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -500,14 +500,14 @@ class TripRepository
         }
 
         // In the list, unpaid sellado trips are visible only to their owner (including for admins)
-        if ($user) {
-            $trips->where(function ($q) use ($user) {
-                $q->where('user_id', $user->id)
-                    ->orWhere('needs_sellado', '=', 0)
-                    ->orWhereNull('needs_sellado')
-                    ->orWhere('state', '=', Trip::STATE_READY);
-            });
-        }
+        $trips->where(function ($q) use ($user) {
+            if ($user) {
+                $q->where('user_id', $user->id);
+            }
+            $q->orWhere('needs_sellado', '=', 0)
+                ->orWhereNull('needs_sellado')
+                ->orWhere('state', '=', Trip::STATE_READY);
+        });
 
         if ($user && ! $user->is_admin) {
             $trips->where(function ($q) use ($user) {

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -1910,21 +1910,54 @@ class TripRepositoryTest extends TestCase
         $this->assertTrue($historyIds->contains($pastNonWeekly->id));
     }
 
-    public function test_search_with_null_user_does_not_apply_owner_sellado_visibility_guard(): void
+    public function test_search_with_null_user_hides_unpaid_sellado_trips(): void
     {
-        // Mutation intent: preserve `if ($user)` guard before unpaid-sellado visibility filter.
-        // Kills: ffe21dba8f63af4a.
         $restricted = Trip::factory()->create([
             'trip_date' => Carbon::now()->addDay(),
             'friendship_type_id' => Trip::PRIVACY_PUBLIC,
             'state' => Trip::STATE_AWAITING_PAYMENT,
             'needs_sellado' => 1,
         ]);
+        $visible = Trip::factory()->create([
+            'trip_date' => Carbon::now()->addDay(),
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+        ]);
 
         $page = $this->repo()->search(null, ['page' => 1, 'page_size' => 20]);
         $ids = collect($page->items())->pluck('id');
 
-        $this->assertTrue($ids->contains($restricted->id));
+        $this->assertFalse($ids->contains($restricted->id));
+        $this->assertTrue($ids->contains($visible->id));
+    }
+
+    public function test_search_admin_hides_other_users_unpaid_sellado_trips(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+        $owner = User::factory()->create();
+
+        $otherUnpaid = Trip::factory()->create([
+            'user_id' => $owner->id,
+            'trip_date' => Carbon::now()->addDay(),
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_AWAITING_PAYMENT,
+            'needs_sellado' => 1,
+        ]);
+        $otherReady = Trip::factory()->create([
+            'user_id' => $owner->id,
+            'trip_date' => Carbon::now()->addDay(),
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'state' => Trip::STATE_READY,
+            'needs_sellado' => 0,
+        ]);
+
+        $page = $this->repo()->search($admin, ['is_admin' => 'true', 'page' => 1, 'page_size' => 20]);
+        $ids = collect($page->items())->pluck('id');
+
+        $this->assertFalse($ids->contains($otherUnpaid->id));
+        $this->assertTrue($ids->contains($otherReady->id));
     }
 
     public function test_search_user_scope_keeps_owner_unpaid_trip_and_hides_other_unpaid_trip(): void


### PR DESCRIPTION
## Summary

Sellado-related visibility and UX fixes across trip search, trip cards, ongoing trip card, and invite-friends flow.

### Backend (`carpoolear_backend` — `sellado-tweaks`)

**Cause:** The unpaid-sellado filter in `TripRepository::search()` only ran when a user was logged in (`if ($user)`). Anonymous users on `/trips` could see trips awaiting sellado payment.

**Fix:** Apply the unpaid-sellado visibility filter for all users. Public listings only show trips that are paid/ready (`needs_sellado = 0`, null, or `state = ready`); trip owners still see their own unpaid trips. Extracted `applyUnpaidSelladoVisibilityFilter()`.

## Test plan

- [ ] Logged out on `/trips`: unpaid sellado trips hidden; paid sellado trips look normal
- [ ] Trip owner: unpaid trip shows sellado pending styling; paid trip does not
- [ ] Ongoing trip card: neutral rating icon aligned with thumbs up/down
- [ ] Trip detail (owner, unpaid sellado): invite friends disabled with tooltip; enabled after payment
- [ ] Backend: `php artisan test`
- [ ] Frontend: `npm run lint` + sellado-related unit tests