### PR TITLE
Stop counting answered seat requests in trip limit

### DIFF
--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -223,17 +223,24 @@ class UserRepository
 
     public function unansweredConversationOrRequestsByTrip($userId, $tripId)
     {
-        // todas las request que pertenezcan a un viaje mio y que esten pendientes
-        $pendingRequests = Passenger::with('trip')
+        return $this->countPendingRequestsByTripOwner($userId, $tripId)
+            + $this->countUnansweredConversationsByTripOwner($userId, $tripId);
+    }
+
+    private function countPendingRequestsByTripOwner($userId, $tripId): int
+    {
+        return Passenger::with('trip')
             ->where('trip_id', $tripId)
             ->whereHas('trip', function ($q) use ($userId) {
                 $q->where('user_id', $userId);
             })
             ->where('request_state', Passenger::STATE_PENDING)
             ->count();
+    }
 
-        // conversaciones que no tegan mensajes mios (respuestas)
-        $unasweredConversations = Conversation::where('trip_id', $tripId)
+    private function countUnansweredConversationsByTripOwner($userId, $tripId): int
+    {
+        return Conversation::where('trip_id', $tripId)
             ->whereDoesntHave('messages', function ($query) use ($userId) {
                 $query->where('user_id', $userId);
             })
@@ -245,7 +252,5 @@ class UserRepository
                     });
             })
             ->count();
-
-        return $pendingRequests + $unasweredConversations;
     }
 }

--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -237,6 +237,13 @@ class UserRepository
             ->whereDoesntHave('messages', function ($query) use ($userId) {
                 $query->where('user_id', $userId);
             })
+            ->whereDoesntHave('users', function ($query) use ($tripId, $userId) {
+                $query->where('users.id', '<>', $userId)
+                    ->whereHas('passenger', function ($passengerQuery) use ($tripId) {
+                        $passengerQuery->where('trip_id', $tripId)
+                            ->where('request_state', '<>', Passenger::STATE_PENDING);
+                    });
+            })
             ->count();
 
         return $pendingRequests + $unasweredConversations;

--- a/tests/Unit/Repository/UserRepositoryTest.php
+++ b/tests/Unit/Repository/UserRepositoryTest.php
@@ -661,6 +661,31 @@ class UserRepositoryTest extends TestCase
         $this->assertSame(1, $after);
     }
 
+    public function test_unanswered_conversation_or_requests_by_trip_ignores_unanswered_conversation_when_same_passenger_request_was_answered(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+        $conversation = Conversation::factory()->create(['trip_id' => $trip->id]);
+        $conversation->users()->attach($driver->id, ['read' => true, 'notifications_enabled' => true]);
+        $conversation->users()->attach($passenger->id, ['read' => true, 'notifications_enabled' => true]);
+        Message::create([
+            'user_id' => $passenger->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Can you confirm the pickup point?',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+
+        $count = $this->repo()->unansweredConversationOrRequestsByTrip($driver->id, $trip->id);
+
+        $this->assertSame(0, $count);
+    }
+
     public function test_unanswered_conversation_or_requests_by_trip_returns_zero_when_none(): void
     {
         // Mutation intent: both `count()` branches (~195–208) zero — no pending passenger rows, no qualifying conversations.


### PR DESCRIPTION
## Summary
- Fix trip seat-request limit counting so unanswered conversations no longer count when the same passenger already has a non-pending seat request on that trip.
- Add a regression test for the case where a driver answers a seat request but has not replied in chat.
- Refactor the limit counter into separate pending-request and unanswered-conversation helpers.

## Cause
The limit counted pending seat requests and unanswered trip conversations independently. If a passenger had both, answering the seat request removed the pending request from the count, but the related conversation still counted until the driver sent a chat message.

## Fix
In `UserRepository`, unanswered trip conversations are now excluded when the other participant already has a non-pending seat request on the same trip (accepted, rejected, canceled, waiting payment, etc.).

## Test plan
- [x] `php artisan test tests/Unit/Repository/UserRepositoryTest.php --filter=unanswered_conversation_or_requests_by_trip`
- [x] Full backend suite: `php artisan test` (3284 passed)
- [x] Frontend lint and build (no frontend changes; sanity check only)