### PR TITLE
Send iOS push notifications through Firebase

### DIFF
--- a/app/Services/Notifications/Channels/PushChannel.php
+++ b/app/Services/Notifications/Channels/PushChannel.php
@@ -152,37 +152,34 @@ class PushChannel
     public function sendIOS($device, $data)
     {
         try {
-            // Create APNs payload
-            $payload = [
-                'aps' => [
-                    'alert' => [
-                        'title' => isset($data['title']) ? $data['title'] : 'Carpoolear',
-                        'body' => $data['message'],
-                    ],
-                    'sound' => 'default',
-                    'badge' => 1,
-                ],
+            $firebase = $this->makeFirebaseService();
+
+            $device_token = $device->device_id;
+
+            $message = [
+                'title' => isset($data['title']) ? $data['title'] : 'Carpoolear',
+                'body' => $data['message'],
+                'sound' => 'default',
             ];
 
-            // Add custom data at root level (not inside aps) so Capacitor can access it
+            $dataPayload = [];
             if (isset($data['type'])) {
-                $payload['type'] = (string) $data['type'];
+                $dataPayload['type'] = (string) $data['type'];
             }
             if (isset($data['extras'])) {
                 foreach ($data['extras'] as $key => $value) {
-                    $payload[$key] = (string) $value;
+                    $dataPayload[$key] = (string) $value;
                 }
             }
             if (isset($data['url'])) {
-                $payload['url'] = (string) $data['url'];
+                $dataPayload['url'] = (string) $data['url'];
             }
 
-            // Send via APNs
-            $result = $this->sendAPNsNotification($device->device_id, $payload);
+            $result = $firebase->sendNotification($device_token, $message, $dataPayload, 'ios');
 
             return $result;
         } catch (\Exception $e) {
-            if (! self::isApnsStaleTokenError($e)) {
+            if (! FirebaseService::isStaleRegistrationTokenError($e)) {
                 \Log::error('PushChannel: sendIOS error', [
                     'device_id' => $device->id,
                     'device_token' => $device->device_id,

--- a/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
+++ b/tests/Unit/Services/Notifications/Channels/PushChannelTest.php
@@ -84,6 +84,41 @@ class PushChannelTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function test_send_ios_uses_firebase_service_with_expected_payload(): void
+    {
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->withArgs(function (string $token, array $message, array $data, string $platform): bool {
+                return $token === 'ios-direct-token'
+                    && $platform === 'ios'
+                    && $message['title'] === 'Title I'
+                    && $message['body'] === 'Body I'
+                    && $message['sound'] === 'default'
+                    && $data['type'] === 'conversation'
+                    && $data['conversation_id'] === '24'
+                    && $data['url'] === 'https://example.com/ios';
+            })
+            ->andReturn(['ok' => true]);
+
+        $channel = new PushChannel(fn () => $firebase);
+        $device = new Device([
+            'id' => 5002,
+            'device_id' => 'ios-direct-token',
+            'device_type' => 'ios',
+        ]);
+
+        $result = $channel->sendIOS($device, [
+            'message' => 'Body I',
+            'title' => 'Title I',
+            'type' => 'conversation',
+            'extras' => ['conversation_id' => 24],
+            'url' => 'https://example.com/ios',
+        ]);
+
+        $this->assertSame(['ok' => true], $result);
+    }
+
     public function test_send_skips_push_pipeline_when_device_notifications_disabled(): void
     {
         Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
@@ -306,10 +341,9 @@ class PushChannelTest extends TestCase
         $this->assertNotSame('', (string) ($ctx['error'] ?? ''));
     }
 
-    public function test_send_logs_ios_inner_and_outer_errors_when_apns_certificate_missing(): void
+    public function test_send_logs_ios_inner_and_outer_errors_when_firebase_send_throws(): void
     {
         Config::set('carpoolear.send_push_notifications_to_device_activity_days', 0);
-        Config::set('push-notification.ios.certificate', base_path('nonexistent-apns-cert-'.uniqid('', true).'.pem'));
 
         $logged = [];
         Log::shouldReceive('error')
@@ -317,11 +351,17 @@ class PushChannelTest extends TestCase
             ->andReturnUsing(function (string $message, array $context = []) use (&$logged): void {
                 $logged[] = ['message' => $message, 'context' => $context];
             });
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+
+        $firebase = Mockery::mock(FirebaseService::class);
+        $firebase->shouldReceive('sendNotification')
+            ->once()
+            ->andThrow($this->fcmInternalErrorException());
 
         $user = User::factory()->create();
         $device = Device::query()->create([
             'user_id' => $user->id,
-            'device_id' => str_repeat('a', 64),
+            'device_id' => 'ios-error-token',
             'device_type' => 'ios',
             'session_id' => 's-ios',
             'notifications' => true,
@@ -334,14 +374,14 @@ class PushChannelTest extends TestCase
         $notification->setAttribute('message', 'Hello ios');
         $notification->setAttribute('title', 'TI');
 
-        (new PushChannel)->send($notification, $user);
+        (new PushChannel(fn () => $firebase))->send($notification, $user);
 
         $inner = $this->firstLogMatching($logged, 'PushChannel: sendIOS error');
         $this->assertNotNull($inner, 'Expected sendIOS catch to log before rethrowing.');
         $ictx = $inner['context'];
         $this->assertSame($device->id, $ictx['device_id']);
         $this->assertSame($device->device_id, $ictx['device_token']);
-        $this->assertStringContainsString('APNs certificate not found', (string) ($ictx['error'] ?? ''));
+        $this->assertStringContainsString('Internal error', (string) ($ictx['error'] ?? ''));
 
         $outer = $this->firstLogMatching($logged, 'PushChannel: Error sending push notification');
         $this->assertNotNull($outer);


### PR DESCRIPTION
## Summary
- switch backend iOS push delivery from the legacy direct APNs path to Firebase/FCM
- keep Android and browser delivery unchanged while aligning iOS with the FCM token now registered by the app
- replace the old APNs certificate-based unit expectations with Firebase-backed iOS delivery tests

## Context
The iOS app now stores Firebase registration tokens instead of raw APNs device tokens. Firebase Console delivery to the device already works, but backend delivery was still using the direct APNs path in `PushChannel::sendIOS()`, which expects a 64-character APNs token and therefore could not deliver to devices registered with FCM tokens.

## Test plan
- [x] Run `php artisan test tests/Unit/Services/Notifications/Channels/PushChannelTest.php`
- [x] Deploy backend branch
- [x] Reinstall or relogin on iOS app if needed so the device row keeps the latest FCM token
- [x] Trigger a backend-generated notification to an iOS device and confirm it arrives
- [x] Confirm Android and browser push delivery still work unchanged

## Follow-up notes
- No backend APNs certificate update is required for this app push path after this change because iOS delivery now goes through Firebase like Android and web
- Existing Firebase project credentials must still be valid in the backend environment