### PR TITLE
Punto de partida/llegada - edit

### DIFF
--- a/tests/Feature/Http/TripControllerIntegrationTest.php
+++ b/tests/Feature/Http/TripControllerIntegrationTest.php
@@ -471,6 +471,53 @@ class TripControllerIntegrationTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_show_returns_punto_partida_and_punto_llegada_for_edit_prefill(): void
+    {
+        $owner = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $owner->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'punto_partida' => 'Terminal de Ómnibus',
+            'punto_llegada' => 'Plaza Principal',
+        ]);
+
+        $this->actingAs($owner, 'api')
+            ->getJson("/api/trips/{$trip->id}")
+            ->assertOk()
+            ->assertJsonPath('data.punto_partida', 'Terminal de Ómnibus')
+            ->assertJsonPath('data.punto_llegada', 'Plaza Principal');
+    }
+
+    public function test_update_persists_punto_partida_and_punto_llegada_and_returns_them_in_payload(): void
+    {
+        Carbon::setTestNow('2028-04-01 12:00:00');
+        $owner = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $owner->id,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'trip_date' => Carbon::parse('2028-05-15 10:00:00'),
+            'punto_partida' => 'Barrio Centro',
+            'punto_llegada' => 'Barrio Norte',
+        ]);
+
+        $this->actingAs($owner, 'api')
+            ->putJson("/api/trips/{$trip->id}", [
+                'punto_partida' => 'Terminal de Ómnibus',
+                'punto_llegada' => 'Plaza Principal',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.punto_partida', 'Terminal de Ómnibus')
+            ->assertJsonPath('data.punto_llegada', 'Plaza Principal');
+
+        $this->assertDatabaseHas('trips', [
+            'id' => $trip->id,
+            'punto_partida' => 'Terminal de Ómnibus',
+            'punto_llegada' => 'Plaza Principal',
+        ]);
+
+        Carbon::setTestNow();
+    }
+
     public function test_update_persists_rear_max_two_passengers_and_returns_it_in_payload(): void
     {
         Carbon::setTestNow('2028-04-01 12:00:00');


### PR DESCRIPTION
## Summary

Pre-fill **punto de partida** and **punto de llegada** (barrio / punto de encuentro público) when editing a trip, and auto-fill them inverted on return trips.

## Cause

- **Edit:** The form had the fields but restoration was inline and not covered by dedicated tests; behavior was fragile and easy to miss.
- **Return trip:** Outbound origin/destination were mirrored when selecting locations, but `punto_partida` / `punto_llegada` were never swapped onto the return trip.

## Fix

### Backend (`carpoolear_backend`)

- No functional changes required — API already exposes and persists `punto_partida` / `punto_llegada`
- Added integration tests:
  - `GET /api/trips/{id}` returns both fields for edit prefill
  - `PUT /api/trips/{id}` persists and returns updated values

## Test plan

- [ ] Edit an existing trip with saved punto partida/llegada → fields pre-filled in the form
- [ ] Create a trip with return trip enabled → return punto partida = outbound punto llegada (and vice versa)
- [ ] Change outbound punto fields with return trip enabled → return fields update inverted
- [ ] Save edited trip → punto values persist after reload