### PR TITLE
Group chat: create at 3 participants with notifications

### DIFF
--- a/app/Listeners/Conversation/addUserConversation.php
+++ b/app/Listeners/Conversation/addUserConversation.php
@@ -3,35 +3,16 @@
 namespace STS\Listeners\Conversation;
 
 use STS\Events\Passenger\Accept;
-use STS\Repository\ConversationRepository;
-use STS\Services\Logic\ConversationsManager;
+use STS\Services\TripGroupChatService;
 
 class addUserConversation
 {
-    protected $conversationRepo;
-
-    protected $conversationLogic;
-
-    public function __construct(ConversationRepository $repo, ConversationsManager $logic)
-    {
-        $this->conversationRepo = $repo;
-        $this->conversationLogic = $logic;
-    }
+    public function __construct(private TripGroupChatService $tripGroupChatService) {}
 
     public function handle(Accept $event)
     {
-        $converstion = $event->trip->conversation;
-        if ($converstion) {
-            $this->conversationRepo->addUser($converstion, $event->to);
-            $subject = is_object($event->to) ? $event->to : \STS\Models\User::find($event->to);
-            if ($subject) {
-                $this->conversationLogic->sendSystemMessage(
-                    $converstion->fresh(),
-                    $subject,
-                    'notifications.group_chat_user_joined',
-                    ['name' => $subject->name]
-                );
-            }
+        if ($event->to) {
+            $this->tripGroupChatService->syncOnPassengerAccept($event->trip, $event->to);
         }
     }
 }

--- a/app/Listeners/Conversation/createConversation.php
+++ b/app/Listeners/Conversation/createConversation.php
@@ -4,7 +4,7 @@ namespace STS\Listeners\Conversation;
 
 use STS\Events\Trip\Create;
 use STS\Repository\ConversationRepository;
-use STS\Services\Logic\ConversationsManager; 
+use STS\Services\Logic\ConversationsManager;
 
 class createConversation
 {
@@ -26,13 +26,10 @@ class createConversation
     /**
      * Handle the event.
      *
-     * @param  Create  $event
      * @return void
      */
     public function handle(Create $event)
     {
-        $trip = $event->trip;
-        $c = $this->conversationLogic->createTripConversation($event->trip->id);
-        $this->repoConv->addUser($c, $trip->user);
+        // Trip group chats are created once the trip reaches three participants.
     }
 }

--- a/app/Notifications/TripGroupChatCreatedNotification.php
+++ b/app/Notifications/TripGroupChatCreatedNotification.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace STS\Notifications;
+
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+
+class TripGroupChatCreatedNotification extends BaseNotification
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->via = [
+            DatabaseChannel::class,
+            PushChannel::class,
+        ];
+    }
+
+    public function toString()
+    {
+        $trip = $this->getAttribute('trip');
+
+        return __('notifications.group_chat_created.message', [
+            'destination' => $trip ? $trip->to_town : __('notifications.destination_unknown'),
+            'day' => $this->tripDay($trip),
+            'hour' => $this->tripHour($trip),
+        ]);
+    }
+
+    public function getExtras()
+    {
+        $conversation = $this->getAttribute('conversation');
+
+        return [
+            'type' => 'conversation',
+            'conversation_id' => $conversation ? $conversation->id : null,
+        ];
+    }
+
+    public function toPush($user, $device)
+    {
+        $conversation = $this->getAttribute('conversation');
+        $conversationId = $conversation ? $conversation->id : '';
+
+        return [
+            'message' => $this->toString(),
+            'url' => '/conversations/'.$conversationId,
+            'type' => 'conversation',
+            'extras' => [
+                'id' => $conversationId,
+            ],
+            'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
+        ];
+    }
+
+    private function tripDay($trip): string
+    {
+        if (! $trip || ! $trip->trip_date) {
+            return __('notifications.date_not_available');
+        }
+
+        return $trip->trip_date->format('d/m/Y');
+    }
+
+    private function tripHour($trip): string
+    {
+        if (! $trip || ! $trip->trip_date) {
+            return __('notifications.date_not_available');
+        }
+
+        return $trip->trip_date->format('H:i');
+    }
+}

--- a/app/Services/TripGroupChatService.php
+++ b/app/Services/TripGroupChatService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\Passenger;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Repository\ConversationRepository;
+use STS\Services\Logic\ConversationsManager;
+
+class TripGroupChatService
+{
+    public const MIN_PARTICIPANTS = 3;
+
+    public function __construct(
+        private ConversationsManager $conversationLogic,
+        private ConversationRepository $conversationRepo,
+    ) {}
+
+    public function syncOnPassengerAccept(Trip $trip, User $acceptedUser): void
+    {
+        $trip = $trip->fresh();
+
+        if ($this->participantCount($trip) < self::MIN_PARTICIPANTS) {
+            return;
+        }
+
+        $conversation = $trip->conversation;
+        $isNew = ! $conversation;
+
+        if ($isNew) {
+            $conversation = $this->conversationLogic->createTripConversation($trip->id);
+            foreach ($this->participants($trip) as $participant) {
+                $this->conversationRepo->addUser($conversation, $participant);
+            }
+
+            return;
+        }
+
+        if (! $conversation->users()->whereKey($acceptedUser->id)->exists()) {
+            $this->conversationRepo->addUser($conversation, $acceptedUser);
+            $this->conversationLogic->sendSystemMessage(
+                $conversation->fresh(),
+                $acceptedUser,
+                'notifications.group_chat_user_joined',
+                ['name' => $acceptedUser->name]
+            );
+        }
+    }
+
+    private function participantCount(Trip $trip): int
+    {
+        return 1 + $trip->passenger()
+            ->whereIn('request_state', [
+                Passenger::STATE_ACCEPTED,
+                Passenger::STATE_WAITING_PAYMENT,
+            ])
+            ->count();
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, User>
+     */
+    private function participants(Trip $trip)
+    {
+        $driver = User::find($trip->user_id);
+        $passengers = $trip->passenger()
+            ->whereIn('request_state', [
+                Passenger::STATE_ACCEPTED,
+                Passenger::STATE_WAITING_PAYMENT,
+            ])
+            ->with('user')
+            ->get()
+            ->map(fn (Passenger $passenger) => $passenger->user)
+            ->filter();
+
+        return collect([$driver])->merge($passengers)->filter()->unique('id');
+    }
+}

--- a/app/Services/TripGroupChatService.php
+++ b/app/Services/TripGroupChatService.php
@@ -5,6 +5,7 @@ namespace STS\Services;
 use STS\Models\Passenger;
 use STS\Models\Trip;
 use STS\Models\User;
+use STS\Notifications\TripGroupChatCreatedNotification;
 use STS\Repository\ConversationRepository;
 use STS\Services\Logic\ConversationsManager;
 
@@ -33,6 +34,7 @@ class TripGroupChatService
             foreach ($this->participants($trip) as $participant) {
                 $this->conversationRepo->addUser($conversation, $participant);
             }
+            $this->notifyUsers($trip, $conversation->fresh(), $this->participants($trip));
 
             return;
         }
@@ -45,6 +47,20 @@ class TripGroupChatService
                 'notifications.group_chat_user_joined',
                 ['name' => $acceptedUser->name]
             );
+            $this->notifyUsers($trip, $conversation->fresh(), collect([$acceptedUser]));
+        }
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<int, User>  $users
+     */
+    private function notifyUsers(Trip $trip, $conversation, $users): void
+    {
+        foreach ($users as $user) {
+            $notification = new TripGroupChatCreatedNotification;
+            $notification->setAttribute('trip', $trip);
+            $notification->setAttribute('conversation', $conversation);
+            $notification->notify($user);
         }
     }
 

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -76,6 +76,7 @@ return [
 
     'group_chat_user_joined' => ':name se sumó al chat',
     'group_chat_user_left' => ':name se fue del chat',
+    'group_chat_created.message' => 'Se creó un chat grupal para el viaje a :destination el :day :hour para ayudar a la coordinación',
     'group_chat_message.trip_title' => 'Viaje :date :hour',
     'group_chat_message.title' => ':trip: :name @ :text',
 

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -70,6 +70,7 @@ return [
 
     'group_chat_user_joined' => ':name se sumó al chat',
     'group_chat_user_left' => ':name se fue del chat',
+    'group_chat_created.message' => 'Se creó un chat grupal para el viaje a :destination el :day :hour para ayudar a la coordinación',
     'group_chat_message.trip_title' => 'Viaje :date :hour',
     'group_chat_message.title' => ':trip: :name @ :text',
 

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -71,6 +71,7 @@ return [
     // Group chat
     'group_chat_user_joined' => ':name joined the chat',
     'group_chat_user_left' => ':name left the chat',
+    'group_chat_created.message' => 'A group chat was created for the trip to :destination on :day at :hour to help with coordination',
     'group_chat_message.trip_title' => 'Trip :date :hour',
     'group_chat_message.title' => ':trip: :name @ :text',
 

--- a/tests/Unit/MessagesTest.php
+++ b/tests/Unit/MessagesTest.php
@@ -246,7 +246,8 @@ class MessagesTest extends TestCase
     public function test_conversation_listeners_create_and_add_or_remove_trip_participant(): void
     {
         $driver = User::factory()->create();
-        $accepted = User::factory()->create();
+        $acceptedOne = User::factory()->create();
+        $acceptedTwo = User::factory()->create();
         $trip = Trip::factory()->create(['user_id' => $driver->id]);
 
         $createListener = new \STS\Listeners\Conversation\createConversation(
@@ -254,37 +255,42 @@ class MessagesTest extends TestCase
             $this->conversationRepository
         );
         $createListener->handle(new \STS\Events\Trip\Create($trip));
-        $this->assertNotNull($trip->fresh()->conversation);
+        $this->assertNull($trip->fresh()->conversation);
+
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $acceptedOne->id,
+            'request_state' => \STS\Models\Passenger::STATE_ACCEPTED,
+        ]);
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $acceptedTwo->id,
+            'request_state' => \STS\Models\Passenger::STATE_ACCEPTED,
+        ]);
+
+        $addListener = $this->app->make(\STS\Listeners\Conversation\addUserConversation::class);
+        $addListener->handle(new \STS\Events\Passenger\Accept($trip, $driver, $acceptedTwo));
 
         $conversation = $trip->fresh()->conversation;
         $this->assertInstanceOf(Conversation::class, $conversation);
-        $this->assertSame(1, $conversation->users()->count(), 'trip creator is attached on conversation creation');
-
-        $addListener = new \STS\Listeners\Conversation\addUserConversation(
-            $this->conversationRepository,
-            $this->conversationManager
-        );
-        $addListener->handle(new \STS\Events\Passenger\Accept($trip, $driver, $accepted));
-        $this->assertSame(2, $conversation->fresh()->users()->count());
-        $joinMessage = $conversation->messages()->where('is_system', true)->first();
-        $this->assertNotNull($joinMessage);
-        $this->assertStringContainsString($accepted->name, $joinMessage->text);
+        $this->assertSame(3, $conversation->users()->count());
 
         $removeListener = new \STS\Listeners\Conversation\removeUserConversation(
             $this->conversationRepository,
             $this->conversationManager
         );
-        $removeListener->handle(new \STS\Events\Passenger\Cancel($trip, $driver, $accepted, 0));
-        $this->assertSame(1, $conversation->fresh()->users()->count());
+        $removeListener->handle(new \STS\Events\Passenger\Cancel($trip, $driver, $acceptedTwo, 0));
+        $this->assertSame(2, $conversation->fresh()->users()->count());
         $leaveMessage = $conversation->messages()->where('is_system', true)->orderByDesc('id')->first();
         $this->assertNotNull($leaveMessage);
-        $this->assertStringContainsString($accepted->name, $leaveMessage->text);
+        $this->assertStringContainsString($acceptedTwo->name, $leaveMessage->text);
     }
 
     public function test_accept_adds_passenger_to_group_chat_when_private_trip_scoped_chat_exists(): void
     {
         $driver = User::factory()->create();
-        $accepted = User::factory()->create();
+        $acceptedOne = User::factory()->create();
+        $acceptedTwo = User::factory()->create();
         $trip = Trip::factory()->create(['user_id' => $driver->id]);
 
         $createListener = new \STS\Listeners\Conversation\createConversation(
@@ -292,26 +298,33 @@ class MessagesTest extends TestCase
             $this->conversationRepository
         );
         $createListener->handle(new \STS\Events\Trip\Create($trip));
-        $groupChat = $trip->fresh()->conversation;
 
         $privateChat = Conversation::factory()->create([
             'trip_id' => $trip->id,
             'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
         ]);
         $privateChat->users()->attach($driver->id, ['read' => true]);
-        $privateChat->users()->attach($accepted->id, ['read' => true]);
+        $privateChat->users()->attach($acceptedOne->id, ['read' => true]);
+        $privateChat->users()->attach($acceptedTwo->id, ['read' => true]);
 
-        $addListener = new \STS\Listeners\Conversation\addUserConversation(
-            $this->conversationRepository,
-            $this->conversationManager
-        );
-        $addListener->handle(new \STS\Events\Passenger\Accept($trip, $driver, $accepted));
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $acceptedOne->id,
+            'request_state' => \STS\Models\Passenger::STATE_ACCEPTED,
+        ]);
+        \STS\Models\Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $acceptedTwo->id,
+            'request_state' => \STS\Models\Passenger::STATE_ACCEPTED,
+        ]);
 
-        $this->assertTrue($groupChat->fresh()->users()->whereKey($accepted->id)->exists());
-        $this->assertSame(2, $groupChat->fresh()->users()->count());
-        $this->assertSame(2, $privateChat->fresh()->users()->count());
-        $joinMessage = $groupChat->messages()->where('is_system', true)->first();
-        $this->assertNotNull($joinMessage);
-        $this->assertStringContainsString($accepted->name, $joinMessage->text);
+        $addListener = $this->app->make(\STS\Listeners\Conversation\addUserConversation::class);
+        $addListener->handle(new \STS\Events\Passenger\Accept($trip, $driver, $acceptedTwo));
+
+        $groupChat = $trip->fresh()->conversation;
+        $this->assertNotNull($groupChat);
+        $this->assertTrue($groupChat->users()->whereKey($acceptedTwo->id)->exists());
+        $this->assertSame(3, $groupChat->users()->count());
+        $this->assertSame(3, $privateChat->fresh()->users()->count());
     }
 }

--- a/tests/Unit/Notifications/TripGroupChatCreatedNotificationTest.php
+++ b/tests/Unit/Notifications/TripGroupChatCreatedNotificationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit\Notifications;
+
+use Carbon\Carbon;
+use STS\Models\Conversation;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Notifications\TripGroupChatCreatedNotification;
+use Tests\TestCase;
+
+class TripGroupChatCreatedNotificationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_to_string_uses_destination_date_and_hour(): void
+    {
+        Carbon::setTestNow('2026-07-26 14:30:00');
+        $trip = Trip::factory()->create([
+            'to_town' => 'Mar del Plata',
+            'trip_date' => Carbon::parse('2026-08-01 09:00:00'),
+        ]);
+        $conversation = Conversation::factory()->create([
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+
+        $notification = new TripGroupChatCreatedNotification;
+        $notification->setAttribute('trip', $trip);
+        $notification->setAttribute('conversation', $conversation);
+
+        $this->assertSame(
+            __('notifications.group_chat_created.message', [
+                'destination' => 'Mar del Plata',
+                'day' => '01/08/2026',
+                'hour' => '09:00',
+            ]),
+            $notification->toString()
+        );
+    }
+
+    public function test_get_extras_points_to_conversation_chat(): void
+    {
+        $trip = Trip::factory()->create();
+        $conversation = Conversation::factory()->create([
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+
+        $notification = new TripGroupChatCreatedNotification;
+        $notification->setAttribute('trip', $trip);
+        $notification->setAttribute('conversation', $conversation);
+
+        $this->assertSame([
+            'type' => 'conversation',
+            'conversation_id' => $conversation->id,
+        ], $notification->getExtras());
+    }
+
+    public function test_to_push_includes_conversation_url(): void
+    {
+        $user = User::factory()->create();
+        $trip = Trip::factory()->create(['to_town' => 'Córdoba']);
+        $conversation = Conversation::factory()->create([
+            'type' => Conversation::TYPE_TRIP_CONVERSATION,
+            'trip_id' => $trip->id,
+        ]);
+
+        $notification = new TripGroupChatCreatedNotification;
+        $notification->setAttribute('trip', $trip);
+        $notification->setAttribute('conversation', $conversation);
+
+        $push = $notification->toPush($user, null);
+
+        $this->assertSame('/conversations/'.$conversation->id, $push['url']);
+        $this->assertSame('conversation', $push['type']);
+        $this->assertSame($conversation->id, $push['extras']['id']);
+    }
+}

--- a/tests/Unit/Services/TripGroupChatServiceTest.php
+++ b/tests/Unit/Services/TripGroupChatServiceTest.php
@@ -173,13 +173,14 @@ class TripGroupChatServiceTest extends TestCase
             'user_id' => $passengerTwo->id,
             'request_state' => Passenger::STATE_ACCEPTED,
         ]);
+
+        $this->service->syncOnPassengerAccept($trip->fresh(), $passengerTwo);
+
         Passenger::factory()->create([
             'trip_id' => $trip->id,
             'user_id' => $passengerThree->id,
             'request_state' => Passenger::STATE_ACCEPTED,
         ]);
-
-        $this->service->syncOnPassengerAccept($trip->fresh(), $passengerTwo);
 
         $this->mock(\STS\Services\Notifications\NotificationServices::class)
             ->shouldReceive('send')

--- a/tests/Unit/Services/TripGroupChatServiceTest.php
+++ b/tests/Unit/Services/TripGroupChatServiceTest.php
@@ -124,4 +124,73 @@ class TripGroupChatServiceTest extends TestCase
         $this->assertNotNull($conversation);
         $this->assertSame(3, $conversation->users()->count());
     }
+
+    public function test_all_participants_notified_when_group_chat_is_created(): void
+    {
+        $driver = User::factory()->create();
+        $passengerOne = User::factory()->create();
+        $passengerTwo = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerOne->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerTwo->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $this->mock(\STS\Services\Notifications\NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(6)
+            ->withArgs(function ($notification, $users, $channel) {
+                return $notification instanceof \STS\Notifications\TripGroupChatCreatedNotification
+                    && $users instanceof User
+                    && is_string($channel);
+            });
+
+        $this->service->syncOnPassengerAccept($trip->fresh(), $passengerTwo);
+    }
+
+    public function test_new_passenger_notified_when_added_to_existing_group_chat(): void
+    {
+        $driver = User::factory()->create();
+        $passengerOne = User::factory()->create();
+        $passengerTwo = User::factory()->create();
+        $passengerThree = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerOne->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerTwo->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerThree->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $this->service->syncOnPassengerAccept($trip->fresh(), $passengerTwo);
+
+        $this->mock(\STS\Services\Notifications\NotificationServices::class)
+            ->shouldReceive('send')
+            ->times(2)
+            ->withArgs(function ($notification, $users, $channel) use ($passengerThree) {
+                return $notification instanceof \STS\Notifications\TripGroupChatCreatedNotification
+                    && $users instanceof User
+                    && $users->is($passengerThree)
+                    && is_string($channel);
+            });
+
+        $this->service->syncOnPassengerAccept($trip->fresh(), $passengerThree);
+    }
 }

--- a/tests/Unit/Services/TripGroupChatServiceTest.php
+++ b/tests/Unit/Services/TripGroupChatServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Carbon\Carbon;
+use STS\Events\Passenger\Accept;
+use STS\Listeners\Conversation\addUserConversation;
+use STS\Listeners\Conversation\createConversation;
+use STS\Models\Conversation;
+use STS\Models\Passenger;
+use STS\Models\Trip;
+use STS\Models\User;
+use STS\Repository\ConversationRepository;
+use STS\Services\Logic\ConversationsManager;
+use STS\Services\TripGroupChatService;
+use Tests\TestCase;
+
+class TripGroupChatServiceTest extends TestCase
+{
+    private ConversationsManager $conversationManager;
+
+    private ConversationRepository $conversationRepository;
+
+    private TripGroupChatService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->conversationManager = $this->app->make(ConversationsManager::class);
+        $this->conversationRepository = $this->app->make(ConversationRepository::class);
+        $this->service = $this->app->make(TripGroupChatService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_trip_creation_does_not_create_group_chat(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        $listener = new createConversation($this->conversationManager, $this->conversationRepository);
+        $listener->handle(new \STS\Events\Trip\Create($trip));
+
+        $this->assertNull($trip->fresh()->conversation);
+    }
+
+    public function test_group_chat_not_created_when_trip_has_fewer_than_three_participants(): void
+    {
+        $driver = User::factory()->create();
+        $passenger = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passenger->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $this->service->syncOnPassengerAccept($trip->fresh(), $passenger);
+
+        $this->assertNull($trip->fresh()->conversation);
+    }
+
+    public function test_group_chat_created_with_all_participants_when_threshold_reached(): void
+    {
+        Carbon::setTestNow('2026-07-26 14:30:00');
+        $driver = User::factory()->create();
+        $passengerOne = User::factory()->create();
+        $passengerTwo = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'to_town' => 'Mar del Plata',
+            'trip_date' => Carbon::parse('2026-08-01 09:00:00'),
+        ]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerOne->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerTwo->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $this->service->syncOnPassengerAccept($trip->fresh(), $passengerTwo);
+
+        $conversation = $trip->fresh()->conversation;
+        $this->assertInstanceOf(Conversation::class, $conversation);
+        $this->assertSame(Conversation::TYPE_TRIP_CONVERSATION, (int) $conversation->type);
+        $this->assertSame(3, $conversation->users()->count());
+        $this->assertTrue($conversation->users()->whereKey($driver->id)->exists());
+        $this->assertTrue($conversation->users()->whereKey($passengerOne->id)->exists());
+        $this->assertTrue($conversation->users()->whereKey($passengerTwo->id)->exists());
+    }
+
+    public function test_add_user_listener_delegates_to_trip_group_chat_service(): void
+    {
+        $driver = User::factory()->create();
+        $passengerOne = User::factory()->create();
+        $passengerTwo = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerOne->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+        Passenger::factory()->create([
+            'trip_id' => $trip->id,
+            'user_id' => $passengerTwo->id,
+            'request_state' => Passenger::STATE_ACCEPTED,
+        ]);
+
+        $listener = new addUserConversation($this->conversationRepository, $this->conversationManager);
+        $listener->handle(new Accept($trip, $driver, $passengerTwo));
+
+        $conversation = $trip->fresh()->conversation;
+        $this->assertNotNull($conversation);
+        $this->assertSame(3, $conversation->users()->count());
+    }
+}

--- a/tests/Unit/Services/TripGroupChatServiceTest.php
+++ b/tests/Unit/Services/TripGroupChatServiceTest.php
@@ -117,7 +117,7 @@ class TripGroupChatServiceTest extends TestCase
             'request_state' => Passenger::STATE_ACCEPTED,
         ]);
 
-        $listener = new addUserConversation($this->conversationRepository, $this->conversationManager);
+        $listener = $this->app->make(addUserConversation::class);
         $listener->handle(new Accept($trip, $driver, $passengerTwo));
 
         $conversation = $trip->fresh()->conversation;


### PR DESCRIPTION
## Summary
- Defer trip group chat creation until the trip has three participants (driver + two passengers)
- Notify all participants when the group chat is created, and notify new passengers when they join an existing group chat
- Notification text: "Se creó un chat grupal para el viaje a \<destination\> el \<day\> \<hour\> para ayudar a la coordinación", with deep link to the conversation in Mensajes

## Test plan
- [x] `php artisan test tests/Unit/Services/TripGroupChatServiceTest.php`
- [x] `php artisan test tests/Unit/Notifications/TripGroupChatCreatedNotificationTest.php`
- [x] `php artisan test tests/Unit/MessagesTest.php`
- [x] `php artisan test tests/Feature/Http/ConversationApiTest.php`
- [ ] Accept two passengers on a trip and verify group chat is created with all three members
- [ ] Verify all three receive in-app/push notification linking to the group chat
- [ ] Accept a fourth passenger and verify they are added and notified