### PR TITLE
Manual identity admin changes

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\SupportTicket;
+use STS\Models\User;
 use STS\Services\ManualIdentityValidationReviewNotifier;
 use STS\Services\UserIdentityVerificationSuccessService;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -147,22 +148,11 @@ class ManualIdentityValidationController extends Controller
         $item->review_note = $validated['note'] ?? '';
         $item->save();
 
-        $user = $item->user;
-        if ($validated['action'] === 'approve') {
-            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
-        } else {
-            // Reject or Pending: clear identity validation flags and metadata
-            $user->identity_validated = false;
-            $user->identity_validated_at = null;
-            $user->identity_validation_type = null;
-            $user->identity_validation_rejected_at = null;
-            $user->identity_validation_reject_reason = null;
-            $user->save();
-        }
+        $this->syncUserIdentityForReviewStatus($item->review_status, $item->user);
 
         if (in_array($validated['action'], ['approve', 'reject'], true)) {
             $this->reviewNotifier->notify(
-                $user,
+                $item->user,
                 $validated['action'] === 'approve' ? 'approved' : 'rejected',
             );
         }
@@ -187,34 +177,43 @@ class ManualIdentityValidationController extends Controller
         $item = ManualIdentityValidation::with('user')->findOrFail($id);
 
         if (array_key_exists('paid', $validated)) {
-            $item->paid = (bool) $validated['paid'];
-            if ($item->paid && $item->paid_at === null) {
-                $item->paid_at = now();
-            }
+            $this->applyPaidState($item, (bool) $validated['paid']);
         }
 
         if (array_key_exists('review_status', $validated)) {
             $item->review_status = $validated['review_status'];
-            $admin = auth()->user();
-            $item->reviewed_by = $admin->id;
+            $item->reviewed_by = auth()->id();
             $item->reviewed_at = now();
-
-            $user = $item->user;
-            if ($validated['review_status'] === 'approved') {
-                app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
-            } else {
-                $user->identity_validated = false;
-                $user->identity_validated_at = null;
-                $user->identity_validation_type = null;
-                $user->identity_validation_rejected_at = null;
-                $user->identity_validation_reject_reason = null;
-                $user->save();
-            }
+            $this->syncUserIdentityForReviewStatus($validated['review_status'], $item->user);
         }
 
         $item->save();
 
         return $this->show($id);
+    }
+
+    private function applyPaidState(ManualIdentityValidation $item, bool $paid): void
+    {
+        $item->paid = $paid;
+        if ($paid && $item->paid_at === null) {
+            $item->paid_at = now();
+        }
+    }
+
+    private function syncUserIdentityForReviewStatus(string $reviewStatus, User $user): void
+    {
+        if ($reviewStatus === ManualIdentityValidation::REVIEW_STATUS_APPROVED) {
+            app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
+
+            return;
+        }
+
+        $user->identity_validated = false;
+        $user->identity_validated_at = null;
+        $user->identity_validation_type = null;
+        $user->identity_validation_rejected_at = null;
+        $user->identity_validation_reject_reason = null;
+        $user->save();
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -168,16 +168,25 @@ class ManualIdentityValidationController extends Controller
         $validated = $request->validate([
             'review_status' => 'sometimes|in:pending,approved,rejected',
             'paid' => 'sometimes|boolean',
+            'photos_submitted' => 'sometimes|boolean',
         ]);
 
-        if (! array_key_exists('review_status', $validated) && ! array_key_exists('paid', $validated)) {
-            return response()->json(['error' => 'At least one of review_status or paid is required'], 422);
+        if (
+            ! array_key_exists('review_status', $validated) &&
+            ! array_key_exists('paid', $validated) &&
+            ! array_key_exists('photos_submitted', $validated)
+        ) {
+            return response()->json(['error' => 'At least one of review_status, paid, or photos_submitted is required'], 422);
         }
 
         $item = ManualIdentityValidation::with('user')->findOrFail($id);
 
         if (array_key_exists('paid', $validated)) {
             $this->applyPaidState($item, (bool) $validated['paid']);
+        }
+
+        if (array_key_exists('photos_submitted', $validated)) {
+            $this->applyPhotosSubmittedState($item, (bool) $validated['photos_submitted']);
         }
 
         if (array_key_exists('review_status', $validated)) {
@@ -197,6 +206,31 @@ class ManualIdentityValidationController extends Controller
         $item->paid = $paid;
         if ($paid && $item->paid_at === null) {
             $item->paid_at = now();
+        }
+    }
+
+    private function applyPhotosSubmittedState(ManualIdentityValidation $item, bool $photosSubmitted): void
+    {
+        if ($photosSubmitted) {
+            if ($item->submitted_at === null) {
+                $item->submitted_at = now();
+            }
+
+            return;
+        }
+
+        $item->submitted_at = null;
+        $this->deleteStoredPhotos($item);
+    }
+
+    private function deleteStoredPhotos(ManualIdentityValidation $item): void
+    {
+        foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $col) {
+            $path = $item->$col;
+            if ($path && Storage::disk('local')->exists($path)) {
+                Storage::disk('local')->delete($path);
+            }
+            $item->$col = null;
         }
     }
 
@@ -239,13 +273,7 @@ class ManualIdentityValidationController extends Controller
     {
         $item = ManualIdentityValidation::findOrFail($id);
 
-        foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $col) {
-            $path = $item->$col;
-            if ($path && Storage::disk('local')->exists($path)) {
-                Storage::disk('local')->delete($path);
-            }
-            $item->$col = null;
-        }
+        $this->deleteStoredPhotos($item);
         $item->images_purged_at = now();
         $item->save();
 

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -171,6 +171,53 @@ class ManualIdentityValidationController extends Controller
     }
 
     /**
+     * POST /api/admin/manual-identity-validations/{id}/state - admin override for review_status and paid.
+     */
+    public function updateState(Request $request, int $id): JsonResponse
+    {
+        $validated = $request->validate([
+            'review_status' => 'sometimes|in:pending,approved,rejected',
+            'paid' => 'sometimes|boolean',
+        ]);
+
+        if (! array_key_exists('review_status', $validated) && ! array_key_exists('paid', $validated)) {
+            return response()->json(['error' => 'At least one of review_status or paid is required'], 422);
+        }
+
+        $item = ManualIdentityValidation::with('user')->findOrFail($id);
+
+        if (array_key_exists('paid', $validated)) {
+            $item->paid = (bool) $validated['paid'];
+            if ($item->paid && $item->paid_at === null) {
+                $item->paid_at = now();
+            }
+        }
+
+        if (array_key_exists('review_status', $validated)) {
+            $item->review_status = $validated['review_status'];
+            $admin = auth()->user();
+            $item->reviewed_by = $admin->id;
+            $item->reviewed_at = now();
+
+            $user = $item->user;
+            if ($validated['review_status'] === 'approved') {
+                app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
+            } else {
+                $user->identity_validated = false;
+                $user->identity_validated_at = null;
+                $user->identity_validation_type = null;
+                $user->identity_validation_rejected_at = null;
+                $user->identity_validation_reject_reason = null;
+                $user->save();
+            }
+        }
+
+        $item->save();
+
+        return $this->show($id);
+    }
+
+    /**
      * POST /api/admin/manual-identity-validations/{id}/private-note - set nullable private_admin_note (admin-only context).
      */
     public function updatePrivateNote(Request $request, int $id): JsonResponse

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -166,7 +166,7 @@ class ManualIdentityValidationController extends Controller
     public function updateState(Request $request, int $id): JsonResponse
     {
         $validated = $request->validate([
-            'review_status' => 'sometimes|in:pending,approved,rejected',
+            'review_status' => 'sometimes|in:pending,awaiting_photos,approved,rejected',
             'paid' => 'sometimes|boolean',
             'photos_submitted' => 'sometimes|boolean',
         ]);
@@ -203,10 +203,13 @@ class ManualIdentityValidationController extends Controller
 
     private function applyPaidState(ManualIdentityValidation $item, bool $paid): void
     {
-        $item->paid = $paid;
-        if ($paid && $item->paid_at === null) {
-            $item->paid_at = now();
+        if ($paid) {
+            $item->markPaidAndAwaitingPhotosIfNeeded();
+
+            return;
         }
+
+        $item->paid = false;
     }
 
     private function applyPhotosSubmittedState(ManualIdentityValidation $item, bool $photosSubmitted): void
@@ -215,12 +218,14 @@ class ManualIdentityValidationController extends Controller
             if ($item->submitted_at === null) {
                 $item->submitted_at = now();
             }
+            $item->markPendingReview();
 
             return;
         }
 
         $item->submitted_at = null;
         $this->deleteStoredPhotos($item);
+        $item->markAwaitingPhotos();
     }
 
     private function deleteStoredPhotos(ManualIdentityValidation $item): void

--- a/app/Http/Controllers/Api/v1/ManualValidationPaymentController.php
+++ b/app/Http/Controllers/Api/v1/ManualValidationPaymentController.php
@@ -25,8 +25,7 @@ class ManualValidationPaymentController extends Controller
         if ($requestId) {
             $validationRequest = ManualIdentityValidation::find($requestId);
             if ($validationRequest && $result === 'success') {
-                $validationRequest->paid = true;
-                $validationRequest->paid_at = now();
+                $validationRequest->markPaidAndAwaitingPhotosIfNeeded();
                 if ($paymentId !== null && $paymentId !== '') {
                     $validationRequest->payment_id = (string) $paymentId;
                 }

--- a/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
@@ -701,9 +701,8 @@ class MercadoPagoWebhookController extends Controller
         $status = $mpPayment['status'] ?? '';
         if ($status === 'approved') {
             if (! $validationRequest->paid) {
-                $validationRequest->paid = true;
-                $validationRequest->paid_at = now();
                 $validationRequest->payment_id = (string) $mpPayment['id'];
+                $validationRequest->markPaidAndAwaitingPhotosIfNeeded();
                 $validationRequest->save();
             }
         }

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -11,6 +11,8 @@ class ManualIdentityValidation extends Model
 
     const REVIEW_STATUS_PENDING = 'pending';
 
+    const REVIEW_STATUS_AWAITING_PHOTOS = 'awaiting_photos';
+
     const REVIEW_STATUS_APPROVED = 'approved';
 
     const REVIEW_STATUS_REJECTED = 'rejected';
@@ -60,6 +62,27 @@ class ManualIdentityValidation extends Model
     public function hasImages(): bool
     {
         return ! empty($this->front_image_path) || ! empty($this->back_image_path) || ! empty($this->selfie_image_path);
+    }
+
+    public function markAwaitingPhotos(): void
+    {
+        $this->review_status = self::REVIEW_STATUS_AWAITING_PHOTOS;
+    }
+
+    public function markPendingReview(): void
+    {
+        $this->review_status = self::REVIEW_STATUS_PENDING;
+    }
+
+    public function markPaidAndAwaitingPhotosIfNeeded(): void
+    {
+        $this->paid = true;
+        if ($this->paid_at === null) {
+            $this->paid_at = now();
+        }
+        if ($this->submitted_at === null) {
+            $this->markAwaitingPhotos();
+        }
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -232,8 +232,8 @@ class User extends Authenticatable implements JWTSubject
     public function donations()
     {
         $donations = $this->hasMany("STS\Models\Donation", 'user_id');
-        $donations->where('month', '<=', date('Y-m-t 23:59:59'));
-        $donations->where('month', '>=', date('Y-m-01 00:00:00'));
+        $donations->where('month', '<=', now()->format('Y-m-t 23:59:59'));
+        $donations->where('month', '>=', now()->format('Y-m-01 00:00:00'));
 
         return $donations;
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -275,6 +275,7 @@ Route::middleware(['api'])->group(function () {
         Route::get('manual-identity-validations/{id}/image/{type}', [AdminManualIdentityValidationController::class, 'image'])->where('type', 'front|back|selfie');
         Route::get('manual-identity-validations/{id}', [AdminManualIdentityValidationController::class, 'show']);
         Route::post('manual-identity-validations/{id}/review', [AdminManualIdentityValidationController::class, 'review']);
+        Route::post('manual-identity-validations/{id}/state', [AdminManualIdentityValidationController::class, 'updateState']);
         Route::post('manual-identity-validations/{id}/private-note', [AdminManualIdentityValidationController::class, 'updatePrivateNote']);
         Route::post('manual-identity-validations/{id}/purge', [AdminManualIdentityValidationController::class, 'purge']);
 

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -523,7 +523,9 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
 
         $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
             'photos_submitted' => false,
-        ])->assertOk()->assertJsonPath('data.submitted_at', null);
+        ])->assertOk()
+            ->assertJsonPath('data.submitted_at', null)
+            ->assertJsonPath('data.review_status', ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS);
 
         $this->assertFalse(Storage::disk('local')->exists($front));
         $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
@@ -548,7 +550,9 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
 
         $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
             'photos_submitted' => true,
-        ])->assertOk()->assertJsonPath('data.submitted_at', fn ($value) => $value !== null);
+        ])->assertOk()
+            ->assertJsonPath('data.submitted_at', fn ($value) => $value !== null)
+            ->assertJsonPath('data.review_status', ManualIdentityValidation::REVIEW_STATUS_PENDING);
 
         $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
         $this->assertNotNull($fresh->submitted_at);

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -502,6 +502,58 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         ])->assertOk();
     }
 
+    public function test_update_state_clearing_photos_submitted_nulls_date_and_deletes_files(): void
+    {
+        Storage::fake('local');
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $front = 'idv/state-clear-front.jpg';
+        Storage::disk('local')->put($front, 'x');
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now()->subDay(),
+            'front_image_path' => $front,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'photos_submitted' => false,
+        ])->assertOk()->assertJsonPath('data.submitted_at', null);
+
+        $this->assertFalse(Storage::disk('local')->exists($front));
+        $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
+        $this->assertNull($fresh->submitted_at);
+        $this->assertNull($fresh->front_image_path);
+    }
+
+    public function test_update_state_setting_photos_submitted_sets_submitted_at(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => null,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'photos_submitted' => true,
+        ])->assertOk()->assertJsonPath('data.submitted_at', fn ($value) => $value !== null);
+
+        $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
+        $this->assertNotNull($fresh->submitted_at);
+    }
+
     public function test_update_state_sets_paid_and_paid_at_when_marking_paid(): void
     {
         $admin = $this->admin();

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -502,6 +502,80 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         ])->assertOk();
     }
 
+    public function test_update_state_sets_paid_and_paid_at_when_marking_paid(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'paid_at' => null,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'paid' => true,
+        ])->assertOk()->assertJsonPath('data.paid', true);
+
+        $fresh = ManualIdentityValidation::query()->findOrFail($row->id);
+        $this->assertTrue($fresh->paid);
+        $this->assertNotNull($fresh->paid_at);
+    }
+
+    public function test_update_state_reject_clears_user_identity(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+            'identity_validation_type' => 'manual',
+        ]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'review_status' => 'rejected',
+        ])->assertOk()->assertJsonPath('data.review_status', 'rejected');
+
+        $user->refresh();
+        $this->assertFalse((bool) $user->identity_validated);
+        $this->assertNull($user->identity_validated_at);
+        $this->assertNull($user->identity_validation_type);
+    }
+
+    public function test_update_state_does_not_notify_user(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) {
+            $mock->shouldReceive('send')->never();
+        });
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'review_status' => 'approved',
+        ])->assertOk();
+    }
+
     public function test_update_state_sets_review_status_and_syncs_user_on_approve(): void
     {
         $admin = $this->admin();

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -502,6 +502,29 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         ])->assertOk();
     }
 
+    public function test_update_state_sets_review_status_and_syncs_user_on_approve(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create(['identity_validated' => false]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'review_status' => 'approved',
+        ])->assertOk()->assertJsonPath('data.review_status', 'approved');
+
+        $user->refresh();
+        $this->assertTrue((bool) $user->identity_validated);
+        $this->assertSame('manual', (string) $user->identity_validation_type);
+    }
+
     public function test_show_includes_support_tickets_count_for_user(): void
     {
         $admin = $this->admin();

--- a/tests/Feature/Http/ManualValidationPaymentControllerTest.php
+++ b/tests/Feature/Http/ManualValidationPaymentControllerTest.php
@@ -70,6 +70,7 @@ class ManualValidationPaymentControllerTest extends TestCase
         $this->assertTrue((bool) $fresh->paid);
         $this->assertNotNull($fresh->paid_at);
         $this->assertSame('mp-555', $fresh->payment_id);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS, $fresh->review_status);
     }
 
     public function test_success_uses_collection_id_when_payment_id_is_absent(): void

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -105,8 +105,37 @@ class ManualIdentityValidationTest extends TestCase
     public function test_review_status_string_constants(): void
     {
         $this->assertSame('pending', ManualIdentityValidation::REVIEW_STATUS_PENDING);
+        $this->assertSame('awaiting_photos', ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS);
         $this->assertSame('approved', ManualIdentityValidation::REVIEW_STATUS_APPROVED);
         $this->assertSame('rejected', ManualIdentityValidation::REVIEW_STATUS_REJECTED);
+    }
+
+    public function test_mark_paid_and_awaiting_photos_if_needed_sets_status_only_before_submission(): void
+    {
+        $user = User::factory()->create();
+        $awaiting = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $awaiting->markPaidAndAwaitingPhotosIfNeeded();
+        $awaiting->save();
+
+        $this->assertTrue($awaiting->fresh()->paid);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS, $awaiting->fresh()->review_status);
+
+        $submitted = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $submitted->markPaidAndAwaitingPhotosIfNeeded();
+        $submitted->save();
+
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $submitted->fresh()->review_status);
     }
 
     public function test_table_name_is_manual_identity_validations(): void


### PR DESCRIPTION
## Summary

Adds admin tools and clearer lifecycle states for manual identity verification: admins can override paid/review/photos-submitted fields, confirm no-op “mark pending” actions, and both users and admins see an explicit **Esperando fotos** state after payment until documents are uploaded.

## Cause

Manual verification had several admin/UX gaps:

- Paid users without a successful upload looked like generic “pending” requests, with no explicit **Esperando fotos** state.
- Admins could not correct payment/submission/review fields from the detail page.
- Marking an already-pending request as pending again had no warning.
- **Fecha de envío** / **Fotos enviadas** could be out of sync with actual stored photos and review queue state.

## Backend

### Fix
- New admin endpoint: `POST /api/admin/manual-identity-validations/{id}/state`
  - Supports `paid`, `photos_submitted`, and `review_status`
  - Syncs user identity on review changes (without notifications)
- New review status: `awaiting_photos`
  - Set automatically when payment succeeds and no documents were submitted yet
  - Set when admin saves **Fotos enviadas = No** (clears `submitted_at`, deletes stored photos)
  - Moves back to `pending` when photos are submitted (user upload or admin **Fotos enviadas = Sí**)
- Shared model helpers: `markPaidAndAwaitingPhotosIfNeeded()`, `markAwaitingPhotos()`, `markPendingReview()`
- Payment success + Mercado Pago webhook now set `awaiting_photos` after marking paid
- Photo deletion logic deduplicated between purge and state updates

### Tests
- Integration tests for state updates, payment redirect, and model transitions
- TDD commits: red → green → refactor


## Test plan

- [ ] Pay for manual verification → admin list/detail shows **Esperando fotos**, user sees upload prompt with that status
- [ ] Upload 3 photos → status becomes **Pendiente de revisión**, `submitted_at` populated
- [ ] Admin sets **Fotos enviadas = No** → photos deleted, `submitted_at` cleared, status **Esperando fotos**
- [ ] Admin sets **Fotos enviadas = Sí** on unpaid submission → `submitted_at` set, status **Pendiente**
- [ ] Click **Marcar como pendiente** on already-pending request → confirmation dialog appears
- [ ] Approve/reject review actions still notify user; admin `/state` overrides do not