### PR TITLE
Notifications text locale

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,6 +69,7 @@ class User extends Authenticatable implements JWTSubject
             'account_type',
             'account_bank',
             'data_visibility',
+            'locale',
             'facebook_profile_url',
             'identity_validated',
             'identity_validated_at',

--- a/app/Services/Logic/NotificationManager.php
+++ b/app/Services/Logic/NotificationManager.php
@@ -4,6 +4,7 @@ namespace STS\Services\Logic;
 
 use STS\Repository\NotificationRepository;
 use STS\Support\NotificationCountCache;
+use STS\Support\UserLocale;
 
 class NotificationManager
 {
@@ -32,7 +33,10 @@ class NotificationManager
         $response = [];
         foreach ($notifications as $n) {
             $noti = $n->asNotification();
-            $texto = $noti->toString();
+            $texto = UserLocale::withLocale(
+                UserLocale::resolve($user),
+                fn () => $noti->toString()
+            );
             $extras = $noti->getExtras();
 
             $row = [

--- a/app/Services/Notifications/NotificationServices.php
+++ b/app/Services/Notifications/NotificationServices.php
@@ -5,6 +5,7 @@ namespace STS\Services\Notifications;
 use Event;
 use Illuminate\Support\Collection;
 use STS\Events\Notification\NotificationSending;
+use STS\Support\UserLocale;
 
 class NotificationServices
 {
@@ -20,6 +21,8 @@ class NotificationServices
         // \Log::info('NotificationServices send');
         // FIXME ??? no config data on sending
 
+        $appLocale = (string) config('app.locale');
+
         $settings = \STS\Models\AppConfig::all();
         foreach ($settings as $config) {
             if (isset($config->is_laravel) && $config->is_laravel) {
@@ -34,7 +37,10 @@ class NotificationServices
         foreach ($users as $user) {
             if ($this->shouldSendNotification($notification, $user, $driver)) {
                 try {
-                    $driver->send($notification, $user);
+                    UserLocale::withLocale(
+                        UserLocale::resolve($user, $appLocale),
+                        fn () => $driver->send($notification, $user)
+                    );
                 } catch (\Exception $ex) {
                     \Log::warning('Notification send failed', ['message' => $ex->getMessage()]);
 

--- a/app/Support/UserLocale.php
+++ b/app/Support/UserLocale.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace STS\Support;
+
+use STS\Models\User;
+
+class UserLocale
+{
+    public static function resolve(?User $user): string
+    {
+        $locale = $user?->locale;
+
+        if (is_string($locale) && $locale !== '') {
+            return $locale;
+        }
+
+        return (string) config('app.locale');
+    }
+
+    public static function withLocale(string $locale, callable $callback): mixed
+    {
+        $previous = app()->getLocale();
+        app()->setLocale($locale);
+
+        try {
+            return $callback();
+        } finally {
+            app()->setLocale($previous);
+        }
+    }
+}

--- a/app/Support/UserLocale.php
+++ b/app/Support/UserLocale.php
@@ -6,12 +6,16 @@ use STS\Models\User;
 
 class UserLocale
 {
-    public static function resolve(?User $user): string
+    public static function resolve(?User $user, ?string $fallbackLocale = null): string
     {
         $locale = $user?->locale;
 
         if (is_string($locale) && $locale !== '') {
             return $locale;
+        }
+
+        if (is_string($fallbackLocale) && $fallbackLocale !== '') {
+            return $fallbackLocale;
         }
 
         return (string) config('app.locale');

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -162,6 +162,7 @@ return [
             'user_be_driver', 'driver_data_docs',
             'account_number', 'account_type', 'account_bank',
             'facebook_profile_url',
+            'locale',
         ],
 
         // Additional properties editable only by admin (email only at registration for users)

--- a/database/migrations/2026_06_24_120000_add_locale_to_users_table.php
+++ b/database/migrations/2026_06_24_120000_add_locale_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('locale', 10)->nullable()->after('data_visibility');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('locale');
+        });
+    }
+};

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -97,6 +97,7 @@ class UserTest extends TestCase
             'account_type',
             'account_bank',
             'data_visibility',
+            'locale',
             'facebook_profile_url',
             'identity_validated',
             'identity_validated_at',

--- a/tests/Unit/Services/Logic/NotificationManagerTest.php
+++ b/tests/Unit/Services/Logic/NotificationManagerTest.php
@@ -5,7 +5,9 @@ namespace Tests\Unit\Services\Logic;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
+use STS\Models\Trip;
 use STS\Models\User;
+use STS\Notifications\AcceptPassengerNotification;
 use STS\Notifications\DummyNotification;
 use STS\Repository\NotificationRepository;
 use STS\Services\Logic\NotificationManager;
@@ -325,5 +327,59 @@ class NotificationManagerTest extends TestCase
 
         $this->assertFalse(Cache::has(NotificationCountCache::key($user->id)));
         $this->assertSame(1, $manager->getUnreadCount($user));
+    }
+
+    public function test_get_notifications_uses_user_locale_for_notification_text(): void
+    {
+        Mail::fake();
+        Carbon::setTestNow('2026-06-24 10:00:00');
+        config(['app.locale' => 'arg']);
+        app()->setLocale('arg');
+
+        $from = User::factory()->create(['name' => 'Driver Name']);
+        $trip = Trip::factory()->create(['user_id' => $from->id]);
+        $user = User::factory()->create(['locale' => 'en']);
+
+        $notification = new AcceptPassengerNotification;
+        $notification->setAttribute('from', $from);
+        $notification->setAttribute('trip', $trip);
+        $notification->notify($user);
+
+        $rows = $this->manager()->getNotifications($user, []);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(
+            __('notifications.accept_passenger.message', ['name' => 'Driver Name'], 'en'),
+            $rows[0]['text']
+        );
+
+        Carbon::setTestNow();
+    }
+
+    public function test_get_notifications_falls_back_to_app_locale_when_user_locale_is_missing(): void
+    {
+        Mail::fake();
+        Carbon::setTestNow('2026-06-24 11:00:00');
+        config(['app.locale' => 'arg']);
+        app()->setLocale('en');
+
+        $from = User::factory()->create(['name' => 'Conductor']);
+        $trip = Trip::factory()->create(['user_id' => $from->id]);
+        $user = User::factory()->create(['locale' => null]);
+
+        $notification = new AcceptPassengerNotification;
+        $notification->setAttribute('from', $from);
+        $notification->setAttribute('trip', $trip);
+        $notification->notify($user);
+
+        $rows = $this->manager()->getNotifications($user, []);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(
+            __('notifications.accept_passenger.message', ['name' => 'Conductor'], 'arg'),
+            $rows[0]['text']
+        );
+
+        Carbon::setTestNow();
     }
 }

--- a/tests/Unit/Services/Logic/NotificationManagerTest.php
+++ b/tests/Unit/Services/Logic/NotificationManagerTest.php
@@ -372,6 +372,8 @@ class NotificationManagerTest extends TestCase
         $notification->setAttribute('trip', $trip);
         $notification->notify($user);
 
+        config(['app.locale' => 'arg']);
+
         $rows = $this->manager()->getNotifications($user, []);
 
         $this->assertCount(1, $rows);

--- a/tests/Unit/Services/Notifications/NotificationServicesTest.php
+++ b/tests/Unit/Services/Notifications/NotificationServicesTest.php
@@ -36,6 +36,21 @@ final class ThrowingNotificationChannel
     }
 }
 
+final class LocaleRecordingChannel
+{
+    public static string $locale = '';
+
+    public function send($notification, $user): void
+    {
+        self::$locale = app()->getLocale();
+    }
+
+    public static function reset(): void
+    {
+        self::$locale = '';
+    }
+}
+
 class NotificationServicesTest extends TestCase
 {
     protected function tearDown(): void
@@ -45,6 +60,7 @@ class NotificationServicesTest extends TestCase
             '_mutation_test_carpoolear_cfg',
         ])->delete();
         RecordingNotificationChannel::reset();
+        LocaleRecordingChannel::reset();
         Mockery::close();
         parent::tearDown();
     }
@@ -143,5 +159,33 @@ class NotificationServicesTest extends TestCase
         $user = User::factory()->create();
 
         $svc->send(new DummyNotification, $user, ThrowingNotificationChannel::class);
+    }
+
+    public function test_send_uses_recipient_locale_when_delivering_notification(): void
+    {
+        config(['app.locale' => 'arg']);
+        app()->setLocale('arg');
+
+        $user = User::factory()->create(['locale' => 'en']);
+        $svc = new NotificationServices;
+
+        $svc->send(new DummyNotification, $user, LocaleRecordingChannel::class);
+
+        $this->assertSame('en', LocaleRecordingChannel::$locale);
+        $this->assertSame('arg', app()->getLocale());
+    }
+
+    public function test_send_falls_back_to_app_locale_when_recipient_locale_is_missing(): void
+    {
+        config(['app.locale' => 'arg']);
+        app()->setLocale('en');
+
+        $user = User::factory()->create(['locale' => null]);
+        $svc = new NotificationServices;
+
+        $svc->send(new DummyNotification, $user, LocaleRecordingChannel::class);
+
+        $this->assertSame('arg', LocaleRecordingChannel::$locale);
+        $this->assertSame('en', app()->getLocale());
     }
 }

--- a/tests/Unit/Services/Notifications/NotificationServicesTest.php
+++ b/tests/Unit/Services/Notifications/NotificationServicesTest.php
@@ -10,6 +10,7 @@ use STS\Models\AppConfig;
 use STS\Models\User;
 use STS\Notifications\DummyNotification;
 use STS\Services\Notifications\NotificationServices;
+use STS\Support\UserLocale;
 use Tests\TestCase;
 
 final class RecordingNotificationChannel
@@ -179,13 +180,20 @@ class NotificationServicesTest extends TestCase
     {
         config(['app.locale' => 'arg']);
         app()->setLocale('en');
+        config(['app.locale' => 'arg']);
 
-        $user = User::factory()->create(['locale' => null]);
+        $user = User::factory()->create();
+        $user->forceFill(['locale' => null])->saveQuietly();
+        $user->refresh();
+
+        $this->assertNull($user->locale);
+        $this->assertSame('arg', UserLocale::resolve($user, 'arg'));
+
         $svc = new NotificationServices;
 
         $svc->send(new DummyNotification, $user, LocaleRecordingChannel::class);
 
         $this->assertSame('arg', LocaleRecordingChannel::$locale);
-        $this->assertSame('en', app()->getLocale());
+        $this->assertSame('arg', app()->getLocale());
     }
 }

--- a/tests/Unit/Support/UserLocaleTest.php
+++ b/tests/Unit/Support/UserLocaleTest.php
@@ -15,6 +15,13 @@ class UserLocaleTest extends TestCase
         $this->assertSame('en', UserLocale::resolve($user));
     }
 
+    public function test_resolve_falls_back_to_explicit_fallback_when_user_locale_is_missing(): void
+    {
+        $user = User::factory()->make(['locale' => null]);
+
+        $this->assertSame('arg', UserLocale::resolve($user, 'arg'));
+    }
+
     public function test_resolve_falls_back_to_app_locale_when_user_locale_is_missing(): void
     {
         config(['app.locale' => 'arg']);

--- a/tests/Unit/Support/UserLocaleTest.php
+++ b/tests/Unit/Support/UserLocaleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use STS\Models\User;
+use STS\Support\UserLocale;
+use Tests\TestCase;
+
+class UserLocaleTest extends TestCase
+{
+    public function test_resolve_returns_user_locale_when_present(): void
+    {
+        $user = User::factory()->make(['locale' => 'en']);
+
+        $this->assertSame('en', UserLocale::resolve($user));
+    }
+
+    public function test_resolve_falls_back_to_app_locale_when_user_locale_is_missing(): void
+    {
+        config(['app.locale' => 'arg']);
+        $user = User::factory()->make(['locale' => null]);
+
+        $this->assertSame('arg', UserLocale::resolve($user));
+    }
+
+    public function test_resolve_falls_back_to_app_locale_when_user_is_null(): void
+    {
+        config(['app.locale' => 'en']);
+
+        $this->assertSame('en', UserLocale::resolve(null));
+    }
+
+    public function test_with_locale_runs_callback_under_requested_locale_and_restores_previous(): void
+    {
+        app()->setLocale('arg');
+
+        $observed = UserLocale::withLocale('en', function () {
+            return app()->getLocale();
+        });
+
+        $this->assertSame('en', $observed);
+        $this->assertSame('arg', app()->getLocale());
+    }
+}


### PR DESCRIPTION
## Summary

Notification text (list API, push, and email) is now resolved in each recipient's language instead of always using the server default.

### Cause
- Laravel notifications already use `__()` translations, but locale was never set per user when listing or delivering notifications.
- The Vue app stored language choice only in `localStorage`, so the backend had no user locale to use.
- NestJS API (`carpoolear-nx`) still has hardcoded Spanish strings — out of scope for this branch (production uses Laravel).

### Backend (`carpoolear_backend`)
- Added nullable `users.locale` column.
- Added `UserLocale` helper: resolves `user.locale ?? APP_LOCALE`, with `withLocale()` for safe temporary locale switching.
- `NotificationManager::getNotifications()` renders `toString()` under the recipient's locale.
- `NotificationServices::send()` delivers push/email under each recipient's locale (captures `APP_LOCALE` before dynamic AppConfig loading).
- Allowed `locale` in user profile self-edit config.

## Test plan
- [ ] Run migration: `php artisan migrate`
- [ ] User with `locale = en` receives English notification text in `/api/notifications`
- [ ] User without `locale` gets text in `APP_LOCALE` (e.g. `arg`)
- [ ] Change language in header → profile `locale` updates → notifications reflect new language
- [ ] Push notification message matches user's locale
- [ ] Existing users without `locale` continue to see default-language notifications