### PR TITLE
Purge rejected manual validation photos after 7 days

### DIFF
--- a/app/Console/Commands/PurgeRejectedManualIdentityValidationPhotos.php
+++ b/app/Console/Commands/PurgeRejectedManualIdentityValidationPhotos.php
@@ -3,8 +3,8 @@
 namespace STS\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Storage;
 use STS\Models\ManualIdentityValidation;
+use STS\Services\ManualIdentityValidationDeletion;
 
 class PurgeRejectedManualIdentityValidationPhotos extends Command
 {
@@ -33,26 +33,12 @@ class PurgeRejectedManualIdentityValidationPhotos extends Command
         $purgedCount = 0;
 
         foreach ($items as $item) {
-            $this->purgePhotos($item);
+            ManualIdentityValidationDeletion::purgeStoredPhotos($item);
             $purgedCount++;
         }
 
         $this->info('Rejected manual identity validation photos purged: '.$purgedCount);
 
         return self::SUCCESS;
-    }
-
-    private function purgePhotos(ManualIdentityValidation $item): void
-    {
-        foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
-            $path = $item->$column;
-            if ($path && Storage::disk('local')->exists($path)) {
-                Storage::disk('local')->delete($path);
-            }
-            $item->$column = null;
-        }
-
-        $item->images_purged_at = now();
-        $item->save();
     }
 }

--- a/app/Console/Commands/PurgeRejectedManualIdentityValidationPhotos.php
+++ b/app/Console/Commands/PurgeRejectedManualIdentityValidationPhotos.php
@@ -5,6 +5,7 @@ namespace STS\Console\Commands;
 use Illuminate\Console\Command;
 use STS\Models\ManualIdentityValidation;
 use STS\Services\ManualIdentityValidationDeletion;
+use STS\Services\ManualIdentityValidationPhotosPurgedNotifier;
 
 class PurgeRejectedManualIdentityValidationPhotos extends Command
 {
@@ -13,12 +14,19 @@ class PurgeRejectedManualIdentityValidationPhotos extends Command
 
     protected $description = 'Purge photos from rejected manual identity validations after retention period';
 
+    public function __construct(
+        private readonly ManualIdentityValidationPhotosPurgedNotifier $photosPurgedNotifier,
+    ) {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $days = (int) ($this->option('days') ?: config('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7));
         $threshold = now()->subDays($days);
 
         $items = ManualIdentityValidation::query()
+            ->with('user')
             ->where('review_status', ManualIdentityValidation::REVIEW_STATUS_REJECTED)
             ->whereNull('images_purged_at')
             ->whereNotNull('reviewed_at')
@@ -34,6 +42,10 @@ class PurgeRejectedManualIdentityValidationPhotos extends Command
 
         foreach ($items as $item) {
             ManualIdentityValidationDeletion::purgeStoredPhotos($item);
+            $item->loadMissing('user');
+            if ($item->user) {
+                $this->photosPurgedNotifier->notify($item->user, $item);
+            }
             $purgedCount++;
         }
 

--- a/app/Console/Commands/PurgeRejectedManualIdentityValidationPhotos.php
+++ b/app/Console/Commands/PurgeRejectedManualIdentityValidationPhotos.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use STS\Models\ManualIdentityValidation;
+
+class PurgeRejectedManualIdentityValidationPhotos extends Command
+{
+    protected $signature = 'manual-identity-validation:purge-rejected-photos
+                            {--days= : Number of days after rejection before purging photos}';
+
+    protected $description = 'Purge photos from rejected manual identity validations after retention period';
+
+    public function handle(): int
+    {
+        $days = (int) ($this->option('days') ?: config('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7));
+        $threshold = now()->subDays($days);
+
+        $items = ManualIdentityValidation::query()
+            ->where('review_status', ManualIdentityValidation::REVIEW_STATUS_REJECTED)
+            ->whereNull('images_purged_at')
+            ->whereNotNull('reviewed_at')
+            ->where('reviewed_at', '<=', $threshold)
+            ->where(function ($query) {
+                $query->whereNotNull('front_image_path')
+                    ->orWhereNotNull('back_image_path')
+                    ->orWhereNotNull('selfie_image_path');
+            })
+            ->get();
+
+        $purgedCount = 0;
+
+        foreach ($items as $item) {
+            $this->purgePhotos($item);
+            $purgedCount++;
+        }
+
+        $this->info('Rejected manual identity validation photos purged: '.$purgedCount);
+
+        return self::SUCCESS;
+    }
+
+    private function purgePhotos(ManualIdentityValidation $item): void
+    {
+        foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
+            $path = $item->$column;
+            if ($path && Storage::disk('local')->exists($path)) {
+                Storage::disk('local')->delete($path);
+            }
+            $item->$column = null;
+        }
+
+        $item->images_purged_at = now();
+        $item->save();
+    }
+}

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -9,6 +9,7 @@ use STS\Http\Controllers\Controller;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\SupportTicket;
 use STS\Models\User;
+use STS\Services\ManualIdentityValidationDeletion;
 use STS\Services\ManualIdentityValidationReviewNotifier;
 use STS\Services\UserIdentityVerificationSuccessService;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -278,9 +279,7 @@ class ManualIdentityValidationController extends Controller
     {
         $item = ManualIdentityValidation::findOrFail($id);
 
-        $this->deleteStoredPhotos($item);
-        $item->images_purged_at = now();
-        $item->save();
+        ManualIdentityValidationDeletion::purgeStoredPhotos($item);
 
         return response()->json(['message' => 'Photos purged', 'data' => $item->fresh()]);
     }

--- a/app/Notifications/ManualIdentityValidationPhotosPurgedNotification.php
+++ b/app/Notifications/ManualIdentityValidationPhotosPurgedNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace STS\Notifications;
+
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+
+class ManualIdentityValidationPhotosPurgedNotification extends BaseNotification
+{
+    protected $via = [
+        DatabaseChannel::class,
+        PushChannel::class,
+    ];
+
+    public function toString()
+    {
+        return __('notifications.manual_identity_validation.photos_purged');
+    }
+
+    public function getExtras()
+    {
+        return [
+            'type' => 'identity_validation_manual',
+            'request_id' => (int) $this->getAttribute('request_id'),
+            'resubmit' => '1',
+        ];
+    }
+
+    public function toPush($user, $device)
+    {
+        $requestId = (int) $this->getAttribute('request_id');
+
+        return [
+            'message' => __('notifications.manual_identity_validation.photos_purged'),
+            'url' => '/app/setting/identity-validation/manual?request_id='.$requestId.'&resubmit=1',
+            'type' => 'identity_validation_manual',
+            'extras' => [
+                'request_id' => $requestId,
+                'resubmit' => '1',
+            ],
+            'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
+        ];
+    }
+}

--- a/app/Services/ManualIdentityValidationDeletion.php
+++ b/app/Services/ManualIdentityValidationDeletion.php
@@ -16,13 +16,21 @@ class ManualIdentityValidationDeletion
 
     public static function deleteRecord(ManualIdentityValidation $item): void
     {
+        self::purgeStoredPhotos($item);
+        $item->delete();
+    }
+
+    public static function purgeStoredPhotos(ManualIdentityValidation $item): void
+    {
         foreach (['front_image_path', 'back_image_path', 'selfie_image_path'] as $column) {
             $path = $item->$column;
             if ($path && Storage::disk('local')->exists($path)) {
                 Storage::disk('local')->delete($path);
             }
+            $item->$column = null;
         }
 
-        $item->delete();
+        $item->images_purged_at = now();
+        $item->save();
     }
 }

--- a/app/Services/ManualIdentityValidationPhotosPurgedNotifier.php
+++ b/app/Services/ManualIdentityValidationPhotosPurgedNotifier.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\ManualIdentityValidation;
+use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationPhotosPurgedNotification;
+
+class ManualIdentityValidationPhotosPurgedNotifier
+{
+    public function notify(User $user, ManualIdentityValidation $validation): void
+    {
+        $notification = new ManualIdentityValidationPhotosPurgedNotification;
+        $notification->setAttribute('request_id', $validation->id);
+
+        try {
+            $notification->notify($user);
+        } catch (\Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -47,6 +47,8 @@ return [
     'manual_identity_validation_cost_cents' => (int) env('MANUAL_IDENTITY_VALIDATION_COST_CENTS', 0),
     // Max document submissions per paid manual validation request (including the first upload).
     'manual_identity_validation_max_submissions' => (int) env('MANUAL_IDENTITY_VALIDATION_MAX_SUBMISSIONS', 3),
+    // Days to keep photos after admin rejects a manual validation before auto-purging.
+    'manual_identity_validation_rejected_photo_retention_days' => (int) env('MANUAL_IDENTITY_VALIDATION_REJECTED_PHOTO_RETENTION_DAYS', 7),
 
     // Master switch: when false, hide identity validation UI and do not enforce (except admin flows).
     'identity_validation_enabled' => filter_var(env('IDENTITY_VALIDATION_ENABLED', false), FILTER_VALIDATE_BOOLEAN),

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -120,4 +120,5 @@ return [
     // ManualIdentityValidationReviewNotification
     'manual_identity_validation.approved' => 'Tu verificación de cuenta fue aprobada. Click acá para ver más información.',
     'manual_identity_validation.rejected' => 'Tu verificación de cuenta fue rechazada. Click acá para ver más información.',
+    'manual_identity_validation.photos_purged' => 'Las fotos de tu validación manual fueron eliminadas, volvelas a subir para continuar',
 ];

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -114,4 +114,5 @@ return [
     // ManualIdentityValidationReviewNotification
     'manual_identity_validation.approved' => 'Tu verificación de cuenta fue aprobada. Click acá para ver más información.',
     'manual_identity_validation.rejected' => 'Tu verificación de cuenta fue rechazada. Click acá para ver más información.',
+    'manual_identity_validation.photos_purged' => 'Las fotos de tu validación manual fueron eliminadas, volvelas a subir para continuar',
 ];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -115,4 +115,5 @@ return [
     // ManualIdentityValidationReviewNotification
     'manual_identity_validation.approved' => 'Your account verification was approved. Click here for more information.',
     'manual_identity_validation.rejected' => 'Your account verification was rejected. Click here for more information.',
+    'manual_identity_validation.photos_purged' => 'Your manual validation photos were deleted. Upload them again to continue.',
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -45,6 +45,11 @@ Schedule::command('auth:cleanup-reset-tokens')->dailyAt('04:00')->timezone('Amer
 // Auto-close resolved support tickets after configured inactivity days
 Schedule::command('support-tickets:autoclose')->dailyAt('04:30')->timezone('America/Argentina/Buenos_Aires');
 
+// Purge photos from rejected manual identity validations after retention period
+Schedule::command('manual-identity-validation:purge-rejected-photos')
+    ->dailyAt('05:00')
+    ->timezone('America/Argentina/Buenos_Aires');
+
 Schedule::command('support-tickets:release-expired-assignments')
     ->everyMinute()
     ->timezone('America/Argentina/Buenos_Aires');

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -112,6 +112,13 @@ class ScheduleTest extends TestCase
         $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
     }
 
+    public function test_manual_identity_validation_purge_rejected_photos_is_scheduled_daily_at5_am()
+    {
+        $event = $this->findEvent('manual-identity-validation:purge-rejected-photos');
+        $this->assertEquals('0 5 * * *', $event->expression);
+        $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
+    }
+
     public function test_support_tickets_release_expired_assignments_is_scheduled_every_minute()
     {
         $event = $this->findEvent('support-tickets:release-expired-assignments');
@@ -154,6 +161,7 @@ class ScheduleTest extends TestCase
             'users:calculate-active-per-month',
             'auth:cleanup-reset-tokens',
             'support-tickets:autoclose',
+            'manual-identity-validation:purge-rejected-photos',
             'support-tickets:release-expired-assignments',
             'car-catalog:sync-argautos',
         ];

--- a/tests/Unit/Console/Commands/PurgeRejectedManualIdentityValidationPhotosTest.php
+++ b/tests/Unit/Console/Commands/PurgeRejectedManualIdentityValidationPhotosTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use STS\Models\ManualIdentityValidation;
+use STS\Models\User;
+use Tests\TestCase;
+
+class PurgeRejectedManualIdentityValidationPhotosTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_handle_purges_photos_for_rejected_requests_older_than_retention_days(): void
+    {
+        Storage::fake('local');
+        Carbon::setTestNow(Carbon::create(2026, 7, 26, 5, 0, 0));
+        Config::set('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7);
+
+        $user = User::factory()->create();
+        $front = 'identity_validations/1/front.jpg';
+        $back = 'identity_validations/1/back.jpg';
+        $selfie = 'identity_validations/1/selfie.jpg';
+        Storage::disk('local')->put($front, 'front-bytes');
+        Storage::disk('local')->put($back, 'back-bytes');
+        Storage::disk('local')->put($selfie, 'selfie-bytes');
+
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => Carbon::now()->subDays(20),
+            'submitted_at' => Carbon::now()->subDays(15),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'reviewed_at' => Carbon::now()->subDays(8),
+            'front_image_path' => $front,
+            'back_image_path' => $back,
+            'selfie_image_path' => $selfie,
+        ]);
+
+        $this->artisan('manual-identity-validation:purge-rejected-photos')
+            ->expectsOutput('Rejected manual identity validation photos purged: 1')
+            ->assertExitCode(0);
+
+        $fresh = $row->fresh();
+        $this->assertFalse(Storage::disk('local')->exists($front));
+        $this->assertFalse(Storage::disk('local')->exists($back));
+        $this->assertFalse(Storage::disk('local')->exists($selfie));
+        $this->assertNull($fresh->front_image_path);
+        $this->assertNull($fresh->back_image_path);
+        $this->assertNull($fresh->selfie_image_path);
+        $this->assertNotNull($fresh->images_purged_at);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_REJECTED, $fresh->review_status);
+    }
+}

--- a/tests/Unit/Console/Commands/PurgeRejectedManualIdentityValidationPhotosTest.php
+++ b/tests/Unit/Console/Commands/PurgeRejectedManualIdentityValidationPhotosTest.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use STS\Models\ManualIdentityValidation;
 use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationPhotosPurgedNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
 
 class PurgeRejectedManualIdentityValidationPhotosTest extends TestCase
@@ -140,5 +144,50 @@ class PurgeRejectedManualIdentityValidationPhotosTest extends TestCase
             '2026-07-24 05:00:00',
             $row->fresh()->images_purged_at->format('Y-m-d H:i:s')
         );
+    }
+
+    public function test_handle_notifies_user_when_photos_are_purged(): void
+    {
+        Storage::fake('local');
+        Carbon::setTestNow(Carbon::create(2026, 7, 26, 5, 0, 0));
+        Config::set('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7);
+
+        $user = User::factory()->create();
+        $front = 'identity_validations/4/front.jpg';
+        Storage::disk('local')->put($front, 'front-bytes');
+
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => Carbon::now()->subDays(20),
+            'submitted_at' => Carbon::now()->subDays(15),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'reviewed_at' => Carbon::now()->subDays(8),
+            'front_image_path' => $front,
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) use ($user, $row) {
+            $mock->shouldReceive('send')
+                ->twice()
+                ->withArgs(function ($notification, $recipient, $channel) use ($user, $row) {
+                    if (! $notification instanceof ManualIdentityValidationPhotosPurgedNotification) {
+                        return false;
+                    }
+                    if ((int) $notification->getAttribute('request_id') !== (int) $row->id) {
+                        return false;
+                    }
+                    if (! $recipient instanceof User || (int) $recipient->id !== (int) $user->id) {
+                        return false;
+                    }
+
+                    return in_array($channel, [
+                        DatabaseChannel::class,
+                        PushChannel::class,
+                    ], true);
+                });
+        });
+
+        $this->artisan('manual-identity-validation:purge-rejected-photos')
+            ->assertExitCode(0);
     }
 }

--- a/tests/Unit/Console/Commands/PurgeRejectedManualIdentityValidationPhotosTest.php
+++ b/tests/Unit/Console/Commands/PurgeRejectedManualIdentityValidationPhotosTest.php
@@ -57,4 +57,88 @@ class PurgeRejectedManualIdentityValidationPhotosTest extends TestCase
         $this->assertNotNull($fresh->images_purged_at);
         $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_REJECTED, $fresh->review_status);
     }
+
+    public function test_handle_does_not_purge_pending_requests_awaiting_admin_review(): void
+    {
+        Storage::fake('local');
+        Carbon::setTestNow(Carbon::create(2026, 7, 26, 5, 0, 0));
+        Config::set('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7);
+
+        $user = User::factory()->create();
+        $front = 'identity_validations/2/front.jpg';
+        Storage::disk('local')->put($front, 'front-bytes');
+
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => Carbon::now()->subDays(20),
+            'submitted_at' => Carbon::now()->subDays(15),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+            'front_image_path' => $front,
+        ]);
+
+        $this->artisan('manual-identity-validation:purge-rejected-photos')
+            ->expectsOutput('Rejected manual identity validation photos purged: 0')
+            ->assertExitCode(0);
+
+        $this->assertTrue(Storage::disk('local')->exists($front));
+        $this->assertSame($front, $row->fresh()->front_image_path);
+        $this->assertNull($row->fresh()->images_purged_at);
+    }
+
+    public function test_handle_does_not_purge_recently_rejected_requests(): void
+    {
+        Storage::fake('local');
+        Carbon::setTestNow(Carbon::create(2026, 7, 26, 5, 0, 0));
+        Config::set('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7);
+
+        $user = User::factory()->create();
+        $front = 'identity_validations/3/front.jpg';
+        Storage::disk('local')->put($front, 'front-bytes');
+
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => Carbon::now()->subDays(10),
+            'submitted_at' => Carbon::now()->subDays(5),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'reviewed_at' => Carbon::now()->subDays(3),
+            'front_image_path' => $front,
+        ]);
+
+        $this->artisan('manual-identity-validation:purge-rejected-photos')
+            ->expectsOutput('Rejected manual identity validation photos purged: 0')
+            ->assertExitCode(0);
+
+        $this->assertTrue(Storage::disk('local')->exists($front));
+        $this->assertSame($front, $row->fresh()->front_image_path);
+        $this->assertNull($row->fresh()->images_purged_at);
+    }
+
+    public function test_handle_does_not_purge_already_purged_requests(): void
+    {
+        Storage::fake('local');
+        Carbon::setTestNow(Carbon::create(2026, 7, 26, 5, 0, 0));
+        Config::set('carpoolear.manual_identity_validation_rejected_photo_retention_days', 7);
+
+        $user = User::factory()->create();
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => Carbon::now()->subDays(20),
+            'submitted_at' => Carbon::now()->subDays(15),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+            'reviewed_at' => Carbon::now()->subDays(10),
+            'images_purged_at' => Carbon::now()->subDays(2),
+        ]);
+
+        $this->artisan('manual-identity-validation:purge-rejected-photos')
+            ->expectsOutput('Rejected manual identity validation photos purged: 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            '2026-07-24 05:00:00',
+            $row->fresh()->images_purged_at->format('Y-m-d H:i:s')
+        );
+    }
 }

--- a/tests/Unit/Notifications/ManualIdentityValidationPhotosPurgedNotificationTest.php
+++ b/tests/Unit/Notifications/ManualIdentityValidationPhotosPurgedNotificationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Notifications;
+
+use STS\Notifications\ManualIdentityValidationPhotosPurgedNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+use Tests\TestCase;
+
+class ManualIdentityValidationPhotosPurgedNotificationTest extends TestCase
+{
+    public function test_via_contains_database_and_push_channels(): void
+    {
+        $notification = new ManualIdentityValidationPhotosPurgedNotification;
+
+        $this->assertSame([
+            DatabaseChannel::class,
+            PushChannel::class,
+        ], $notification->getVia());
+    }
+
+    public function test_to_string_returns_photos_purged_message(): void
+    {
+        $notification = new ManualIdentityValidationPhotosPurgedNotification;
+
+        $this->assertSame(
+            __('notifications.manual_identity_validation.photos_purged'),
+            $notification->toString()
+        );
+    }
+
+    public function test_get_extras_returns_manual_validation_type_and_request_id(): void
+    {
+        $notification = new ManualIdentityValidationPhotosPurgedNotification;
+        $notification->setAttribute('request_id', 42);
+
+        $this->assertSame([
+            'type' => 'identity_validation_manual',
+            'request_id' => 42,
+            'resubmit' => '1',
+        ], $notification->getExtras());
+    }
+
+    public function test_to_push_builds_manual_validation_url_with_request_id(): void
+    {
+        $notification = new ManualIdentityValidationPhotosPurgedNotification;
+        $notification->setAttribute('request_id', 42);
+
+        $push = $notification->toPush(null, null);
+
+        $this->assertSame(
+            __('notifications.manual_identity_validation.photos_purged'),
+            $push['message']
+        );
+        $this->assertSame('/app/setting/identity-validation/manual?request_id=42&resubmit=1', $push['url']);
+        $this->assertSame('identity_validation_manual', $push['type']);
+        $this->assertSame(42, $push['extras']['request_id']);
+        $this->assertSame('1', $push['extras']['resubmit']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a daily scheduled command that purges photos from manual identity validations rejected more than 7 days ago when the user has not re-uploaded
- Sends a notification with the message "Las fotos de tu validación manual fueron eliminadas, volvelas a subir para continuar"
- Only affects `rejected` requests with stored photos; pending requests awaiting admin review are untouched
- Reuses shared `ManualIdentityValidationDeletion::purgeStoredPhotos()` for file cleanup

## Test plan
- [x] `php artisan test` for purge command, notification, and schedule tests
- [ ] Reject a manual validation, wait 7+ days (or run `php artisan manual-identity-validation:purge-rejected-photos --days=0` in staging), confirm photos are deleted and user receives notification
- [ ] Confirm pending validations are not purged
- [ ] Confirm notification deep-links to manual validation upload page