### PR TITLE
Block user migration when either account is banned

### DIFF
--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -75,13 +75,22 @@ class UserMigrationController extends Controller
         $removedId = (int) $validated['user_id_removed'];
         $fieldSources = $validated['field_sources'] ?? [];
 
+        $kept = User::findOrFail($keptId);
+        $removed = User::findOrFail($removedId);
+
+        if ($bannedUser = $this->findBannedMigrationUser($kept, $removed)) {
+            return response()->json([
+                'message' => 'migration_banned_user',
+                'user_id' => $bannedUser->id,
+                'user_name' => $bannedUser->name ?? '',
+            ], 422);
+        }
+
         Artisan::call('user:update', [
             'original' => (string) $removedId,
             'new' => (string) $keptId,
         ]);
 
-        $kept = User::findOrFail($keptId);
-        $removed = User::findOrFail($removedId);
         $this->fieldMerger->apply($kept, $removed, $fieldSources);
 
         $removalAction = $this->removeOrAnonymize($removedId, $admin);
@@ -108,6 +117,19 @@ class UserMigrationController extends Controller
                 'created_at' => $row->created_at?->toAtomString(),
             ],
         ]);
+    }
+
+    private function findBannedMigrationUser(User $kept, User $removed): ?User
+    {
+        if ($kept->banned) {
+            return $kept;
+        }
+
+        if ($removed->banned) {
+            return $removed;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminUserMigrationControllerIntegrationTest.php
@@ -88,6 +88,70 @@ class AdminUserMigrationControllerIntegrationTest extends TestCase
         ])->assertUnprocessable();
     }
 
+    public function test_store_rejects_when_kept_user_is_banned(): void
+    {
+        $admin = $this->admin();
+        $kept = User::factory()->create([
+            'name' => 'Cuenta Suspendida',
+            'banned' => true,
+        ]);
+        $removed = User::factory()->create(['banned' => false]);
+        $trip = Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'migration_banned_user',
+            'user_id' => $kept->id,
+            'user_name' => 'Cuenta Suspendida',
+        ]);
+
+        $this->assertSame($removed->id, (int) $trip->fresh()->user_id);
+        $this->assertDatabaseMissing('user_migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+    }
+
+    public function test_store_rejects_when_removed_user_is_banned(): void
+    {
+        $admin = $this->admin();
+        $kept = User::factory()->create(['banned' => false]);
+        $removed = User::factory()->create([
+            'name' => 'Usuario Bloqueado',
+            'banned' => true,
+        ]);
+        $trip = Trip::factory()->create(['user_id' => $removed->id]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/user-migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'migration_banned_user',
+            'user_id' => $removed->id,
+            'user_name' => 'Usuario Bloqueado',
+        ]);
+
+        $this->assertSame($removed->id, (int) $trip->fresh()->user_id);
+        $this->assertDatabaseMissing('user_migrations', [
+            'user_id_kept' => $kept->id,
+            'user_id_removed' => $removed->id,
+        ]);
+    }
+
     public function test_store_runs_user_update_artisan_and_persists_migration_row(): void
     {
         $admin = $this->admin();


### PR DESCRIPTION
## Summary
- Reject admin user migrations with HTTP 422 when the kept or removed account has `banned = 1`
- Return `migration_banned_user` with `user_id` and `user_name` so the frontend can show a specific error
- Prevent the migration artisan command and persistence from running when either account is suspended

## Test plan
- [x] `php artisan test --filter=AdminUserMigrationControllerIntegrationTest`
- [x] Full backend suite passes (3333 tests)
- [x] Manually attempt migration in admin with a banned kept user
- [x] Manually attempt migration in admin with a banned removed user