### PR TITLE
Mandatory rating tweaks

### DIFF
--- a/app/Repository/RatingRepository.php
+++ b/app/Repository/RatingRepository.php
@@ -77,6 +77,13 @@ class RatingRepository
         $ratings->where('voted', false);
         $ratings->with(['from', 'to', 'trip']);
         $ratings->where('created_at', '>=', Carbon::Now()->subDays(RatingModel::RATING_INTERVAL));
+        $ratings->whereNotExists(function ($query) use ($user) {
+            $query->select(DB::raw(1))
+                ->from('rating as prior_ratings')
+                ->whereColumn('prior_ratings.user_id_to', 'rating.user_id_to')
+                ->where('prior_ratings.user_id_from', $user->id)
+                ->where('prior_ratings.voted', true);
+        });
 
         return $ratings->get();
     }

--- a/app/Repository/RatingRepository.php
+++ b/app/Repository/RatingRepository.php
@@ -77,15 +77,42 @@ class RatingRepository
         $ratings->where('voted', false);
         $ratings->with(['from', 'to', 'trip']);
         $ratings->where('created_at', '>=', Carbon::Now()->subDays(RatingModel::RATING_INTERVAL));
-        $ratings->whereNotExists(function ($query) use ($user) {
-            $query->select(DB::raw(1))
-                ->from('rating as prior_ratings')
-                ->whereColumn('prior_ratings.user_id_to', 'rating.user_id_to')
-                ->where('prior_ratings.user_id_from', $user->id)
-                ->where('prior_ratings.voted', true);
-        });
+        $this->applyExcludeAlreadyRatedUsers($ratings, $user->id);
 
         return $ratings->get();
+    }
+
+    public function isMandatoryPendingRating(RatingModel $rating): bool
+    {
+        if ($rating->voted) {
+            return false;
+        }
+
+        if ($rating->created_at->lt(Carbon::Now()->subDays(RatingModel::RATING_INTERVAL))) {
+            return false;
+        }
+
+        return ! $this->hasPriorVoteForPair($rating->user_id_from, $rating->user_id_to);
+    }
+
+    public function hasPriorVoteForPair(int $fromId, int $toId): bool
+    {
+        return RatingModel::query()
+            ->where('user_id_from', $fromId)
+            ->where('user_id_to', $toId)
+            ->where('voted', true)
+            ->exists();
+    }
+
+    private function applyExcludeAlreadyRatedUsers($query, int $userId): void
+    {
+        $query->whereNotExists(function ($subquery) use ($userId) {
+            $subquery->select(DB::raw(1))
+                ->from('rating as prior_ratings')
+                ->whereColumn('prior_ratings.user_id_to', 'rating.user_id_to')
+                ->where('prior_ratings.user_id_from', $userId)
+                ->where('prior_ratings.voted', true);
+        });
     }
 
     public function find($id)

--- a/app/Services/Logic/RatingManager.php
+++ b/app/Services/Logic/RatingManager.php
@@ -84,7 +84,7 @@ class RatingManager extends BaseManager
         $response = [];
         $rates = $this->ratingRepository->findBy('voted_hash', $hash);
         foreach ($rates as $rate) {
-            if (! $rate->voted && $rate->created_at->addDays(Rating::RATING_INTERVAL)->gte(Carbon::now())) {
+            if ($this->ratingRepository->isMandatoryPendingRating($rate)) {
                 $response[] = $rate;
             }
         }

--- a/tests/Feature/Http/RatingApiTest.php
+++ b/tests/Feature/Http/RatingApiTest.php
@@ -277,6 +277,72 @@ class RatingApiTest extends TestCase
         $this->assertContains($pending->id, $ids);
     }
 
+    public function test_pending_omits_repeat_user_when_voter_already_rated_them(): void
+    {
+        Carbon::setTestNow('2026-06-15 12:00:00');
+        $voter = User::factory()->create(['active' => true, 'banned' => false]);
+        $alreadyRated = User::factory()->create(['active' => true, 'banned' => false]);
+        $firstTime = User::factory()->create(['active' => true, 'banned' => false]);
+
+        $priorTrip = Trip::factory()->create(['user_id' => $alreadyRated->id]);
+        $this->persistRating([
+            'trip_id' => $priorTrip->id,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $alreadyRated->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => Rating::STATE_POSITIVO,
+            'comment' => 'ok',
+            'reply_comment' => '',
+            'voted' => true,
+            'voted_hash' => 'prior-vote',
+            'rate_at' => Carbon::now(),
+            'available' => 0,
+        ]);
+
+        $repeatTrip = Trip::factory()->create(['user_id' => $alreadyRated->id]);
+        $repeatPending = $this->persistRating([
+            'trip_id' => $repeatTrip->id,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $alreadyRated->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => null,
+            'comment' => '',
+            'reply_comment' => '',
+            'voted' => false,
+            'voted_hash' => 'repeat-pending',
+            'rate_at' => null,
+            'available' => 0,
+        ]);
+
+        $firstTrip = Trip::factory()->create(['user_id' => $firstTime->id]);
+        $mandatoryPending = $this->persistRating([
+            'trip_id' => $firstTrip->id,
+            'user_id_from' => $voter->id,
+            'user_id_to' => $firstTime->id,
+            'user_to_type' => Passenger::TYPE_PASAJERO,
+            'user_to_state' => Passenger::STATE_ACCEPTED,
+            'rating' => null,
+            'comment' => '',
+            'reply_comment' => '',
+            'voted' => false,
+            'voted_hash' => 'first-pending',
+            'rate_at' => null,
+            'available' => 0,
+        ]);
+
+        $this->actingAs($voter, 'api');
+
+        $response = $this->getJson('api/users/ratings/pending');
+        $response->assertOk();
+        $ids = array_column($response->json('data'), 'id');
+        $this->assertNotContains($repeatPending->id, $ids);
+        $this->assertContains($mandatoryPending->id, $ids);
+
+        Carbon::setTestNow();
+    }
+
     public function test_pending_as_guest_without_hash_is_rejected(): void
     {
         $this->getJson('api/users/ratings/pending')

--- a/tests/Unit/Repository/RatingRepositoryTest.php
+++ b/tests/Unit/Repository/RatingRepositoryTest.php
@@ -318,6 +318,31 @@ class RatingRepositoryTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_get_pending_ratings_excludes_repeat_user_when_already_rated_them(): void
+    {
+        Carbon::setTestNow('2026-06-15 12:00:00');
+        $user = User::factory()->create();
+        $alreadyRated = User::factory()->create();
+        $firstTime = User::factory()->create();
+        $repo = new RatingRepository;
+
+        $priorTrip = Trip::factory()->create(['user_id' => $alreadyRated->id]);
+        $this->seedRating($user, $alreadyRated, $priorTrip);
+
+        $repeatTrip = Trip::factory()->create(['user_id' => $alreadyRated->id]);
+        $repo->create($user->id, $alreadyRated->id, $repeatTrip->id, 0, 0, 'repeat-'.uniqid('', true));
+
+        $firstTrip = Trip::factory()->create(['user_id' => $firstTime->id]);
+        $mandatory = $repo->create($user->id, $firstTime->id, $firstTrip->id, 0, 0, 'first-'.uniqid('', true));
+
+        $listed = $repo->getPendingRatings($user);
+
+        $this->assertCount(1, $listed);
+        $this->assertTrue($listed->first()->is($mandatory));
+
+        Carbon::setTestNow();
+    }
+
     public function test_get_ratings_filters_available_and_value_when_page_size_null(): void
     {
         $driver = User::factory()->create();

--- a/tests/Unit/Repository/RatingRepositoryTest.php
+++ b/tests/Unit/Repository/RatingRepositoryTest.php
@@ -298,6 +298,7 @@ class RatingRepositoryTest extends TestCase
         Carbon::setTestNow('2026-06-15 12:00:00');
         $user = User::factory()->create();
         $other = User::factory()->create();
+        $votedOther = User::factory()->create();
         $trip = Trip::factory()->create(['user_id' => $other->id]);
         $repo = new RatingRepository;
 
@@ -305,7 +306,7 @@ class RatingRepositoryTest extends TestCase
         $old = $repo->create($user->id, $other->id, $trip->id, 0, 0, 'r2-'.uniqid('', true));
         $old->forceFill(['created_at' => '2026-05-01 00:00:00'])->saveQuietly();
         // Must be excluded by where('voted', false).
-        $voted = $repo->create($user->id, $other->id, $trip->id, 0, 0, 'r3-'.uniqid('', true));
+        $voted = $repo->create($user->id, $votedOther->id, $trip->id, 0, 0, 'r3-'.uniqid('', true));
         $voted->forceFill(['voted' => true])->saveQuietly();
 
         $listed = $repo->getPendingRatings($user);

--- a/tests/Unit/Services/Logic/RatingManagerTest.php
+++ b/tests/Unit/Services/Logic/RatingManagerTest.php
@@ -119,6 +119,37 @@ class RatingManagerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function test_get_pending_ratings_by_hash_excludes_repeat_user_when_already_rated_them(): void
+    {
+        Carbon::setTestNow('2026-10-01 12:00:00');
+        $user = User::factory()->create();
+        $alreadyRated = User::factory()->create();
+        $firstTime = User::factory()->create();
+        $repo = new RatingRepository;
+
+        $priorTrip = Trip::factory()->create(['user_id' => $alreadyRated->id]);
+        Rating::factory()->create([
+            'trip_id' => $priorTrip->id,
+            'user_id_from' => $user->id,
+            'user_id_to' => $alreadyRated->id,
+            'rating' => Rating::STATE_POSITIVO,
+            'voted' => true,
+        ]);
+
+        $hash = 'batch-'.uniqid('', true);
+        $repeatTrip = Trip::factory()->create(['user_id' => $alreadyRated->id]);
+        $repo->create($user->id, $alreadyRated->id, $repeatTrip->id, 0, 0, $hash);
+
+        $firstTrip = Trip::factory()->create(['user_id' => $firstTime->id]);
+        $mandatory = $repo->create($user->id, $firstTime->id, $firstTrip->id, 0, 0, $hash);
+
+        $collection = $this->manager()->getPendingRatingsByHash($hash);
+        $this->assertCount(1, $collection);
+        $this->assertTrue($collection->first()->is($mandatory));
+
+        Carbon::setTestNow();
+    }
+
     public function test_get_rate_returns_pending_rating_for_user_within_interval(): void
     {
         Carbon::setTestNow('2026-11-05 10:00:00');


### PR DESCRIPTION
## Summary

Only enforce mandatory rating submission when it is the **first time** a user is rating another person. Repeat trip ratings for someone already rated are no longer returned as pending, so they no longer block normal app usage.

## Cause

The pending-ratings enforcement treated every open rating as mandatory. After a user had already rated someone once, a new trip with that same person still appeared in `/api/users/ratings/pending` and triggered the frontend redirect/blocking logic (same pattern as incomplete profile).

## Fix

### Backend
- `RatingRepository::getPendingRatings()` excludes pending rows when the voter already has a `voted = true` rating for the same `user_id_to`.
- `RatingManager::getPendingRatingsByHash()` applies the same rule for guest/email hash flows.
- Extracted shared helpers: `isMandatoryPendingRating()`, `hasPriorVoteForPair()`, `applyExcludeAlreadyRatedUsers()`.

### Frontend
- No code changes. Existing enforcement (`requirePendingRatingsSubmission`, `$redirectToMyTripsIfPendingRatingsRequired`, `PendingRatingsBanner`) already relies on the pending API response.

## Test plan
- [ ] User with a pending rating for someone they **never** rated before → blocked from restricted routes, banner shown, redirected to Mis viajes.
- [ ] User with a pending rating for someone they **already** rated on a prior trip → can browse/create trips, chat, etc. normally.
- [ ] Guest pending-ratings link with hash → same mandatory/optional behavior.
- [ ] First-time pending ratings still appear in Mis viajes and can be submitted.