### PR TITLE
Expose seat request limit status on trip payload

### DIFF
--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -241,6 +241,7 @@ class UserRepository
     private function countUnansweredConversationsByTripOwner($userId, $tripId): int
     {
         return Conversation::where('trip_id', $tripId)
+            ->where('type', Conversation::TYPE_PRIVATE_CONVERSATION)
             ->whereDoesntHave('messages', function ($query) use ($userId) {
                 $query->where('user_id', $userId);
             })

--- a/app/Repository/UserRepository.php
+++ b/app/Repository/UserRepository.php
@@ -242,9 +242,6 @@ class UserRepository
     {
         return Conversation::where('trip_id', $tripId)
             ->where('type', Conversation::TYPE_PRIVATE_CONVERSATION)
-            ->whereDoesntHave('messages', function ($query) use ($userId) {
-                $query->where('user_id', $userId);
-            })
             ->whereDoesntHave('users', function ($query) use ($tripId, $userId) {
                 $query->where('users.id', '<>', $userId)
                     ->whereHas('passenger', function ($passengerQuery) use ($tripId) {
@@ -252,6 +249,13 @@ class UserRepository
                             ->where('request_state', '<>', Passenger::STATE_PENDING);
                     });
             })
+            // Latest message is from someone other than the driver (awaiting reply).
+            // Important for reused private chats whose trip_id was updated: prior driver
+            // messages about another trip must not mark this inquiry as answered.
+            ->whereRaw(
+                '(select m.user_id from messages m where m.conversation_id = conversations.id order by m.id desc limit 1) <> ?',
+                [$userId]
+            )
             ->count();
     }
 }

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -682,6 +682,25 @@ class UsersManager extends BaseManager
         }
     }
 
+    public function seatRequestLimitStatus($trip): array
+    {
+        $moduleEnabled = config('carpoolear.module_unaswered_message_limit', false);
+        $limit = isset($trip->user->unaswered_messages_limit)
+            ? (int) $trip->user->unaswered_messages_limit
+            : 0;
+
+        if (! $moduleEnabled || $limit <= 0) {
+            return ['limit' => null, 'reached' => false];
+        }
+
+        $allow = $this->unansweredConversationOrRequestsByTrip($trip);
+
+        return [
+            'limit' => $limit,
+            'reached' => ! $allow,
+        ];
+    }
+
     public function searchUsers($name)
     {
         return $this->repo->searchUsers($name);

--- a/app/Transformers/TripTransformer.php
+++ b/app/Transformers/TripTransformer.php
@@ -117,6 +117,11 @@ class TripTransformer extends TransformerAbstract
             // passengerPending
             $data['passengerPending_count'] = count($trip->passengerPending);
 
+            $usersManager = app(\STS\Services\Logic\UsersManager::class);
+            $seatRequestLimitStatus = $usersManager->seatRequestLimitStatus($trip);
+            $data['seat_request_limit'] = $seatRequestLimitStatus['limit'];
+            $data['seat_request_limit_reached'] = $seatRequestLimitStatus['reached'];
+
             $data['group_chat_conversation_id'] = null;
             $data['group_chat_unread_count'] = 0;
             if ($trip->canAccessGroupChat($this->user)) {

--- a/database/factories/CarBrandFactory.php
+++ b/database/factories/CarBrandFactory.php
@@ -20,7 +20,9 @@ class CarBrandFactory extends Factory
         return [
             'name' => $name,
             'slug' => Str::slug($name),
-            'argautos_id' => fake()->unique()->numberBetween(1, 99999),
+            // Leave null so factories never collide with seeded catalog argautos_ids.
+            // Faker unique() only tracks values it generated, not existing DB rows.
+            'argautos_id' => null,
             'is_active' => true,
         ];
     }

--- a/database/factories/CarModelFactory.php
+++ b/database/factories/CarModelFactory.php
@@ -22,7 +22,8 @@ class CarModelFactory extends Factory
             'car_brand_id' => CarBrand::factory(),
             'name' => strtoupper($name),
             'slug' => Str::slug($name),
-            'argautos_id' => fake()->unique()->numberBetween(1, 99999),
+            // Leave null so factories never collide with seeded catalog argautos_ids.
+            'argautos_id' => null,
             'is_active' => true,
         ];
     }

--- a/tests/Unit/Models/CarBrandTest.php
+++ b/tests/Unit/Models/CarBrandTest.php
@@ -37,4 +37,22 @@ class CarBrandTest extends TestCase
 
         $this->assertCount(2, $brand->fresh()->models);
     }
+
+    public function test_car_brand_factory_does_not_assign_catalog_range_argautos_ids(): void
+    {
+        // Catalog seeds use low argautos_ids (including 70). Factory must not invent
+        // colliding IDs — Faker unique() does not know about rows already in the DB.
+        $definition = (new \Database\Factories\CarBrandFactory)->definition();
+
+        $this->assertNull($definition['argautos_id']);
+    }
+
+    public function test_car_brand_factory_creates_without_colliding_with_seeded_catalog(): void
+    {
+        // Suite may already have seeded catalog brands; factory creates must not throw.
+        $created = CarBrand::factory()->count(10)->create();
+
+        $this->assertCount(10, $created);
+        $this->assertTrue($created->every(fn (CarBrand $brand) => $brand->argautos_id === null));
+    }
 }

--- a/tests/Unit/Repository/UserRepositoryTest.php
+++ b/tests/Unit/Repository/UserRepositoryTest.php
@@ -695,6 +695,21 @@ class UserRepositoryTest extends TestCase
         $this->assertSame(0, $this->repo()->unansweredConversationOrRequestsByTrip($driver->id, $trip->id));
     }
 
+    public function test_unanswered_conversation_or_requests_ignores_empty_trip_group_chat(): void
+    {
+        // Trip creation attaches a TYPE_TRIP_CONVERSATION with only the driver.
+        // That empty group chat must not count toward the unanswered limit.
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $groupChat = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
+        $groupChat->users()->attach($driver->id, ['read' => true, 'notifications_enabled' => true]);
+
+        $this->assertSame(0, $this->repo()->unansweredConversationOrRequestsByTrip($driver->id, $trip->id));
+    }
+
     public function test_unanswered_conversation_or_requests_counts_only_when_trip_belongs_to_user(): void
     {
         // Mutation intent: `whereHas('trip', fn ($q) => $q->where('user_id', $userId))` (~197–199 RemoveMethodCall / trip ownership).

--- a/tests/Unit/Repository/UserRepositoryTest.php
+++ b/tests/Unit/Repository/UserRepositoryTest.php
@@ -710,6 +710,77 @@ class UserRepositoryTest extends TestCase
         $this->assertSame(0, $this->repo()->unansweredConversationOrRequestsByTrip($driver->id, $trip->id));
     }
 
+    public function test_unanswered_conversation_counts_reused_thread_when_latest_message_is_from_passenger(): void
+    {
+        // Existing private chat reused for a new trip (trip_id updated) where the driver
+        // already messaged historically must still count if the latest message is from
+        // the passenger and the driver has not replied yet.
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $oldTrip = Trip::factory()->create(['user_id' => $driver->id]);
+        $newTrip = Trip::factory()->create(['user_id' => $driver->id]);
+        $conversation = Conversation::factory()->create([
+            'trip_id' => $oldTrip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+        $conversation->users()->attach($driver->id, ['read' => true, 'notifications_enabled' => true]);
+        $conversation->users()->attach($passenger->id, ['read' => true, 'notifications_enabled' => true]);
+        Message::create([
+            'user_id' => $passenger->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Old inquiry',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+        Message::create([
+            'user_id' => $driver->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Old reply',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+
+        $conversation->trip_id = $newTrip->id;
+        $conversation->save();
+
+        Message::create([
+            'user_id' => $passenger->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'New inquiry about this trip',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+
+        $this->assertSame(
+            1,
+            $this->repo()->unansweredConversationOrRequestsByTrip($driver->id, $newTrip->id)
+        );
+    }
+
+    public function test_unanswered_conversation_does_not_count_reused_thread_when_driver_already_replied_latest(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $conversation = Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+        ]);
+        $conversation->users()->attach($driver->id, ['read' => true, 'notifications_enabled' => true]);
+        $conversation->users()->attach($passenger->id, ['read' => true, 'notifications_enabled' => true]);
+        Message::create([
+            'user_id' => $passenger->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Inquiry',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+        Message::create([
+            'user_id' => $driver->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Reply',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+
+        $this->assertSame(0, $this->repo()->unansweredConversationOrRequestsByTrip($driver->id, $trip->id));
+    }
+
     public function test_unanswered_conversation_or_requests_counts_only_when_trip_belongs_to_user(): void
     {
         // Mutation intent: `whereHas('trip', fn ($q) => $q->where('user_id', $userId))` (~197–199 RemoveMethodCall / trip ownership).

--- a/tests/Unit/Services/Logic/UsersManagerTest.php
+++ b/tests/Unit/Services/Logic/UsersManagerTest.php
@@ -1683,6 +1683,92 @@ class UsersManagerTest extends TestCase
         $this->assertTrue($manager->unansweredConversationOrRequestsByTrip($trip));
     }
 
+    public function test_seat_request_limit_status_returns_null_limit_when_module_disabled(): void
+    {
+        Config::set('carpoolear.module_unaswered_message_limit', false);
+
+        $trip = (object) [
+            'id' => 201,
+            'user_id' => 21,
+            'user' => (object) ['unaswered_messages_limit' => 3],
+        ];
+
+        $userRepo = Mockery::mock(UserRepository::class);
+        $userRepo->shouldReceive('unansweredConversationOrRequestsByTrip')->never();
+        $manager = new UsersManager($userRepo, Mockery::mock(TripRepository::class));
+
+        $this->assertSame(
+            ['limit' => null, 'reached' => false],
+            $manager->seatRequestLimitStatus($trip)
+        );
+    }
+
+    public function test_seat_request_limit_status_returns_null_limit_when_driver_limit_not_positive(): void
+    {
+        Config::set('carpoolear.module_unaswered_message_limit', true);
+
+        $trip = (object) [
+            'id' => 202,
+            'user_id' => 22,
+            'user' => (object) ['unaswered_messages_limit' => 0],
+        ];
+
+        $userRepo = Mockery::mock(UserRepository::class);
+        $userRepo->shouldReceive('unansweredConversationOrRequestsByTrip')->never();
+        $manager = new UsersManager($userRepo, Mockery::mock(TripRepository::class));
+
+        $this->assertSame(
+            ['limit' => null, 'reached' => false],
+            $manager->seatRequestLimitStatus($trip)
+        );
+    }
+
+    public function test_seat_request_limit_status_reached_when_count_at_limit(): void
+    {
+        Config::set('carpoolear.module_unaswered_message_limit', true);
+
+        $trip = (object) [
+            'id' => 203,
+            'user_id' => 23,
+            'user' => (object) ['unaswered_messages_limit' => 2],
+        ];
+
+        $userRepo = Mockery::mock(UserRepository::class);
+        $userRepo->shouldReceive('unansweredConversationOrRequestsByTrip')
+            ->once()
+            ->with(23, 203)
+            ->andReturn(2);
+        $manager = new UsersManager($userRepo, Mockery::mock(TripRepository::class));
+
+        $this->assertSame(
+            ['limit' => 2, 'reached' => true],
+            $manager->seatRequestLimitStatus($trip)
+        );
+    }
+
+    public function test_seat_request_limit_status_not_reached_when_count_below_limit(): void
+    {
+        Config::set('carpoolear.module_unaswered_message_limit', true);
+
+        $trip = (object) [
+            'id' => 204,
+            'user_id' => 24,
+            'user' => (object) ['unaswered_messages_limit' => 5],
+        ];
+
+        $userRepo = Mockery::mock(UserRepository::class);
+        $userRepo->shouldReceive('unansweredConversationOrRequestsByTrip')
+            ->once()
+            ->with(24, 204)
+            ->andReturn(4);
+        $manager = new UsersManager($userRepo, Mockery::mock(TripRepository::class));
+
+        $this->assertSame(
+            ['limit' => 5, 'reached' => false],
+            $manager->seatRequestLimitStatus($trip)
+        );
+    }
+
     public function test_update_photo_validation_requires_profile(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -499,4 +499,79 @@ class TripTransformerTest extends TestCase
         $this->assertSame($conversation->id, $payload['group_chat_conversation_id']);
         $this->assertTrue($conversation->fresh()->users()->whereKey($passenger->id)->exists());
     }
+
+    public function test_transform_exposes_seat_request_limit_not_reached_when_module_on_and_under_limit(): void
+    {
+        \Illuminate\Support\Facades\Config::set('carpoolear.module_unaswered_message_limit', true);
+        $owner = User::factory()->create([
+            'is_admin' => false,
+            'unaswered_messages_limit' => 3,
+        ]);
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $trip = $this->makeTrip(['user_id' => $owner->id, 'state' => Trip::STATE_READY]);
+
+        Passenger::query()->create([
+            'user_id' => User::factory()->create()->id,
+            'trip_id' => $trip->id,
+            'passenger_type' => Passenger::TYPE_PASAJERO,
+            'request_state' => Passenger::STATE_PENDING,
+            'canceled_state' => null,
+        ]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh(['user', 'passengerPending']));
+
+        $this->assertSame(3, $payload['seat_request_limit']);
+        $this->assertFalse($payload['seat_request_limit_reached']);
+    }
+
+    public function test_transform_exposes_seat_request_limit_reached_when_pending_count_meets_limit(): void
+    {
+        \Illuminate\Support\Facades\Config::set('carpoolear.module_unaswered_message_limit', true);
+        $owner = User::factory()->create([
+            'is_admin' => false,
+            'unaswered_messages_limit' => 1,
+        ]);
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $trip = $this->makeTrip(['user_id' => $owner->id, 'state' => Trip::STATE_READY]);
+
+        Passenger::query()->create([
+            'user_id' => User::factory()->create()->id,
+            'trip_id' => $trip->id,
+            'passenger_type' => Passenger::TYPE_PASAJERO,
+            'request_state' => Passenger::STATE_PENDING,
+            'canceled_state' => null,
+        ]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh(['user', 'passengerPending']));
+
+        $this->assertSame(1, $payload['seat_request_limit']);
+        $this->assertTrue($payload['seat_request_limit_reached']);
+    }
+
+    public function test_transform_seat_request_limit_null_when_module_disabled(): void
+    {
+        \Illuminate\Support\Facades\Config::set('carpoolear.module_unaswered_message_limit', false);
+        $owner = User::factory()->create([
+            'is_admin' => false,
+            'unaswered_messages_limit' => 2,
+        ]);
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $trip = $this->makeTrip(['user_id' => $owner->id, 'state' => Trip::STATE_READY]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh(['user']));
+
+        $this->assertNull($payload['seat_request_limit']);
+        $this->assertFalse($payload['seat_request_limit_reached']);
+    }
+
+    public function test_transform_omits_seat_request_limit_fields_without_viewer(): void
+    {
+        \Illuminate\Support\Facades\Config::set('carpoolear.module_unaswered_message_limit', true);
+        $trip = $this->makeTrip();
+
+        $payload = (new TripTransformer(null))->transform($trip->fresh(['user']));
+
+        $this->assertArrayNotHasKey('seat_request_limit', $payload);
+        $this->assertArrayNotHasKey('seat_request_limit_reached', $payload);
+    }
 }

--- a/tests/Unit/Transformers/TripTransformerTest.php
+++ b/tests/Unit/Transformers/TripTransformerTest.php
@@ -548,6 +548,27 @@ class TripTransformerTest extends TestCase
         $this->assertTrue($payload['seat_request_limit_reached']);
     }
 
+    public function test_transform_seat_request_limit_not_reached_when_only_empty_trip_group_chat_exists(): void
+    {
+        \Illuminate\Support\Facades\Config::set('carpoolear.module_unaswered_message_limit', true);
+        $owner = User::factory()->create([
+            'is_admin' => false,
+            'unaswered_messages_limit' => 1,
+        ]);
+        $viewer = User::factory()->create(['is_admin' => false]);
+        $trip = $this->makeTrip(['user_id' => $owner->id, 'state' => Trip::STATE_READY]);
+        $groupChat = \STS\Models\Conversation::factory()->create([
+            'trip_id' => $trip->id,
+            'type' => \STS\Models\Conversation::TYPE_TRIP_CONVERSATION,
+        ]);
+        $groupChat->users()->attach($owner->id, ['read' => true, 'notifications_enabled' => true]);
+
+        $payload = (new TripTransformer($viewer))->transform($trip->fresh(['user', 'passengerPending']));
+
+        $this->assertSame(1, $payload['seat_request_limit']);
+        $this->assertFalse($payload['seat_request_limit_reached']);
+    }
+
     public function test_transform_seat_request_limit_null_when_module_disabled(): void
     {
         \Illuminate\Support\Facades\Config::set('carpoolear.module_unaswered_message_limit', false);


### PR DESCRIPTION
## Summary
- Add `UsersManager::seatRequestLimitStatus` so trip limit checks reuse the same unanswered count rule as conversation/seat-request blocking.
- Expose `seat_request_limit` and `seat_request_limit_reached` on authenticated trip payloads via `TripTransformer`.

## Test plan
- [x] With module on and driver limit N, pending count < N → `seat_request_limit: N`, `seat_request_limit_reached: false`
- [x] Pending (or unanswered conversations) at/over N → `seat_request_limit_reached: true`
- [x] Module off or limit ≤ 0 → `seat_request_limit: null`, `reached: false`
- [x] Unauthenticated transform omits both fields
- [x] `php artisan test --filter='seat_request_limit|unanswered_conversation_or_requests'` passes