### PR TITLE
feat(api): admin support ticket self-assignment

### DIFF
--- a/app/Console/Commands/SupportTicketsReleaseExpiredAssignments.php
+++ b/app/Console/Commands/SupportTicketsReleaseExpiredAssignments.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use STS\Services\SupportTicketService;
+
+class SupportTicketsReleaseExpiredAssignments extends Command
+{
+    protected $signature = 'support-tickets:release-expired-assignments';
+
+    protected $description = 'Release expired support ticket assignments after inactivity threshold';
+
+    public function __construct(private readonly SupportTicketService $supportTicketService)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $released = $this->supportTicketService->releaseExpiredAssignments();
+
+        $this->info('Support ticket assignments released: '.$released);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -13,6 +13,7 @@ use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
 use STS\Support\ImageAttachmentRules;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class SupportTicketController extends Controller
 {
@@ -30,6 +31,7 @@ class SupportTicketController extends Controller
             'replies.user:id,name',
             'attachments',
             'user',
+            'assignedTo:id,name',
         ];
     }
 
@@ -38,7 +40,7 @@ class SupportTicketController extends Controller
      */
     private static function ticketIndexRelationships(): array
     {
-        return ['user:id,name'];
+        return ['user:id,name', 'assignedTo:id,name'];
     }
 
     public function __construct(private readonly SupportTicketService $supportTicketService) {}
@@ -309,6 +311,34 @@ class SupportTicketController extends Controller
         $this->supportTicketService->purgeTicketAttachments($id);
 
         return response()->json(['message' => 'Attachments purged']);
+    }
+
+    public function assignMe(int $id): JsonResponse
+    {
+        $admin = auth()->user();
+        $ticket = SupportTicket::with(self::ticketDetailRelationships())->findOrFail($id);
+
+        try {
+            $this->supportTicketService->assignTicketToAdmin($ticket, $admin);
+        } catch (HttpException $exception) {
+            return response()->json(['error' => $exception->getMessage()], $exception->getStatusCode());
+        }
+
+        return response()->json(['data' => $ticket->fresh(self::ticketDetailRelationships())]);
+    }
+
+    public function unassignMe(int $id): JsonResponse
+    {
+        $admin = auth()->user();
+        $ticket = SupportTicket::with(self::ticketDetailRelationships())->findOrFail($id);
+
+        try {
+            $this->supportTicketService->unassignTicketFromAdmin($ticket, $admin);
+        } catch (HttpException $exception) {
+            return response()->json(['error' => $exception->getMessage()], $exception->getStatusCode());
+        }
+
+        return response()->json(['data' => $ticket->fresh(self::ticketDetailRelationships())]);
     }
 
     private function applyActionStatus(int $id, Request $request, string $status): JsonResponse

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -47,6 +47,7 @@ class SupportTicketController extends Controller
 
     public function index(Request $request): JsonResponse
     {
+        $this->supportTicketService->releaseExpiredAssignments();
         $query = $this->buildAdminIndexQuery($request);
 
         return response()->json([
@@ -86,6 +87,7 @@ class SupportTicketController extends Controller
 
     public function show(int $id): JsonResponse
     {
+        $this->supportTicketService->releaseExpiredAssignments();
         $ticket = SupportTicket::with(self::ticketDetailRelationships())->findOrFail($id);
 
         return response()->json(['data' => $ticket]);
@@ -315,6 +317,7 @@ class SupportTicketController extends Controller
 
     public function assignMe(int $id): JsonResponse
     {
+        $this->supportTicketService->releaseExpiredAssignments();
         $admin = auth()->user();
         $ticket = SupportTicket::with(self::ticketDetailRelationships())->findOrFail($id);
 
@@ -329,6 +332,7 @@ class SupportTicketController extends Controller
 
     public function unassignMe(int $id): JsonResponse
     {
+        $this->supportTicketService->releaseExpiredAssignments();
         $admin = auth()->user();
         $ticket = SupportTicket::with(self::ticketDetailRelationships())->findOrFail($id);
 

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -155,6 +155,10 @@ class SupportTicketController extends Controller
             return response()->json(['error' => 'Ticket is closed for replies'], 422);
         }
 
+        if (! $this->supportTicketService->adminCanReplyToTicket($ticket, $admin)) {
+            return response()->json(['error' => 'Ticket is assigned to another admin'], 403);
+        }
+
         if ($this->supportTicketService->ticketAlreadyHasReplyWithMessageMarkdown(
             $ticket->id,
             $validated['message_markdown'],

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -366,6 +366,9 @@ class SupportTicketController extends Controller
 
             $ticket->status = $status;
             $ticket->updated_by = $admin->id;
+            if (in_array($status, ['Resuelto', 'Cerrado'], true)) {
+                $this->supportTicketService->clearTicketAssignment($ticket);
+            }
             if ($status === 'Cerrado') {
                 $ticket->closed_by = $admin->id;
                 $ticket->closed_at = now();

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -78,6 +78,8 @@ class SupportTicket extends Model
         'updated_by',
         'closed_by',
         'closed_at',
+        'assigned_to_user_id',
+        'assigned_at',
     ];
 
     protected function casts(): array
@@ -85,12 +87,18 @@ class SupportTicket extends Model
         return [
             'last_reply_at' => 'datetime',
             'closed_at' => 'datetime',
+            'assigned_at' => 'datetime',
         ];
     }
 
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function assignedTo()
+    {
+        return $this->belongsTo(User::class, 'assigned_to_user_id');
     }
 
     public function replies()

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -126,6 +126,30 @@ class SupportTicket extends Model
             });
     }
 
+    public function isAssignedTo(int $adminId): bool
+    {
+        return $this->assigned_to_user_id !== null
+            && (int) $this->assigned_to_user_id === $adminId;
+    }
+
+    public function isAssignmentExpired(?int $timeoutMinutes = null): bool
+    {
+        if ($this->assigned_to_user_id === null || $this->assigned_at === null) {
+            return false;
+        }
+
+        $minutes = $timeoutMinutes ?? (int) config('carpoolear.support_ticket_assignment_timeout_minutes', 10);
+
+        return $this->assigned_at->lte(now()->subMinutes($minutes));
+    }
+
+    public function hasActiveAssignment(?int $timeoutMinutes = null): bool
+    {
+        return $this->assigned_to_user_id !== null
+            && $this->assigned_at !== null
+            && ! $this->isAssignmentExpired($timeoutMinutes);
+    }
+
     public static function countForUser(?int $userId): int
     {
         if ($userId === null) {

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -179,6 +179,15 @@ class SupportTicketService
         return ! in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true);
     }
 
+    public function adminCanReplyToTicket(SupportTicket $ticket, User $admin): bool
+    {
+        if (! $ticket->hasActiveAssignment()) {
+            return true;
+        }
+
+        return $ticket->isAssignedTo((int) $admin->id);
+    }
+
     public function ticketIsAssignableByAdmin(SupportTicket $ticket): bool
     {
         if (in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true)) {

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -174,4 +174,17 @@ class SupportTicketService
     {
         return ! in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true);
     }
+
+    public function ticketIsAssignableByAdmin(SupportTicket $ticket): bool
+    {
+        if (in_array($ticket->status, self::TERMINAL_USER_REPLY_STATUSES, true)) {
+            return false;
+        }
+
+        if ((int) $ticket->unread_for_admin > 0) {
+            return true;
+        }
+
+        return in_array($ticket->status, ['Open', 'En revision', SupportTicket::STATUS_NEEDS_REVIEW], true);
+    }
 }

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -8,6 +8,9 @@ use STS\Models\SupportTicketAttachment;
 use STS\Models\SupportTicketReply;
 use STS\Models\User;
 use STS\Support\SupportTicketOpeningAutoReply;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class SupportTicketService
 {
@@ -186,5 +189,63 @@ class SupportTicketService
         }
 
         return in_array($ticket->status, ['Open', 'En revision', SupportTicket::STATUS_NEEDS_REVIEW], true);
+    }
+
+    public function assignTicketToAdmin(SupportTicket $ticket, User $admin): void
+    {
+        if ($ticket->isAssignmentExpired()) {
+            $this->clearTicketAssignment($ticket);
+            $ticket->save();
+        }
+
+        if (! $this->ticketIsAssignableByAdmin($ticket)) {
+            throw new UnprocessableEntityHttpException('Ticket cannot be assigned');
+        }
+
+        if ($ticket->hasActiveAssignment() && ! $ticket->isAssignedTo($admin->id)) {
+            throw new ConflictHttpException('Ticket is already assigned to another admin');
+        }
+
+        $ticket->assigned_to_user_id = $admin->id;
+        $ticket->assigned_at = now();
+        $ticket->updated_by = $admin->id;
+        $ticket->save();
+    }
+
+    public function unassignTicketFromAdmin(SupportTicket $ticket, User $admin): void
+    {
+        if ($ticket->assigned_to_user_id === null) {
+            throw new UnprocessableEntityHttpException('Ticket is not assigned');
+        }
+
+        if (! $ticket->isAssignedTo($admin->id)) {
+            throw new AccessDeniedHttpException('Only the assigned admin can unassign this ticket');
+        }
+
+        $this->clearTicketAssignment($ticket);
+        $ticket->updated_by = $admin->id;
+        $ticket->save();
+    }
+
+    public function clearTicketAssignment(SupportTicket $ticket): void
+    {
+        $ticket->assigned_to_user_id = null;
+        $ticket->assigned_at = null;
+    }
+
+    public function releaseExpiredAssignments(): int
+    {
+        $timeoutMinutes = (int) config('carpoolear.support_ticket_assignment_timeout_minutes', 10);
+        $threshold = now()->subMinutes($timeoutMinutes);
+
+        return SupportTicket::query()
+            ->whereNotNull('assigned_to_user_id')
+            ->whereNotNull('assigned_at')
+            ->where('assigned_at', '<=', $threshold)
+            ->update([
+                'assigned_to_user_id' => null,
+                'assigned_at' => null,
+                'updated_at' => now(),
+            ]);
     }
 }

--- a/app/Services/SupportTicketService.php
+++ b/app/Services/SupportTicketService.php
@@ -137,6 +137,7 @@ class SupportTicketService
         $ticket->unread_for_admin = 0;
         $ticket->last_reply_at = now();
         $ticket->updated_by = $actorUserId;
+        $this->clearTicketAssignment($ticket);
     }
 
     /**

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -112,6 +112,7 @@ return [
 
     // Support tickets
     'support_ticket_autoclose_days' => (int) env('SUPPORT_TICKET_AUTOCLOSE_DAYS', 10),
+    'support_ticket_assignment_timeout_minutes' => (int) env('SUPPORT_TICKET_ASSIGNMENT_TIMEOUT_MINUTES', 10),
     'support_ticket_rate_limit_create_per_hour' => (int) env('SUPPORT_TICKET_RATE_LIMIT_CREATE_PER_HOUR', 5),
     'support_ticket_rate_limit_reply_per_hour' => (int) env('SUPPORT_TICKET_RATE_LIMIT_REPLY_PER_HOUR', 20),
     'support_ticket_rate_limit_admin_reply_per_hour' => (int) env('SUPPORT_TICKET_RATE_LIMIT_ADMIN_REPLY_PER_HOUR', 120),

--- a/database/migrations/2026_07_19_120000_add_assignment_to_support_tickets_table.php
+++ b/database/migrations/2026_07_19_120000_add_assignment_to_support_tickets_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('support_tickets', function (Blueprint $table) {
+            $table->unsignedInteger('assigned_to_user_id')->nullable()->after('closed_at');
+            $table->timestamp('assigned_at')->nullable()->after('assigned_to_user_id');
+            $table->foreign('assigned_to_user_id')->references('id')->on('users')->nullOnDelete();
+            $table->index(['assigned_to_user_id', 'assigned_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('support_tickets', function (Blueprint $table) {
+            $table->dropForeign(['assigned_to_user_id']);
+            $table->dropIndex(['assigned_to_user_id', 'assigned_at']);
+            $table->dropColumn(['assigned_to_user_id', 'assigned_at']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -317,6 +317,8 @@ Route::middleware(['api'])->group(function () {
         Route::post('support/tickets/{id}/reopen', [AdminSupportTicketController::class, 'reopen']);
         Route::post('support/tickets/{id}/unresolve', [AdminSupportTicketController::class, 'unresolve']);
         Route::post('support/tickets/{id}/needs-review', [AdminSupportTicketController::class, 'markNeedsReview']);
+        Route::post('support/tickets/{id}/assign-me', [AdminSupportTicketController::class, 'assignMe']);
+        Route::post('support/tickets/{id}/unassign-me', [AdminSupportTicketController::class, 'unassignMe']);
         Route::get('support/tickets/{ticketId}/attachments/{attachmentId}/image', [AdminSupportTicketController::class, 'attachmentImage']);
         Route::post('support/tickets/{id}/purge-attachments', [AdminSupportTicketController::class, 'purgeAttachments']);
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -45,6 +45,10 @@ Schedule::command('auth:cleanup-reset-tokens')->dailyAt('04:00')->timezone('Amer
 // Auto-close resolved support tickets after configured inactivity days
 Schedule::command('support-tickets:autoclose')->dailyAt('04:30')->timezone('America/Argentina/Buenos_Aires');
 
+Schedule::command('support-tickets:release-expired-assignments')
+    ->everyMinute()
+    ->timezone('America/Argentina/Buenos_Aires');
+
 Schedule::command('car-catalog:sync-argautos --mode=incremental')
     ->weeklyOn(1, '03:00')
     ->timezone('America/Argentina/Buenos_Aires');

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -112,6 +112,13 @@ class ScheduleTest extends TestCase
         $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
     }
 
+    public function test_support_tickets_release_expired_assignments_is_scheduled_every_minute()
+    {
+        $event = $this->findEvent('support-tickets:release-expired-assignments');
+        $this->assertEquals('* * * * *', $event->expression);
+        $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
+    }
+
     // -- Monthly commands --
 
     public function test_calculate_active_users_is_scheduled_monthly_on_first()
@@ -147,6 +154,7 @@ class ScheduleTest extends TestCase
             'users:calculate-active-per-month',
             'auth:cleanup-reset-tokens',
             'support-tickets:autoclose',
+            'support-tickets:release-expired-assignments',
             'car-catalog:sync-argautos',
         ];
 

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -1293,4 +1293,48 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertNull($row['assigned_to_user_id']);
         $this->assertNull($row['assigned_to']);
     }
+
+    public function test_index_includes_assigned_admin_for_claimed_ticket(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'subject' => 'claimed-ticket',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets')->assertOk()->json('data'));
+        $row = $rows->firstWhere('id', $ticket->id);
+
+        $this->assertSame($admin->id, (int) $row['assigned_to_user_id']);
+        $this->assertSame($admin->name, $row['assigned_to']['name']);
+    }
+
+    public function test_admin_reply_clears_ticket_assignment(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'subject' => 'reply-clears-assignment',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/replies', [
+            'message_markdown' => 'Handled now.',
+        ])->assertOk();
+
+        $fresh = $ticket->fresh();
+        $this->assertNull($fresh->assigned_to_user_id);
+        $this->assertNull($fresh->assigned_at);
+    }
 }

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -1337,4 +1337,24 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertNull($fresh->assigned_to_user_id);
         $this->assertNull($fresh->assigned_at);
     }
+
+    public function test_admin_reply_returns_forbidden_when_ticket_assigned_to_another_admin(): void
+    {
+        $assignee = $this->adminUser();
+        $otherAdmin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'subject' => 'assigned-to-other',
+            'assigned_to_user_id' => $assignee->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->actingAs($otherAdmin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/replies', [
+            'message_markdown' => 'Should not post.',
+        ])->assertStatus(403);
+    }
 }

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -1173,4 +1173,99 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
             'message_markdown' => 'Hello owner.',
         ])->assertOk();
     }
+
+    public function test_assign_me_claims_assignable_ticket_for_current_admin(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, ['status' => 'Open', 'subject' => 'assign-me']);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/support/tickets/'.$ticket->id.'/assign-me')->assertOk();
+        $data = $response->json('data');
+
+        $this->assertSame($admin->id, (int) $data['assigned_to_user_id']);
+        $this->assertNotNull($data['assigned_at']);
+        $this->assertSame($admin->id, (int) $data['assigned_to']['id']);
+        $this->assertSame($admin->name, $data['assigned_to']['name']);
+    }
+
+    public function test_assign_me_returns_conflict_when_ticket_assigned_to_another_admin(): void
+    {
+        $adminA = $this->adminUser();
+        $adminB = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'assigned_to_user_id' => $adminA->id,
+            'assigned_at' => now(),
+            'subject' => 'already-assigned',
+        ]);
+
+        $this->actingAs($adminB, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/assign-me')
+            ->assertStatus(409);
+    }
+
+    public function test_assign_me_returns_unprocessable_when_ticket_not_assignable(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Esperando respuesta',
+            'unread_for_admin' => 0,
+            'subject' => 'waiting-user',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/assign-me')
+            ->assertStatus(422);
+    }
+
+    public function test_unassign_me_clears_assignment_for_current_admin(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now(),
+            'subject' => 'unassign-me',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->postJson('api/admin/support/tickets/'.$ticket->id.'/unassign-me')->assertOk();
+        $data = $response->json('data');
+
+        $this->assertNull($data['assigned_to_user_id']);
+        $this->assertNull($data['assigned_at']);
+        $this->assertNull($data['assigned_to']);
+    }
+
+    public function test_unassign_me_returns_forbidden_for_non_assignee(): void
+    {
+        $assignee = $this->adminUser();
+        $otherAdmin = $this->adminUser();
+        $owner = User::factory()->create();
+        $ticket = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'assigned_to_user_id' => $assignee->id,
+            'assigned_at' => now(),
+            'subject' => 'forbidden-unassign',
+        ]);
+
+        $this->actingAs($otherAdmin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/support/tickets/'.$ticket->id.'/unassign-me')
+            ->assertStatus(403);
+    }
 }

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -1268,4 +1268,29 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->postJson('api/admin/support/tickets/'.$ticket->id.'/unassign-me')
             ->assertStatus(403);
     }
+
+    public function test_index_releases_expired_assignment_before_returning_rows(): void
+    {
+        \Carbon\Carbon::setTestNow('2026-07-19 12:00:00');
+        config()->set('carpoolear.support_ticket_assignment_timeout_minutes', 10);
+
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+        $expired = $this->makeTicket($owner, [
+            'status' => 'Open',
+            'subject' => 'expired-assignment',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now()->subMinutes(11),
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $rows = collect($this->getJson('api/admin/support/tickets')->assertOk()->json('data'));
+        $row = $rows->firstWhere('id', $expired->id);
+
+        $this->assertNotNull($row);
+        $this->assertNull($row['assigned_to_user_id']);
+        $this->assertNull($row['assigned_to']);
+    }
 }

--- a/tests/Unit/Console/Commands/SupportTicketsReleaseExpiredAssignmentsTest.php
+++ b/tests/Unit/Console/Commands/SupportTicketsReleaseExpiredAssignmentsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
+use STS\Console\Commands\SupportTicketsReleaseExpiredAssignments;
+use STS\Models\SupportTicket;
+use STS\Models\User;
+use Tests\TestCase;
+
+class SupportTicketsReleaseExpiredAssignmentsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_handle_releases_expired_assignments(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 7, 19, 12, 0, 0));
+        Config::set('carpoolear.support_ticket_assignment_timeout_minutes', 10);
+
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $active = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Active',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => Carbon::now()->subMinutes(5),
+        ]);
+        $expired = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Expired',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => Carbon::now()->subMinutes(11),
+        ]);
+
+        $this->artisan('support-tickets:release-expired-assignments')
+            ->expectsOutput('Support ticket assignments released: 1')
+            ->assertExitCode(0);
+
+        $this->assertSame($admin->id, (int) $active->fresh()->assigned_to_user_id);
+        $this->assertNull($expired->fresh()->assigned_to_user_id);
+        $this->assertNull($expired->fresh()->assigned_at);
+    }
+
+    public function test_command_contract_is_exposed(): void
+    {
+        $command = new SupportTicketsReleaseExpiredAssignments(
+            $this->app->make(\STS\Services\SupportTicketService::class)
+        );
+
+        $this->assertSame('support-tickets:release-expired-assignments', $command->getName());
+        $this->assertStringContainsString('Release expired support ticket assignments', $command->getDescription());
+    }
+}

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -101,7 +101,24 @@ class SupportTicketTest extends TestCase
             'updated_by',
             'closed_by',
             'closed_at',
+            'assigned_to_user_id',
+            'assigned_at',
         ], (new SupportTicket)->getFillable());
+    }
+
+    public function test_assigned_to_relation_resolves_user(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = $this->makeTicket($owner, [
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => '2026-07-19 12:00:00',
+        ]);
+
+        $ticket = $ticket->fresh(['assignedTo']);
+
+        $this->assertTrue($ticket->assignedTo->is($admin));
+        $this->assertInstanceOf(CarbonInterface::class, $ticket->assigned_at);
     }
 
     private function makeTicket(User $user, array $overrides = []): SupportTicket

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -210,6 +210,22 @@ class SupportTicketServiceTest extends TestCase
         $this->assertNotNull($ticket->last_reply_at);
     }
 
+    public function test_apply_admin_reply_transition_clears_active_assignment(): void
+    {
+        $ticket = new SupportTicket([
+            'status' => 'Open',
+            'unread_for_user' => 0,
+            'unread_for_admin' => 1,
+            'assigned_to_user_id' => 12,
+            'assigned_at' => now(),
+        ]);
+
+        $this->service()->applyAdminReplyTransition($ticket, 99);
+
+        $this->assertNull($ticket->assigned_to_user_id);
+        $this->assertNull($ticket->assigned_at);
+    }
+
     public function test_apply_admin_reply_transition_when_waiting_for_user_stays_esperando_respuesta(): void
     {
         $ticket = new SupportTicket([

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -444,4 +444,32 @@ class SupportTicketServiceTest extends TestCase
         $this->assertFalse($service->ticketAcceptsReplies(new SupportTicket(['status' => 'Cerrado'])));
         $this->assertTrue($service->ticketAcceptsReplies(new SupportTicket(['status' => 'Open'])));
     }
+
+    public function test_ticket_is_assignable_by_admin_for_actionable_statuses(): void
+    {
+        $service = $this->service();
+
+        $this->assertTrue($service->ticketIsAssignableByAdmin(new SupportTicket(['status' => 'Open', 'unread_for_admin' => 0])));
+        $this->assertTrue($service->ticketIsAssignableByAdmin(new SupportTicket(['status' => 'En revision', 'unread_for_admin' => 0])));
+        $this->assertTrue($service->ticketIsAssignableByAdmin(new SupportTicket([
+            'status' => SupportTicket::STATUS_NEEDS_REVIEW,
+            'unread_for_admin' => 0,
+        ])));
+        $this->assertTrue($service->ticketIsAssignableByAdmin(new SupportTicket([
+            'status' => 'Esperando respuesta',
+            'unread_for_admin' => 1,
+        ])));
+    }
+
+    public function test_ticket_is_not_assignable_by_admin_when_waiting_on_user_without_unread(): void
+    {
+        $service = $this->service();
+
+        $this->assertFalse($service->ticketIsAssignableByAdmin(new SupportTicket([
+            'status' => 'Esperando respuesta',
+            'unread_for_admin' => 0,
+        ])));
+        $this->assertFalse($service->ticketIsAssignableByAdmin(new SupportTicket(['status' => 'Resuelto', 'unread_for_admin' => 0])));
+        $this->assertFalse($service->ticketIsAssignableByAdmin(new SupportTicket(['status' => 'Cerrado', 'unread_for_admin' => 0])));
+    }
 }

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -663,4 +663,51 @@ class SupportTicketServiceTest extends TestCase
         $this->assertNull($expired->fresh()->assigned_to_user_id);
         $this->assertNull($expired->fresh()->assigned_at);
     }
+
+    public function test_admin_can_reply_to_ticket_when_assigned_to_them(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => User::factory()->create()->id,
+            'type' => 'contact',
+            'subject' => 'Assigned to me',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->assertTrue($this->service()->adminCanReplyToTicket($ticket, $admin));
+    }
+
+    public function test_admin_cannot_reply_to_ticket_assigned_to_another_admin(): void
+    {
+        $assignee = User::factory()->create(['is_admin' => true]);
+        $otherAdmin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => User::factory()->create()->id,
+            'type' => 'contact',
+            'subject' => 'Assigned elsewhere',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $assignee->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->assertFalse($this->service()->adminCanReplyToTicket($ticket, $otherAdmin));
+    }
+
+    public function test_admin_can_reply_when_ticket_is_unassigned(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => User::factory()->create()->id,
+            'type' => 'contact',
+            'subject' => 'Unassigned',
+            'status' => 'Open',
+            'priority' => 'normal',
+        ]);
+
+        $this->assertTrue($this->service()->adminCanReplyToTicket($ticket, $admin));
+    }
 }

--- a/tests/Unit/Services/SupportTicketServiceTest.php
+++ b/tests/Unit/Services/SupportTicketServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services;
 
+use Carbon\Carbon;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use STS\Models\SupportTicket;
@@ -10,6 +11,9 @@ use STS\Models\SupportTicketReply;
 use STS\Models\User;
 use STS\Services\SupportTicketService;
 use STS\Support\SupportTicketOpeningAutoReply;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Tests\TestCase;
 
 class SupportTicketServiceTest extends TestCase
@@ -471,5 +475,176 @@ class SupportTicketServiceTest extends TestCase
         ])));
         $this->assertFalse($service->ticketIsAssignableByAdmin(new SupportTicket(['status' => 'Resuelto', 'unread_for_admin' => 0])));
         $this->assertFalse($service->ticketIsAssignableByAdmin(new SupportTicket(['status' => 'Cerrado', 'unread_for_admin' => 0])));
+    }
+
+    public function test_assign_ticket_to_admin_sets_assignment_fields(): void
+    {
+        Carbon::setTestNow('2026-07-19 12:00:00');
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+        ]);
+
+        $this->service()->assignTicketToAdmin($ticket->fresh(), $admin);
+
+        $fresh = $ticket->fresh();
+        $this->assertSame($admin->id, (int) $fresh->assigned_to_user_id);
+        $this->assertSame('2026-07-19 12:00:00', $fresh->assigned_at?->format('Y-m-d H:i:s'));
+        $this->assertSame($admin->id, (int) $fresh->updated_by);
+    }
+
+    public function test_assign_ticket_to_admin_rejects_non_assignable_ticket(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Esperando respuesta',
+            'priority' => 'normal',
+            'unread_for_admin' => 0,
+        ]);
+
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->service()->assignTicketToAdmin($ticket->fresh(), $admin);
+    }
+
+    public function test_assign_ticket_to_admin_rejects_ticket_assigned_to_another_admin(): void
+    {
+        Carbon::setTestNow('2026-07-19 12:00:00');
+        $owner = User::factory()->create();
+        $adminA = User::factory()->create(['is_admin' => true]);
+        $adminB = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $adminA->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->expectException(ConflictHttpException::class);
+        $this->service()->assignTicketToAdmin($ticket->fresh(), $adminB);
+    }
+
+    public function test_assign_ticket_to_admin_succeeds_when_prior_assignment_expired(): void
+    {
+        Carbon::setTestNow('2026-07-19 12:00:00');
+        config()->set('carpoolear.support_ticket_assignment_timeout_minutes', 10);
+        $owner = User::factory()->create();
+        $adminA = User::factory()->create(['is_admin' => true]);
+        $adminB = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $adminA->id,
+            'assigned_at' => now()->subMinutes(11),
+        ]);
+
+        $this->service()->assignTicketToAdmin($ticket->fresh(), $adminB);
+
+        $fresh = $ticket->fresh();
+        $this->assertSame($adminB->id, (int) $fresh->assigned_to_user_id);
+        $this->assertSame('2026-07-19 12:00:00', $fresh->assigned_at?->format('Y-m-d H:i:s'));
+    }
+
+    public function test_unassign_ticket_from_admin_clears_assignment_for_assignee(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->service()->unassignTicketFromAdmin($ticket->fresh(), $admin);
+
+        $fresh = $ticket->fresh();
+        $this->assertNull($fresh->assigned_to_user_id);
+        $this->assertNull($fresh->assigned_at);
+    }
+
+    public function test_unassign_ticket_from_admin_rejects_non_assignee(): void
+    {
+        $owner = User::factory()->create();
+        $assignee = User::factory()->create(['is_admin' => true]);
+        $otherAdmin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $assignee->id,
+            'assigned_at' => now(),
+        ]);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->service()->unassignTicketFromAdmin($ticket->fresh(), $otherAdmin);
+    }
+
+    public function test_unassign_ticket_from_admin_rejects_unassigned_ticket(): void
+    {
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $ticket = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Help',
+            'status' => 'Open',
+            'priority' => 'normal',
+        ]);
+
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->service()->unassignTicketFromAdmin($ticket->fresh(), $admin);
+    }
+
+    public function test_release_expired_assignments_clears_stale_claims(): void
+    {
+        Carbon::setTestNow('2026-07-19 12:00:00');
+        config()->set('carpoolear.support_ticket_assignment_timeout_minutes', 10);
+        $owner = User::factory()->create();
+        $admin = User::factory()->create(['is_admin' => true]);
+        $active = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Active',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now()->subMinutes(5),
+        ]);
+        $expired = SupportTicket::query()->create([
+            'user_id' => $owner->id,
+            'type' => 'contact',
+            'subject' => 'Expired',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'assigned_to_user_id' => $admin->id,
+            'assigned_at' => now()->subMinutes(11),
+        ]);
+
+        $released = $this->service()->releaseExpiredAssignments();
+
+        $this->assertSame(1, $released);
+        $this->assertSame($admin->id, (int) $active->fresh()->assigned_to_user_id);
+        $this->assertNull($expired->fresh()->assigned_to_user_id);
+        $this->assertNull($expired->fresh()->assigned_at);
     }
 }


### PR DESCRIPTION
## Summary
- Add `assigned_to_user_id` / `assigned_at` on support tickets with assign-me and unassign-me admin API endpoints.
- Enforce assignability using the same rules as tickets needing admin attention; block conflicts when another admin holds an active claim.
- Auto-release assignments after 10 minutes via lazy expiry on read, a scheduled minute command, and clear assignment on admin reply/resolve/close.

## Related PR
- Frontend companion: https://github.com/STS-Rosario/carpoolear/pull/new/admin-tickets-assign (will update link after frontend PR is created)

## Test plan
- [x] `php artisan test` (3356 passed)
- [x] Admin A assigns an Open ticket via `POST /api/admin/support/tickets/{id}/assign-me`
- [x] Admin B receives 409 when ticket is actively assigned to Admin A
- [x] Assignment clears after 10+ minutes (or via `support-tickets:release-expired-assignments`)
- [x] Admin reply clears assignment
- [x] `GET /api/admin/support/tickets` returns `assigned_to` payload