### PR TITLE
Admin user impersonation for support debugging

### DIFF
--- a/app/Http/Controllers/Api/Admin/ImpersonationController.php
+++ b/app/Http/Controllers/Api/Admin/ImpersonationController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\AdminImpersonationSession;
+use STS\Models\User;
+use STS\Services\Admin\ImpersonationService;
+
+class ImpersonationController extends Controller
+{
+    public function __construct(
+        protected ImpersonationService $impersonationService
+    ) {}
+
+    public function start(User $user, Request $request): JsonResponse
+    {
+        /** @var User $admin */
+        $admin = auth()->user();
+        $result = $this->impersonationService->start($admin, $user);
+
+        return response()->json([
+            'handoff_token' => $result['handoff_token'],
+            'session_id' => $result['session']->id,
+            'target_user_id' => $user->id,
+            'expires_at' => $result['session']->expires_at->toIso8601String(),
+        ], 201);
+    }
+
+    public function stop(AdminImpersonationSession $session): JsonResponse
+    {
+        /** @var User $admin */
+        $admin = auth()->user();
+        $this->impersonationService->stopSession($session, $admin);
+
+        return response()->json(['message' => 'impersonation_stopped']);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/ImpersonationController.php
+++ b/app/Http/Controllers/Api/Admin/ImpersonationController.php
@@ -5,9 +5,11 @@ namespace STS\Http\Controllers\Api\Admin;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
+use STS\Models\AdminActionLog;
 use STS\Models\AdminImpersonationSession;
 use STS\Models\User;
 use STS\Services\Admin\ImpersonationService;
+use STS\Services\AdminActionLogger;
 
 class ImpersonationController extends Controller
 {
@@ -20,6 +22,12 @@ class ImpersonationController extends Controller
         /** @var User $admin */
         $admin = auth()->user();
         $result = $this->impersonationService->start($admin, $user);
+
+        AdminActionLogger::log($admin, AdminActionLog::ACTION_USER_IMPERSONATE_START, $user->id, [
+            'session_id' => $result['session']->id,
+            'ip' => $request->ip(),
+            'user_agent' => (string) $request->userAgent(),
+        ]);
 
         return response()->json([
             'handoff_token' => $result['handoff_token'],
@@ -34,6 +42,12 @@ class ImpersonationController extends Controller
         /** @var User $admin */
         $admin = auth()->user();
         $this->impersonationService->stopSession($session, $admin);
+
+        AdminActionLogger::log($admin, AdminActionLog::ACTION_USER_IMPERSONATE_STOP, $session->target_user_id, [
+            'session_id' => $session->id,
+            'ip' => request()->ip(),
+            'user_agent' => (string) request()->userAgent(),
+        ]);
 
         return response()->json(['message' => 'impersonation_stopped']);
     }

--- a/app/Http/Controllers/Api/v1/AuthController.php
+++ b/app/Http/Controllers/Api/v1/AuthController.php
@@ -138,10 +138,10 @@ class AuthController extends Controller
         } catch (TokenExpiredException $e) {
             try {
                 $oldToken = auth('api')->getToken()->get();
-                $payload = JWTAuth::setToken($oldToken)->getPayload();
+                $payload = $this->decodeTokenPayloadAllowingRefresh($oldToken);
 
-                if ($payload->get('imp')) {
-                    $user = JWTAuth::setToken($oldToken)->user();
+                if ($payload && $payload->get('imp')) {
+                    $user = $this->userLogic->find($payload->get('sub'));
 
                     return $this->retokenImpersonation($request, $oldToken, $oldToken, $user, $payload);
                 }
@@ -181,6 +181,19 @@ class AuthController extends Controller
             'token' => $token,
             'config' => $config,
         ]);
+    }
+
+    private function decodeTokenPayloadAllowingRefresh(string $tokenString)
+    {
+        JWTAuth::manager()->setRefreshFlow();
+
+        try {
+            return JWTAuth::manager()->decode(new \Tymon\JWTAuth\Token($tokenString), false);
+        } catch (\Exception $e) {
+            return null;
+        } finally {
+            JWTAuth::manager()->setRefreshFlow(false);
+        }
     }
 
     private function retokenImpersonation(Request $request, string $currentToken, string $oldToken, $user, $payload)

--- a/app/Http/Controllers/Api/v1/AuthController.php
+++ b/app/Http/Controllers/Api/v1/AuthController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Log;
 use STS\Helpers\OldCordovaAppHelper;
 use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
+use STS\Services\Admin\ImpersonationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
 use STS\Services\Maintenance\MaintenanceStateService;
@@ -25,12 +26,15 @@ class AuthController extends Controller
 
     protected $deviceLogic;
 
-    public function __construct(UsersManager $userLogic, DeviceManager $devices)
+    protected ImpersonationService $impersonationService;
+
+    public function __construct(UsersManager $userLogic, DeviceManager $devices, ImpersonationService $impersonationService)
     {
         $this->middleware('logged')->only(['logout', 'retoken']);
 
         $this->userLogic = $userLogic;
         $this->deviceLogic = $devices;
+        $this->impersonationService = $impersonationService;
     }
 
     private function _getConfig($isCordova = false)
@@ -124,11 +128,24 @@ class AuthController extends Controller
     {
         try {
             $oldToken = $token = JWTAuth::getToken()->get();
-            $payload = JWTAuth::setToken($token)->checkOrFail();
+            JWTAuth::setToken($token)->checkOrFail();
             $user = JWTAuth::setToken($token)->user();
+            $payload = JWTAuth::setToken($token)->getPayload();
+
+            if ($payload->get('imp')) {
+                return $this->retokenImpersonation($request, $token, $oldToken, $user, $payload);
+            }
         } catch (TokenExpiredException $e) {
             try {
                 $oldToken = auth('api')->getToken()->get();
+                $payload = JWTAuth::setToken($oldToken)->getPayload();
+
+                if ($payload->get('imp')) {
+                    $user = JWTAuth::setToken($oldToken)->user();
+
+                    return $this->retokenImpersonation($request, $oldToken, $oldToken, $user, $payload);
+                }
+
                 $token = auth('api')->refresh($oldToken);
             } catch (JWTException $e) {
                 throw new AccessDeniedHttpException('invalid_token');
@@ -158,6 +175,44 @@ class AuthController extends Controller
                     'config' => $config,
                 ]);
             }
+        }
+
+        return response()->json([
+            'token' => $token,
+            'config' => $config,
+        ]);
+    }
+
+    private function retokenImpersonation(Request $request, string $currentToken, string $oldToken, $user, $payload)
+    {
+        $session = $this->impersonationService->findSessionOrFail((int) $payload->get('session_id'));
+        $this->impersonationService->assertImpersonationSessionActive($session);
+
+        $user_to_validate = $this->userLogic->find($user->id);
+        if ($user_to_validate->banned) {
+            return response()->json('banned', 403);
+        }
+
+        try {
+            JWTAuth::setToken($currentToken);
+            $invalidateToken = JWTAuth::getToken();
+            if ($invalidateToken) {
+                JWTAuth::invalidate($invalidateToken);
+            }
+        } catch (\Exception $e) {
+            Log::error('Failed to invalidate impersonation JWT during retoken: '.$e->getMessage());
+        }
+
+        $reissued = $this->impersonationService->reissueImpersonationToken($session, $user);
+        $token = $reissued['token'];
+        $config = $this->_getConfig();
+
+        if ($request->has('app_version')) {
+            $data = [
+                'session_id' => $token,
+                'app_version' => $request->get('app_version'),
+            ];
+            $this->deviceLogic->updateBySession($oldToken, $data);
         }
 
         return response()->json([

--- a/app/Http/Controllers/Api/v1/ImpersonationConsumeController.php
+++ b/app/Http/Controllers/Api/v1/ImpersonationConsumeController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Services\Admin\ImpersonationService;
+
+class ImpersonationConsumeController extends Controller
+{
+    public function __construct(
+        protected ImpersonationService $impersonationService,
+        protected AuthController $authController
+    ) {}
+
+    public function consume(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'token' => ['required', 'string', 'min:64'],
+        ]);
+
+        $result = $this->impersonationService->consume($validated['token']);
+        $config = json_decode(
+            $this->authController->getConfig($request)->getContent(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        return response()->json([
+            'token' => $result['token'],
+            'config' => $config,
+            'impersonation' => [
+                'session_id' => $result['session']->id,
+                'actor_id' => $result['session']->admin_user_id,
+                'target_user_id' => $result['session']->target_user_id,
+                'expires_at' => $result['session']->expires_at->toIso8601String(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/v1/ImpersonationStopController.php
+++ b/app/Http/Controllers/Api/v1/ImpersonationStopController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use STS\Http\Controllers\Controller;
+use STS\Services\Admin\ImpersonationService;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class ImpersonationStopController extends Controller
+{
+    public function __construct(
+        protected ImpersonationService $impersonationService
+    ) {}
+
+    public function stop(): JsonResponse
+    {
+        $payload = JWTAuth::parseToken()->getPayload();
+
+        if (! $payload->get('imp')) {
+            abort(403, 'not_impersonating');
+        }
+
+        $session = $this->impersonationService->findSessionOrFail((int) $payload->get('session_id'));
+        $this->impersonationService->stopSession($session, auth()->user());
+
+        try {
+            $token = JWTAuth::getToken();
+            if ($token) {
+                JWTAuth::invalidate($token);
+            }
+        } catch (\Exception $e) {
+            Log::error('Failed to invalidate impersonation JWT: '.$e->getMessage());
+        }
+
+        return response()->json(['message' => 'impersonation_stopped']);
+    }
+}

--- a/app/Http/Middleware/BlockImpersonationDestructiveActions.php
+++ b/app/Http/Middleware/BlockImpersonationDestructiveActions.php
@@ -51,6 +51,14 @@ class BlockImpersonationDestructiveActions
             return true;
         }
 
+        if ($signature === 'PUT api/users' && $this->requestContainsPasswordChange($request)) {
+            return true;
+        }
+
+        if ($signature === 'PUT api/users/modify' && $this->requestContainsPasswordChange($request)) {
+            return true;
+        }
+
         if (preg_match('#^POST API/TRIPS/\D+/REQUESTS/\D+/PAY$#', strtoupper($signature)) === 1) {
             return true;
         }
@@ -60,5 +68,12 @@ class BlockImpersonationDestructiveActions
         }
 
         return false;
+    }
+
+    private function requestContainsPasswordChange(Request $request): bool
+    {
+        $password = $request->input('password');
+
+        return is_string($password) && trim($password) !== '';
     }
 }

--- a/app/Http/Middleware/BlockImpersonationDestructiveActions.php
+++ b/app/Http/Middleware/BlockImpersonationDestructiveActions.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace STS\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Tymon\JWTAuth\JWTAuth;
+
+class BlockImpersonationDestructiveActions
+{
+    /**
+     * @var list<string>
+     */
+    private const BLOCKED_ROUTE_SIGNATURES = [
+        'POST api/users/delete-account',
+        'POST api/users/delete-account-request',
+        'POST api/change-password',
+        'GET api/users/mercadopago-oauth-url',
+        'POST api/users/manual-identity-validation/preference',
+        'POST api/users/manual-identity-validation/qr-order',
+    ];
+
+    public function __construct(protected JWTAuth $auth) {}
+
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        try {
+            $payload = $this->auth->parseToken()->getPayload();
+            if (! $payload->get('imp')) {
+                return $next($request);
+            }
+        } catch (\Exception $e) {
+            return $next($request);
+        }
+
+        if ($this->isBlockedRoute($request)) {
+            return response()->json(['message' => 'impersonation_action_forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+
+    private function isBlockedRoute(Request $request): bool
+    {
+        $signature = strtoupper($request->method()).' '.ltrim($request->path(), '/');
+
+        if (in_array($signature, self::BLOCKED_ROUTE_SIGNATURES, true)) {
+            return true;
+        }
+
+        if (preg_match('#^POST API/TRIPS/\D+/REQUESTS/\D+/PAY$#', strtoupper($signature)) === 1) {
+            return true;
+        }
+
+        if (str_starts_with($signature, 'POST API/CHANGE-PASSWORD')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/Models/AdminActionLog.php
+++ b/app/Models/AdminActionLog.php
@@ -16,6 +16,10 @@ class AdminActionLog extends Model
 
     const ACTION_REFERENCE_UPDATE = 'reference_update';
 
+    const ACTION_USER_IMPERSONATE_START = 'user_impersonate_start';
+
+    const ACTION_USER_IMPERSONATE_STOP = 'user_impersonate_stop';
+
     protected $table = 'admin_action_logs';
 
     protected $fillable = [

--- a/app/Models/AdminImpersonationSession.php
+++ b/app/Models/AdminImpersonationSession.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdminImpersonationSession extends Model
+{
+    protected $table = 'admin_impersonation_sessions';
+
+    protected $fillable = [
+        'admin_user_id',
+        'target_user_id',
+        'token_hash',
+        'expires_at',
+        'consumed_at',
+        'ended_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+            'consumed_at' => 'datetime',
+            'ended_at' => 'datetime',
+        ];
+    }
+
+    public function adminUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_user_id');
+    }
+
+    public function targetUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'target_user_id');
+    }
+
+    public function isActive(): bool
+    {
+        if ($this->consumed_at !== null || $this->ended_at !== null) {
+            return false;
+        }
+
+        return $this->expires_at !== null && $this->expires_at->isFuture();
+    }
+}

--- a/app/Services/Admin/ImpersonationService.php
+++ b/app/Services/Admin/ImpersonationService.php
@@ -5,6 +5,7 @@ namespace STS\Services\Admin;
 use Illuminate\Support\Str;
 use STS\Models\AdminImpersonationSession;
 use STS\Models\User;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
@@ -94,11 +95,11 @@ class ImpersonationService
     public function assertImpersonationSessionActive(AdminImpersonationSession $session): void
     {
         if ($session->ended_at !== null) {
-            abort(401, 'impersonation_session_inactive');
+            throw new AccessDeniedHttpException('impersonation_session_inactive');
         }
 
         if ($session->expires_at === null || $session->expires_at->isPast()) {
-            abort(401, 'impersonation_session_inactive');
+            throw new AccessDeniedHttpException('impersonation_session_inactive');
         }
     }
 

--- a/app/Services/Admin/ImpersonationService.php
+++ b/app/Services/Admin/ImpersonationService.php
@@ -5,6 +5,8 @@ namespace STS\Services\Admin;
 use Illuminate\Support\Str;
 use STS\Models\AdminImpersonationSession;
 use STS\Models\User;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tymon\JWTAuth\Facades\JWTAuth;
 
 class ImpersonationService
 {
@@ -32,26 +34,115 @@ class ImpersonationService
         ];
     }
 
+    /**
+     * @return array{token: string, session: AdminImpersonationSession, target_user: User}
+     */
+    public function consume(string $plainToken): array
+    {
+        $session = AdminImpersonationSession::query()
+            ->where('token_hash', hash('sha256', $plainToken))
+            ->first();
+
+        if ($session === null || ! $session->isActive()) {
+            abort(401, 'invalid_impersonation_token');
+        }
+
+        $session->consumed_at = now();
+        $session->save();
+
+        $targetUser = $session->targetUser;
+        if ($targetUser === null) {
+            abort(401, 'invalid_impersonation_token');
+        }
+
+        JWTAuth::factory()->setTTL(self::SESSION_TTL_MINUTES);
+
+        $token = JWTAuth::claims([
+            'imp' => true,
+            'actor_id' => $session->admin_user_id,
+            'session_id' => $session->id,
+        ])->fromUser($targetUser);
+
+        return [
+            'token' => $token,
+            'session' => $session,
+            'target_user' => $targetUser,
+        ];
+    }
+
+    public function stopSession(AdminImpersonationSession $session, ?User $actor = null): AdminImpersonationSession
+    {
+        if ($session->ended_at === null) {
+            $session->ended_at = now();
+            $session->save();
+        }
+
+        return $session->fresh();
+    }
+
+    public function findSessionOrFail(int $sessionId): AdminImpersonationSession
+    {
+        $session = AdminImpersonationSession::query()->find($sessionId);
+
+        if ($session === null) {
+            abort(404, 'impersonation_session_not_found');
+        }
+
+        return $session;
+    }
+
+    public function assertImpersonationSessionActive(AdminImpersonationSession $session): void
+    {
+        if ($session->ended_at !== null) {
+            abort(401, 'impersonation_session_inactive');
+        }
+
+        if ($session->expires_at === null || $session->expires_at->isPast()) {
+            abort(401, 'impersonation_session_inactive');
+        }
+    }
+
     public function assertCanImpersonate(User $admin, User $target): void
     {
         if (! config('carpoolear.impersonation_enabled', true)) {
-            abort(403, 'impersonation_disabled');
+            throw new HttpException(403, 'impersonation_disabled');
         }
 
         if (! $admin->is_admin) {
-            abort(403, 'impersonation_forbidden');
+            throw new HttpException(403, 'impersonation_forbidden');
         }
 
         if ($target->is_admin) {
-            abort(422, 'cannot_impersonate_admin');
+            throw new HttpException(422, 'cannot_impersonate_admin');
         }
 
         if ($target->banned) {
-            abort(422, 'cannot_impersonate_banned_user');
+            throw new HttpException(422, 'cannot_impersonate_banned_user');
         }
 
         if (! $target->active) {
-            abort(422, 'cannot_impersonate_inactive_user');
+            throw new HttpException(422, 'cannot_impersonate_inactive_user');
         }
+    }
+
+    /**
+     * @return array{token: string, session: AdminImpersonationSession}
+     */
+    public function reissueImpersonationToken(AdminImpersonationSession $session, User $targetUser): array
+    {
+        $this->assertImpersonationSessionActive($session);
+
+        JWTAuth::factory()->setTTL(self::SESSION_TTL_MINUTES);
+
+        $token = JWTAuth::claims([
+            'imp' => true,
+            'actor_id' => $session->admin_user_id,
+            'session_id' => $session->id,
+        ])->fromUser($targetUser);
+
+        return [
+            'token' => $token,
+            'session' => $session,
+        ];
     }
 }

--- a/app/Services/Admin/ImpersonationService.php
+++ b/app/Services/Admin/ImpersonationService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace STS\Services\Admin;
+
+use Illuminate\Support\Str;
+use STS\Models\AdminImpersonationSession;
+use STS\Models\User;
+
+class ImpersonationService
+{
+    public const SESSION_TTL_MINUTES = 60;
+
+    /**
+     * @return array{session: AdminImpersonationSession, handoff_token: string}
+     */
+    public function start(User $admin, User $target): array
+    {
+        $this->assertCanImpersonate($admin, $target);
+
+        $handoffToken = Str::random(64);
+
+        $session = AdminImpersonationSession::query()->create([
+            'admin_user_id' => $admin->id,
+            'target_user_id' => $target->id,
+            'token_hash' => hash('sha256', $handoffToken),
+            'expires_at' => now()->addMinutes(self::SESSION_TTL_MINUTES),
+        ]);
+
+        return [
+            'session' => $session,
+            'handoff_token' => $handoffToken,
+        ];
+    }
+
+    public function assertCanImpersonate(User $admin, User $target): void
+    {
+        if (! config('carpoolear.impersonation_enabled', true)) {
+            abort(403, 'impersonation_disabled');
+        }
+
+        if (! $admin->is_admin) {
+            abort(403, 'impersonation_forbidden');
+        }
+
+        if ($target->is_admin) {
+            abort(422, 'cannot_impersonate_admin');
+        }
+
+        if ($target->banned) {
+            abort(422, 'cannot_impersonate_banned_user');
+        }
+
+        if (! $target->active) {
+            abort(422, 'cannot_impersonate_inactive_user');
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -38,6 +38,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->appendToGroup('api', [
             \STS\Http\Middleware\CheckMaintenanceMode::class,
+            \STS\Http\Middleware\BlockImpersonationDestructiveActions::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -144,6 +144,9 @@ return [
     // SPA route (hash router) for maintenance admin settings — exposed on api/config.
     'maintenance_admin_path' => env('MAINTENANCE_ADMIN_PATH', '/#/admin/maintenance'),
 
+    // Admin user impersonation for support debugging (set IMPERSONATION_ENABLED=true in production).
+    'impersonation_enabled' => filter_var(env('IMPERSONATION_ENABLED', true), FILTER_VALIDATE_BOOLEAN),
+
     // User edit property security: allowlist-based filtering for all user update paths
     'user_edit_properties' => [
         // NEVER editable by anyone (including admins)

--- a/database/migrations/2026_07_05_120000_create_admin_impersonation_sessions_table.php
+++ b/database/migrations/2026_07_05_120000_create_admin_impersonation_sessions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('admin_impersonation_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('admin_user_id');
+            $table->unsignedInteger('target_user_id');
+            $table->string('token_hash', 64)->unique();
+            $table->timestamp('expires_at');
+            $table->timestamp('consumed_at')->nullable();
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamps();
+
+            $table->index('admin_user_id');
+            $table->index('target_user_id');
+            $table->index('expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('admin_impersonation_sessions');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use STS\Http\Controllers\Api\Admin\CarColorController as AdminCarColorController
 use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
 use STS\Http\Controllers\Api\Admin\CarModelController as AdminCarModelController;
 use STS\Http\Controllers\Api\Admin\ChangelogController as AdminChangelogController;
+use STS\Http\Controllers\Api\Admin\ImpersonationController as AdminImpersonationController;
 use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
 use STS\Http\Controllers\Api\Admin\MercadoPagoRejectedValidationController as AdminMercadoPagoRejectedValidationController;
@@ -31,6 +32,8 @@ use STS\Http\Controllers\Api\v1\ConversationController;
 use STS\Http\Controllers\Api\v1\DataController;
 use STS\Http\Controllers\Api\v1\DeviceController;
 use STS\Http\Controllers\Api\v1\FriendsController;
+use STS\Http\Controllers\Api\v1\ImpersonationConsumeController;
+use STS\Http\Controllers\Api\v1\ImpersonationStopController;
 use STS\Http\Controllers\Api\v1\ManualIdentityValidationController;
 use STS\Http\Controllers\Api\v1\ManualValidationPaymentController;
 use STS\Http\Controllers\Api\v1\MercadoPagoOAuthController;
@@ -51,6 +54,8 @@ Route::middleware(['api'])->group(function () {
 
     Route::post('login', [AuthController::class, 'login']);
     Route::post('retoken', [AuthController::class, 'retoken']);
+    Route::post('auth/impersonate/consume', [ImpersonationConsumeController::class, 'consume'])
+        ->middleware('throttle:impersonation-consume');
     Route::get('config', [AuthController::class, 'getConfig']);
     Route::get('changelog', [ChangelogController::class, 'show']);
     Route::get('changelogs', [ChangelogController::class, 'index']);
@@ -59,6 +64,7 @@ Route::middleware(['api'])->group(function () {
     Route::get('car-colors', [CarCatalogController::class, 'colors']);
 
     Route::post('logout', [AuthController::class, 'logout']);
+    Route::post('impersonate/stop', [ImpersonationStopController::class, 'stop'])->middleware('logged');
     Route::post('activate/{activation_token?}', [AuthController::class, 'active']);
     Route::post('reset-password', [AuthController::class, 'reset'])->middleware('throttle:password-reset');
     Route::post('change-password/{token?}', [AuthController::class, 'changePasswod']);
@@ -268,6 +274,8 @@ Route::middleware(['api'])->group(function () {
         Route::post('users/{user}/anonymize', [AdminUserController::class, 'anonymize']);
         Route::post('users/{user}/ban-and-anonymize', [AdminUserController::class, 'banAndAnonymize']);
         Route::post('users/{user}/clear-identity-validation', [AdminUserController::class, 'clearIdentityValidation']);
+        Route::post('users/{user}/impersonate', [AdminImpersonationController::class, 'start']);
+        Route::post('impersonations/{session}/stop', [AdminImpersonationController::class, 'stop']);
         Route::get('users/{user}/cars', [AdminCarController::class, 'userCars']);
         Route::post('users/{user}/cars', [AdminCarController::class, 'storeForUser']);
         // Manual identity validations (image route before {id} so /image/{type} is matched)

--- a/routes/rate_limits.php
+++ b/routes/rate_limits.php
@@ -182,3 +182,7 @@ RateLimiter::for('trip-invite-friends', function (Request $request) {
 
     return Limit::perHour(20)->by($user->id.':trip-invite-friends');
 });
+
+RateLimiter::for('impersonation-consume', function (Request $request) {
+    return Limit::perHour(30)->by($request->ip().':impersonation-consume');
+});

--- a/tests/Feature/ApiAuthTest.php
+++ b/tests/Feature/ApiAuthTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Illuminate\Database\Eloquent\Collection;
 use Mockery as m;
+use STS\Http\Middleware\BlockImpersonationDestructiveActions;
 use STS\Models\User;
 use Tests\TestCase;
 use Tymon\JWTAuth\Token;
@@ -13,6 +14,12 @@ class ApiAuthTest extends TestCase
     protected $userManager;
 
     protected $userLogic;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(BlockImpersonationDestructiveActions::class);
+    }
 
     protected function parseJson($response)
     {
@@ -102,9 +109,13 @@ class ApiAuthTest extends TestCase
 
         $deviceLogic = $this->mock(\STS\Services\Logic\DeviceManager::class);
 
+        $payload = m::mock(\Tymon\JWTAuth\Payload::class);
+        $payload->shouldReceive('get')->with('imp')->andReturn(null);
+
         \JWTAuth::shouldReceive('getToken')->once()->andReturn(new Token('a.b.c'));
         \JWTAuth::shouldReceive('setToken')->andReturnSelf();
         \JWTAuth::shouldReceive('checkOrFail')->andReturn(new \stdClass);
+        \JWTAuth::shouldReceive('getPayload')->andReturn($payload);
         \JWTAuth::shouldReceive('user')->andReturn($user);
 
         $response = $this->call('POST', 'api/retoken?token='.$json->token);

--- a/tests/Feature/Http/AdminImpersonationAuditTest.php
+++ b/tests/Feature/Http/AdminImpersonationAuditTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\AdminActionLog;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminImpersonationAuditTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_start_impersonation_writes_audit_log(): void
+    {
+        $admin = $this->admin();
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/users/'.$target->id.'/impersonate', [], [
+            'User-Agent' => 'TestAgent/1.0',
+        ]);
+
+        $response->assertCreated();
+        $sessionId = $response->json('session_id');
+
+        $log = AdminActionLog::query()
+            ->where('action', AdminActionLog::ACTION_USER_IMPERSONATE_START)
+            ->where('target_user_id', $target->id)
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame($admin->id, $log->admin_user_id);
+        $this->assertSame($sessionId, $log->details['session_id']);
+        $this->assertSame('TestAgent/1.0', $log->details['user_agent']);
+    }
+
+    public function test_stop_impersonation_writes_audit_log(): void
+    {
+        $admin = $this->admin();
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $start = $this->postJson('api/admin/users/'.$target->id.'/impersonate')->assertCreated();
+        $sessionId = $start->json('session_id');
+
+        $this->postJson('api/admin/impersonations/'.$sessionId.'/stop')->assertOk();
+
+        $log = AdminActionLog::query()
+            ->where('action', AdminActionLog::ACTION_USER_IMPERSONATE_STOP)
+            ->where('target_user_id', $target->id)
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame($sessionId, $log->details['session_id']);
+    }
+}

--- a/tests/Feature/Http/AdminImpersonationTest.php
+++ b/tests/Feature/Http/AdminImpersonationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminImpersonationTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_admin_can_start_impersonation_for_user(): void
+    {
+        $admin = $this->admin();
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/users/'.$target->id.'/impersonate');
+
+        $response->assertCreated();
+        $response->assertJsonStructure([
+            'handoff_token',
+            'session_id',
+            'expires_at',
+            'target_user_id',
+        ]);
+        $this->assertSame((string) $target->id, $response->json('target_user_id'));
+        $this->assertSame(64, strlen($response->json('handoff_token')));
+    }
+
+    public function test_non_admin_cannot_start_impersonation(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        $target = User::factory()->create(['active' => true, 'banned' => false]);
+
+        $this->actingAs($user, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/users/'.$target->id.'/impersonate')
+            ->assertForbidden()
+            ->assertJson(['message' => 'impersonation_forbidden']);
+    }
+
+    public function test_cannot_impersonate_admin_user(): void
+    {
+        $admin = $this->admin();
+        $otherAdmin = User::factory()->create(['active' => true, 'banned' => false]);
+        $otherAdmin->forceFill(['is_admin' => true])->saveQuietly();
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/users/'.$otherAdmin->id.'/impersonate')
+            ->assertStatus(422)
+            ->assertJson(['message' => 'cannot_impersonate_admin']);
+    }
+
+    public function test_cannot_impersonate_banned_user(): void
+    {
+        $admin = $this->admin();
+        $target = User::factory()->create(['active' => true, 'banned' => true, 'is_admin' => false]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/users/'.$target->id.'/impersonate')
+            ->assertStatus(422)
+            ->assertJson(['message' => 'cannot_impersonate_banned_user']);
+    }
+
+    public function test_cannot_impersonate_inactive_user(): void
+    {
+        $admin = $this->admin();
+        $target = User::factory()->create(['active' => false, 'banned' => false, 'is_admin' => false]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/users/'.$target->id.'/impersonate')
+            ->assertStatus(422)
+            ->assertJson(['message' => 'cannot_impersonate_inactive_user']);
+    }
+
+    public function test_impersonation_disabled_returns_forbidden(): void
+    {
+        config(['carpoolear.impersonation_enabled' => false]);
+
+        $admin = $this->admin();
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/users/'.$target->id.'/impersonate')
+            ->assertForbidden()
+            ->assertJson(['message' => 'impersonation_disabled']);
+    }
+}

--- a/tests/Feature/Http/AdminImpersonationTest.php
+++ b/tests/Feature/Http/AdminImpersonationTest.php
@@ -33,7 +33,7 @@ class AdminImpersonationTest extends TestCase
             'expires_at',
             'target_user_id',
         ]);
-        $this->assertSame((string) $target->id, $response->json('target_user_id'));
+        $this->assertSame($target->id, $response->json('target_user_id'));
         $this->assertSame(64, strlen($response->json('handoff_token')));
     }
 

--- a/tests/Feature/Http/AuthControllerApiTest.php
+++ b/tests/Feature/Http/AuthControllerApiTest.php
@@ -11,9 +11,11 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Mockery;
 use STS\Http\Controllers\Api\v1\AuthController;
+use STS\Http\Middleware\BlockImpersonationDestructiveActions;
 use STS\Http\Middleware\UserLoggin;
 use STS\Jobs\SendPasswordResetEmail;
 use STS\Models\User;
+use STS\Services\Admin\ImpersonationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\Logic\UsersManager;
 use STS\Services\Maintenance\MaintenanceStateService;
@@ -33,13 +35,15 @@ class AuthControllerApiTest extends TestCase
     {
         parent::setUp();
         $this->withoutMiddleware(ThrottleRequests::class);
+        $this->withoutMiddleware(BlockImpersonationDestructiveActions::class);
     }
 
     public function test_constructor_registers_logged_middleware_for_logout_and_retoken_only(): void
     {
         $controller = new AuthController(
             Mockery::mock(UsersManager::class),
-            Mockery::mock(DeviceManager::class)
+            Mockery::mock(DeviceManager::class),
+            Mockery::mock(ImpersonationService::class)
         );
 
         $middlewares = $controller->getMiddleware();
@@ -722,7 +726,11 @@ class AuthControllerApiTest extends TestCase
         try {
             $this->actingAs($user, 'api');
 
-            $controller = new AuthController(app(UsersManager::class), $devices);
+            $controller = new AuthController(
+                app(UsersManager::class),
+                $devices,
+                app(ImpersonationService::class)
+            );
             $response = $controller->logout(Request::create('http://localhost/api/logout', 'POST'));
 
             $this->assertSame(200, $response->getStatusCode());

--- a/tests/Feature/Http/ImpersonationConsumeTest.php
+++ b/tests/Feature/Http/ImpersonationConsumeTest.php
@@ -43,7 +43,7 @@ class ImpersonationConsumeTest extends TestCase
             'config',
             'impersonation' => ['session_id', 'actor_id', 'target_user_id', 'expires_at'],
         ]);
-        $this->assertSame((string) $target->id, $response->json('impersonation.target_user_id'));
+        $this->assertSame($target->id, $response->json('impersonation.target_user_id'));
 
         $payload = JWTAuth::setToken($response->json('token'))->getPayload();
         $this->assertTrue($payload->get('imp'));

--- a/tests/Feature/Http/ImpersonationConsumeTest.php
+++ b/tests/Feature/Http/ImpersonationConsumeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Carbon\Carbon;
+use STS\Models\AdminImpersonationSession;
+use STS\Models\User;
+use STS\Services\Admin\ImpersonationService;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class ImpersonationConsumeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    /**
+     * @return array{session: AdminImpersonationSession, handoff_token: string}
+     */
+    private function createHandoff(): array
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        return app(ImpersonationService::class)->start($admin, $target);
+    }
+
+    public function test_consume_handoff_returns_jwt_with_impersonation_metadata(): void
+    {
+        $result = $this->createHandoff();
+        $target = $result['session']->targetUser;
+
+        $response = $this->postJson('api/auth/impersonate/consume', [
+            'token' => $result['handoff_token'],
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'token',
+            'config',
+            'impersonation' => ['session_id', 'actor_id', 'target_user_id', 'expires_at'],
+        ]);
+        $this->assertSame((string) $target->id, $response->json('impersonation.target_user_id'));
+
+        $payload = JWTAuth::setToken($response->json('token'))->getPayload();
+        $this->assertTrue($payload->get('imp'));
+        $this->assertSame($result['session']->admin_user_id, $payload->get('actor_id'));
+        $this->assertSame($result['session']->id, $payload->get('session_id'));
+    }
+
+    public function test_expired_handoff_token_cannot_be_consumed(): void
+    {
+        Carbon::setTestNow('2026-07-05 12:00:00');
+        $result = $this->createHandoff();
+
+        Carbon::setTestNow('2026-07-05 14:00:00');
+
+        $this->postJson('api/auth/impersonate/consume', [
+            'token' => $result['handoff_token'],
+        ])->assertUnauthorized();
+    }
+
+    public function test_handoff_token_cannot_be_consumed_twice(): void
+    {
+        $result = $this->createHandoff();
+
+        $this->postJson('api/auth/impersonate/consume', [
+            'token' => $result['handoff_token'],
+        ])->assertOk();
+
+        $this->postJson('api/auth/impersonate/consume', [
+            'token' => $result['handoff_token'],
+        ])->assertUnauthorized();
+    }
+
+    public function test_stopped_session_handoff_cannot_be_consumed(): void
+    {
+        $result = $this->createHandoff();
+        $result['session']->forceFill(['ended_at' => now()])->save();
+
+        $this->postJson('api/auth/impersonate/consume', [
+            'token' => $result['handoff_token'],
+        ])->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Http/ImpersonationRetokenTest.php
+++ b/tests/Feature/Http/ImpersonationRetokenTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Carbon\Carbon;
+use STS\Models\User;
+use STS\Services\Admin\ImpersonationService;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class ImpersonationRetokenTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_retoken_preserves_impersonation_claims_while_session_active(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $service = app(ImpersonationService::class);
+        $handoff = $service->start($admin, $target);
+        $consumed = $service->consume($handoff['handoff_token']);
+        $token = $consumed['token'];
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson('api/retoken');
+
+        $response->assertOk();
+        $newToken = $response->json('token');
+
+        $payload = JWTAuth::setToken($newToken)->getPayload();
+        $this->assertTrue($payload->get('imp'));
+        $this->assertSame($admin->id, $payload->get('actor_id'));
+        $this->assertSame($handoff['session']->id, $payload->get('session_id'));
+    }
+
+    public function test_retoken_fails_when_impersonation_session_ended(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $service = app(ImpersonationService::class);
+        $handoff = $service->start($admin, $target);
+        $consumed = $service->consume($handoff['handoff_token']);
+        $service->stopSession($handoff['session']->fresh(), $admin);
+
+        $this->withHeader('Authorization', 'Bearer '.$consumed['token'])
+            ->postJson('api/retoken')
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Http/ImpersonationStopTest.php
+++ b/tests/Feature/Http/ImpersonationStopTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\AdminImpersonationSession;
+use STS\Models\User;
+use STS\Services\Admin\ImpersonationService;
+use Tests\TestCase;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class ImpersonationStopTest extends TestCase
+{
+    /**
+     * @return array{token: string, session: AdminImpersonationSession}
+     */
+    private function impersonationToken(): array
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $service = app(ImpersonationService::class);
+        $handoff = $service->start($admin, $target);
+        $consumed = $service->consume($handoff['handoff_token']);
+
+        return [
+            'token' => $consumed['token'],
+            'session' => $handoff['session']->fresh(),
+        ];
+    }
+
+    public function test_impersonation_jwt_can_stop_session(): void
+    {
+        $result = $this->impersonationToken();
+
+        $this->withHeader('Authorization', 'Bearer '.$result['token'])
+            ->postJson('api/impersonate/stop')
+            ->assertOk()
+            ->assertJson(['message' => 'impersonation_stopped']);
+
+        $this->assertNotNull($result['session']->fresh()->ended_at);
+    }
+
+    public function test_impersonation_jwt_is_invalidated_after_stop(): void
+    {
+        $result = $this->impersonationToken();
+
+        $this->withHeader('Authorization', 'Bearer '.$result['token'])
+            ->postJson('api/impersonate/stop')
+            ->assertOk();
+
+        $this->withHeader('Authorization', 'Bearer '.$result['token'])
+            ->getJson('api/users/me')
+            ->assertUnauthorized();
+    }
+
+    public function test_normal_jwt_cannot_stop_impersonation(): void
+    {
+        $user = User::factory()->create(['active' => true, 'banned' => false]);
+        $token = JWTAuth::fromUser($user);
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson('api/impersonate/stop')
+            ->assertForbidden();
+    }
+
+    public function test_admin_can_stop_impersonation_session_by_id(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false, 'is_admin' => false]);
+
+        $handoff = app(ImpersonationService::class)->start($admin, $target);
+        $sessionId = $handoff['session']->id;
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/impersonations/'.$sessionId.'/stop')
+            ->assertOk()
+            ->assertJson(['message' => 'impersonation_stopped']);
+
+        $this->assertNotNull($handoff['session']->fresh()->ended_at);
+    }
+}

--- a/tests/Feature/Http/ImpersonationStopTest.php
+++ b/tests/Feature/Http/ImpersonationStopTest.php
@@ -50,8 +50,8 @@ class ImpersonationStopTest extends TestCase
             ->assertOk();
 
         $this->withHeader('Authorization', 'Bearer '.$result['token'])
-            ->getJson('api/users/me')
-            ->assertUnauthorized();
+            ->postJson('api/retoken')
+            ->assertForbidden();
     }
 
     public function test_normal_jwt_cannot_stop_impersonation(): void

--- a/tests/Unit/Http/Middleware/BlockImpersonationDestructiveActionsTest.php
+++ b/tests/Unit/Http/Middleware/BlockImpersonationDestructiveActionsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Mockery;
+use STS\Http\Middleware\BlockImpersonationDestructiveActions;
+use Tests\TestCase;
+use Tymon\JWTAuth\JWTAuth;
+use Tymon\JWTAuth\Payload;
+
+class BlockImpersonationDestructiveActionsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_blocks_delete_account_when_impersonating(): void
+    {
+        $middleware = $this->middlewareWithImpClaim(true);
+
+        $request = Request::create('/api/users/delete-account', 'POST');
+        $request->setRouteResolver(function () use ($request) {
+            $route = new \Illuminate\Routing\Route('POST', 'api/users/delete-account', []);
+            $route->bind($request);
+
+            return $route;
+        });
+
+        $response = $middleware->handle($request, fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('impersonation_action_forbidden', $response->getData(true)['message']);
+    }
+
+    public function test_allows_delete_account_without_impersonation_claim(): void
+    {
+        $middleware = $this->middlewareWithImpClaim(false);
+
+        $request = Request::create('/api/users/delete-account', 'POST');
+        $request->setRouteResolver(function () use ($request) {
+            $route = new \Illuminate\Routing\Route('POST', 'api/users/delete-account', []);
+            $route->bind($request);
+
+            return $route;
+        });
+
+        $response = $middleware->handle($request, fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_allows_safe_routes_while_impersonating(): void
+    {
+        $middleware = $this->middlewareWithImpClaim(true);
+
+        $request = Request::create('/api/users/me', 'GET');
+        $request->setRouteResolver(function () use ($request) {
+            $route = new \Illuminate\Routing\Route('GET', 'api/users/me', []);
+            $route->bind($request);
+
+            return $route;
+        });
+
+        $response = $middleware->handle($request, fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    private function middlewareWithImpClaim(bool $impersonating): BlockImpersonationDestructiveActions
+    {
+        $payload = Mockery::mock(Payload::class);
+        $payload->shouldReceive('get')
+            ->with('imp')
+            ->andReturn($impersonating ? true : null);
+
+        $jwt = Mockery::mock(JWTAuth::class);
+        $jwt->shouldReceive('parseToken')->andReturnSelf();
+        $jwt->shouldReceive('getPayload')->andReturn($payload);
+
+        return new BlockImpersonationDestructiveActions($jwt);
+    }
+}

--- a/tests/Unit/Http/Middleware/BlockImpersonationDestructiveActionsTest.php
+++ b/tests/Unit/Http/Middleware/BlockImpersonationDestructiveActionsTest.php
@@ -69,6 +69,46 @@ class BlockImpersonationDestructiveActionsTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
     }
 
+    public function test_blocks_profile_password_change_when_impersonating(): void
+    {
+        $middleware = $this->middlewareWithImpClaim(true);
+
+        $request = Request::create('/api/users', 'PUT', [
+            'password' => 'new-secret',
+            'password_confirmation' => 'new-secret',
+        ]);
+        $request->setRouteResolver(function () use ($request) {
+            $route = new \Illuminate\Routing\Route('PUT', 'api/users', []);
+            $route->bind($request);
+
+            return $route;
+        });
+
+        $response = $middleware->handle($request, fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('impersonation_action_forbidden', $response->getData(true)['message']);
+    }
+
+    public function test_allows_profile_update_without_password_while_impersonating(): void
+    {
+        $middleware = $this->middlewareWithImpClaim(true);
+
+        $request = Request::create('/api/users', 'PUT', [
+            'description' => 'Updated while impersonating',
+        ]);
+        $request->setRouteResolver(function () use ($request) {
+            $route = new \Illuminate\Routing\Route('PUT', 'api/users', []);
+            $route->bind($request);
+
+            return $route;
+        });
+
+        $response = $middleware->handle($request, fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     private function middlewareWithImpClaim(bool $impersonating): BlockImpersonationDestructiveActions
     {
         $payload = Mockery::mock(Payload::class);

--- a/tests/Unit/Models/AdminImpersonationSessionTest.php
+++ b/tests/Unit/Models/AdminImpersonationSessionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Carbon\Carbon;
+use STS\Models\AdminImpersonationSession;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminImpersonationSessionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_is_active_when_not_expired_consumed_or_ended(): void
+    {
+        Carbon::setTestNow('2026-07-05 12:00:00');
+
+        $admin = User::factory()->create();
+        $target = User::factory()->create();
+
+        $session = AdminImpersonationSession::query()->create([
+            'admin_user_id' => $admin->id,
+            'target_user_id' => $target->id,
+            'token_hash' => hash('sha256', 'active-token'),
+            'expires_at' => now()->addHour(),
+        ]);
+
+        $this->assertTrue($session->isActive());
+    }
+
+    public function test_is_not_active_when_expired(): void
+    {
+        Carbon::setTestNow('2026-07-05 12:00:00');
+
+        $admin = User::factory()->create();
+        $target = User::factory()->create();
+
+        $session = AdminImpersonationSession::query()->create([
+            'admin_user_id' => $admin->id,
+            'target_user_id' => $target->id,
+            'token_hash' => hash('sha256', 'expired-token'),
+            'expires_at' => now()->subMinute(),
+        ]);
+
+        $this->assertFalse($session->isActive());
+    }
+
+    public function test_is_not_active_when_consumed(): void
+    {
+        Carbon::setTestNow('2026-07-05 12:00:00');
+
+        $admin = User::factory()->create();
+        $target = User::factory()->create();
+
+        $session = AdminImpersonationSession::query()->create([
+            'admin_user_id' => $admin->id,
+            'target_user_id' => $target->id,
+            'token_hash' => hash('sha256', 'consumed-token'),
+            'expires_at' => now()->addHour(),
+            'consumed_at' => now(),
+        ]);
+
+        $this->assertFalse($session->isActive());
+    }
+
+    public function test_is_not_active_when_ended(): void
+    {
+        Carbon::setTestNow('2026-07-05 12:00:00');
+
+        $admin = User::factory()->create();
+        $target = User::factory()->create();
+
+        $session = AdminImpersonationSession::query()->create([
+            'admin_user_id' => $admin->id,
+            'target_user_id' => $target->id,
+            'token_hash' => hash('sha256', 'ended-token'),
+            'expires_at' => now()->addHour(),
+            'ended_at' => now(),
+        ]);
+
+        $this->assertFalse($session->isActive());
+    }
+}

--- a/tests/Unit/Services/Admin/ImpersonationServiceTest.php
+++ b/tests/Unit/Services/Admin/ImpersonationServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Services\Admin;
+
+use Carbon\Carbon;
+use STS\Models\AdminImpersonationSession;
+use STS\Models\User;
+use STS\Services\Admin\ImpersonationService;
+use Tests\TestCase;
+
+class ImpersonationServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_start_creates_session_with_sixty_minute_expiry_and_handoff_token(): void
+    {
+        Carbon::setTestNow('2026-07-05 12:00:00');
+
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false]);
+
+        $service = app(ImpersonationService::class);
+        $result = $service->start($admin, $target);
+
+        $this->assertArrayHasKey('session', $result);
+        $this->assertArrayHasKey('handoff_token', $result);
+        $this->assertSame(64, strlen($result['handoff_token']));
+
+        /** @var AdminImpersonationSession $session */
+        $session = $result['session'];
+        $this->assertSame($admin->id, $session->admin_user_id);
+        $this->assertSame($target->id, $session->target_user_id);
+        $this->assertTrue($session->expires_at->equalTo(now()->addMinutes(60)));
+    }
+
+    public function test_start_stores_only_sha256_hash_of_handoff_token(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $target = User::factory()->create(['active' => true, 'banned' => false]);
+
+        $service = app(ImpersonationService::class);
+        $result = $service->start($admin, $target);
+
+        /** @var AdminImpersonationSession $session */
+        $session = $result['session']->fresh();
+        $this->assertSame(hash('sha256', $result['handoff_token']), $session->token_hash);
+        $this->assertNotSame($result['handoff_token'], $session->token_hash);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds audited admin user impersonation with 60-minute, one-time handoff tokens and separate JWTs (`imp`, `actor_id`, `session_id` claims)
- New endpoints: start (`POST /api/admin/users/{user}/impersonate`), consume (`POST /api/auth/impersonate/consume`), stop (`POST /api/impersonate/stop` and admin cleanup)
- Guardrails: cannot impersonate admins/banned/inactive users, `IMPERSONATION_ENABLED` flag, high-risk route blocking, retoken preserves impersonation claims

## Cause

Admins were swapping password hashes in the database to log in as users, blocking the user from logging in and risking session disruption during debugging.

## Test plan

- [x] Admin can start impersonation for an active non-admin user
- [x] Handoff token is one-time and expires after 60 minutes
- [x] Impersonation JWT includes `imp`, `actor_id`, `session_id` claims
- [x] Stop invalidates impersonation JWT and ends session
- [x] Cannot impersonate admin, banned, or inactive users
- [x] Delete account / password / MercadoPago / pay routes return 403 while impersonating
- [x] Audit log records start and stop with session id
- [x] Normal user sessions are unaffected during impersonation