### PR TITLE
feat: add admin list pagination (backend)

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -11,7 +11,7 @@ use STS\Models\SupportTicket;
 use STS\Models\User;
 use STS\Services\ManualIdentityValidationDeletion;
 use STS\Services\ManualIdentityValidationReviewNotifier;
-use STS\Services\UserIdentityVerificationSuccessService;
+use STS\Support\AdminPagination;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ManualIdentityValidationController extends Controller
@@ -24,30 +24,62 @@ class ManualIdentityValidationController extends Controller
      * GET /api/admin/manual-identity-validations - list: paid first; within paid: with submitted_at (docs sent) first, then pending review, approved, rejected; then by waiting time (oldest first).
      * Waiting time = submitted_at (if submitted), else paid_at, else created_at.
      */
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        $items = ManualIdentityValidation::with('user:id,name')
+        $query = ManualIdentityValidation::with('user:id,name')
             ->orderByRaw('CASE WHEN paid = 1 THEN 0 ELSE 1 END')
             ->orderByRaw('CASE WHEN submitted_at IS NOT NULL THEN 0 ELSE 1 END')
             ->orderByRaw("CASE WHEN COALESCE(review_status, '') = 'approved' THEN 1 WHEN COALESCE(review_status, '') = 'rejected' THEN 2 ELSE 0 END")
             ->orderByRaw('COALESCE(submitted_at, paid_at, created_at) ASC')
-            ->orderBy('created_at', 'asc')
-            ->get()
-            ->map(function ($item) {
-                return [
-                    'id' => $item->id,
-                    'user_id' => $item->user_id,
-                    'user_name' => $item->user ? $item->user->name : null,
-                    'paid_at' => $item->paid_at ? $item->paid_at->toDateTimeString() : null,
-                    'submitted_at' => $item->submitted_at ? $item->submitted_at->toDateTimeString() : null,
-                    'manual_validation_started_at' => $item->manual_validation_started_at ? $item->manual_validation_started_at->toDateTimeString() : null,
-                    'paid' => $item->paid,
-                    'review_status' => $item->review_status,
-                    'has_images' => $item->hasImages(),
-                ];
-            });
+            ->orderBy('created_at', 'asc');
 
-        return response()->json(['data' => $items]);
+        if (! $this->queryFlagIsTruthy($request->query('show_resolved'))) {
+            $query->where(function ($builder) {
+                $builder->whereNull('review_status')
+                    ->orWhereNotIn('review_status', ['approved', 'approve', 'rejected', 'reject']);
+            });
+        }
+
+        $perPage = AdminPagination::resolvePerPage($request->query('per_page'));
+        $page = AdminPagination::resolvePage($request->query('page'));
+        $paginator = $query->paginate($perPage, ['*'], 'page', $page);
+
+        $items = collect($paginator->items())->map(fn (ManualIdentityValidation $item) => $this->serializeIndexRow($item))->values()->all();
+
+        return response()->json([
+            'data' => $items,
+            'meta' => [
+                'pagination' => AdminPagination::paginationMeta($paginator),
+            ],
+        ]);
+    }
+
+    private function serializeIndexRow(ManualIdentityValidation $item): array
+    {
+        return [
+            'id' => $item->id,
+            'user_id' => $item->user_id,
+            'user_name' => $item->user ? $item->user->name : null,
+            'paid_at' => $item->paid_at ? $item->paid_at->toDateTimeString() : null,
+            'submitted_at' => $item->submitted_at ? $item->submitted_at->toDateTimeString() : null,
+            'manual_validation_started_at' => $item->manual_validation_started_at ? $item->manual_validation_started_at->toDateTimeString() : null,
+            'paid' => $item->paid,
+            'review_status' => $item->review_status,
+            'has_images' => $item->hasImages(),
+        ];
+    }
+
+    private function queryFlagIsTruthy(mixed $value): bool
+    {
+        if ($value === true || $value === 1) {
+            return true;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -11,6 +11,7 @@ use STS\Models\SupportTicket;
 use STS\Models\User;
 use STS\Services\ManualIdentityValidationDeletion;
 use STS\Services\ManualIdentityValidationReviewNotifier;
+use STS\Services\UserIdentityVerificationSuccessService;
 use STS\Support\AdminPagination;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 

--- a/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
+++ b/app/Http/Controllers/Api/Admin/MercadoPagoRejectedValidationController.php
@@ -8,31 +8,41 @@ use STS\Http\Controllers\Controller;
 use STS\Models\MercadoPagoRejectedValidation;
 use STS\Models\SupportTicket;
 use STS\Services\UserIdentityVerificationSuccessService;
+use STS\Support\AdminPagination;
 
 class MercadoPagoRejectedValidationController extends Controller
 {
     /**
      * GET /api/admin/mercado-pago-rejected-validations - list, newest first (user_id, name, nro_doc, reject_reason, created_at).
      */
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        $items = MercadoPagoRejectedValidation::with('user:id,name,nro_doc,identity_validated')
-            ->orderBy('created_at', 'desc')
-            ->get()
-            ->map(function ($item) {
-                return [
-                    'id' => $item->id,
-                    'user_id' => $item->user_id,
-                    'user_name' => $item->user ? $item->user->name : null,
-                    'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
-                    'user_identity_validated' => $item->user ? (bool) $item->user->identity_validated : false,
-                    'reject_reason' => $item->reject_reason,
-                    'review_status' => $item->review_status,
-                    'created_at' => $item->created_at->toDateTimeString(),
-                ];
-            });
+        $perPage = AdminPagination::resolvePerPage($request->query('per_page'));
+        $page = AdminPagination::resolvePage($request->query('page'));
 
-        return response()->json(['data' => $items]);
+        $paginator = MercadoPagoRejectedValidation::with('user:id,name,nro_doc,identity_validated')
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage, ['*'], 'page', $page);
+
+        $items = collect($paginator->items())->map(function ($item) {
+            return [
+                'id' => $item->id,
+                'user_id' => $item->user_id,
+                'user_name' => $item->user ? $item->user->name : null,
+                'user_nro_doc' => $item->user ? $item->user->nro_doc : null,
+                'user_identity_validated' => $item->user ? (bool) $item->user->identity_validated : false,
+                'reject_reason' => $item->reject_reason,
+                'review_status' => $item->review_status,
+                'created_at' => $item->created_at->toDateTimeString(),
+            ];
+        })->values()->all();
+
+        return response()->json([
+            'data' => $items,
+            'meta' => [
+                'pagination' => AdminPagination::paginationMeta($paginator),
+            ],
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -11,7 +11,7 @@ use STS\Models\SupportTicket;
 use STS\Models\SupportTicketReply;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
-use STS\Support\ImageAttachmentRules;
+use STS\Support\AdminPagination;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -49,9 +49,16 @@ class SupportTicketController extends Controller
     {
         $this->supportTicketService->releaseExpiredAssignments();
         $query = $this->buildAdminIndexQuery($request);
+        $perPage = AdminPagination::resolvePerPage($request->query('per_page'));
+        $page = AdminPagination::resolvePage($request->query('page'));
+
+        $paginator = $query->orderByDesc('id')->paginate($perPage, ['*'], 'page', $page);
 
         return response()->json([
-            'data' => $query->orderByDesc('id')->get(),
+            'data' => $paginator->items(),
+            'meta' => [
+                'pagination' => AdminPagination::paginationMeta($paginator),
+            ],
         ]);
     }
 

--- a/app/Http/Controllers/Api/Admin/SupportTicketController.php
+++ b/app/Http/Controllers/Api/Admin/SupportTicketController.php
@@ -12,6 +12,7 @@ use STS\Models\SupportTicketReply;
 use STS\Notifications\SupportTicketReplyNotification;
 use STS\Services\SupportTicketService;
 use STS\Support\AdminPagination;
+use STS\Support\ImageAttachmentRules;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 

--- a/app/Http/Controllers/Api/Admin/UserMigrationController.php
+++ b/app/Http/Controllers/Api/Admin/UserMigrationController.php
@@ -14,6 +14,7 @@ use STS\Services\AnonymizationService;
 use STS\Services\Logic\DeviceManager;
 use STS\Services\UserDeletionService;
 use STS\Services\UserMigrationFieldMerger;
+use STS\Support\AdminPagination;
 use Throwable;
 
 class UserMigrationController extends Controller
@@ -27,13 +28,14 @@ class UserMigrationController extends Controller
 
     public function index(Request $request): JsonResponse
     {
-        $perPage = min(max((int) $request->get('per_page', 20), 1), 100);
+        $perPage = AdminPagination::resolvePerPage($request->get('per_page'));
+        $page = AdminPagination::resolvePage($request->get('page'));
 
         $paginator = UserMigration::query()
             ->with(['admin:id,name'])
             ->orderByDesc('created_at')
             ->orderByDesc('id')
-            ->paginate($perPage);
+            ->paginate($perPage, ['*'], 'page', $page);
 
         $items = collect($paginator->items())->map(function (UserMigration $m) {
             return [
@@ -52,12 +54,7 @@ class UserMigrationController extends Controller
         return response()->json([
             'data' => $items,
             'meta' => [
-                'pagination' => [
-                    'current_page' => $paginator->currentPage(),
-                    'per_page' => $paginator->perPage(),
-                    'total' => $paginator->total(),
-                    'total_pages' => $paginator->lastPage(),
-                ],
+                'pagination' => AdminPagination::paginationMeta($paginator),
             ],
         ]);
     }

--- a/app/Support/AdminPagination.php
+++ b/app/Support/AdminPagination.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace STS\Support;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class AdminPagination
+{
+    public const DEFAULT_PER_PAGE = 20;
+
+    /** @var list<int> */
+    public const ALLOWED_PER_PAGE_OPTIONS = [10, 20, 30, 50, 100];
+
+    public static function resolvePerPage(mixed $value): int
+    {
+        $perPage = (int) $value;
+
+        if (in_array($perPage, self::ALLOWED_PER_PAGE_OPTIONS, true)) {
+            return $perPage;
+        }
+
+        return self::DEFAULT_PER_PAGE;
+    }
+
+    public static function resolvePage(mixed $value): int
+    {
+        $page = (int) $value;
+
+        return max($page, 1);
+    }
+
+    /**
+     * @return array{current_page: int, per_page: int, total: int, total_pages: int}
+     */
+    public static function paginationMeta(LengthAwarePaginator $paginator): array
+    {
+        return [
+            'current_page' => $paginator->currentPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+            'total_pages' => $paginator->lastPage(),
+        ];
+    }
+}

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -41,7 +41,8 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->withoutMiddleware(UserAdmin::class);
 
         $response = $this->getJson('api/admin/manual-identity-validations')->assertOk();
-        $this->assertSame(['data'], array_keys($response->json()));
+        $this->assertArrayHasKey('data', $response->json());
+        $this->assertArrayHasKey('meta', $response->json());
 
         $row = collect($response->json('data'))->firstWhere('user_id', $user->id);
         $this->assertNotNull($row);
@@ -59,6 +60,70 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->assertSame('Manual User', $row['user_name']);
         $this->assertTrue($row['paid']);
         $this->assertFalse($row['has_images']);
+    }
+
+    public function test_index_paginates_with_default_twenty_per_page(): void
+    {
+        $admin = $this->admin();
+
+        for ($i = 0; $i < 22; $i++) {
+            $user = User::factory()->create();
+            ManualIdentityValidation::create([
+                'user_id' => $user->id,
+                'paid' => true,
+                'paid_at' => now(),
+                'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+            ]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/manual-identity-validations')
+            ->assertOk()
+            ->assertJsonPath('meta.pagination.per_page', 20)
+            ->assertJsonPath('meta.pagination.current_page', 1)
+            ->assertJsonPath('meta.pagination.total', 22)
+            ->assertJsonCount(20, 'data');
+    }
+
+    public function test_index_excludes_resolved_rows_unless_show_resolved_is_true(): void
+    {
+        $admin = $this->admin();
+        $pendingUser = User::factory()->create();
+        $approvedUser = User::factory()->create();
+
+        ManualIdentityValidation::create([
+            'user_id' => $pendingUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        ManualIdentityValidation::create([
+            'user_id' => $approvedUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $defaultIds = collect($this->getJson('api/admin/manual-identity-validations')->json('data'))
+            ->pluck('user_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertContains($pendingUser->id, $defaultIds);
+        $this->assertNotContains($approvedUser->id, $defaultIds);
+
+        $resolvedIds = collect($this->getJson('api/admin/manual-identity-validations?show_resolved=1')->json('data'))
+            ->pluck('user_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertContains($pendingUser->id, $resolvedIds);
+        $this->assertContains($approvedUser->id, $resolvedIds);
     }
 
     public function test_show_builds_image_urls_from_rtrimmed_app_url_without_double_slash(): void

--- a/tests/Feature/Http/AdminMercadoPagoRejectedValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminMercadoPagoRejectedValidationControllerIntegrationTest.php
@@ -45,7 +45,8 @@ class AdminMercadoPagoRejectedValidationControllerIntegrationTest extends TestCa
         $this->withoutMiddleware(UserAdmin::class);
 
         $response = $this->getJson('api/admin/mercado-pago-rejected-validations')->assertOk();
-        $this->assertSame(['data'], array_keys($response->json()));
+        $this->assertArrayHasKey('data', $response->json());
+        $this->assertArrayHasKey('meta', $response->json());
 
         $rows = collect($response->json('data'));
         $this->assertGreaterThanOrEqual(2, $rows->count());
@@ -59,6 +60,30 @@ class AdminMercadoPagoRejectedValidationControllerIntegrationTest extends TestCa
         $this->assertSame('dni_mismatch', $first['reject_reason']);
         $this->assertArrayHasKey('review_status', $first);
         $this->assertArrayHasKey('created_at', $first);
+    }
+
+    public function test_index_paginates_with_default_twenty_per_page(): void
+    {
+        $admin = $this->admin();
+
+        for ($i = 0; $i < 21; $i++) {
+            $user = User::factory()->create();
+            MercadoPagoRejectedValidation::create([
+                'user_id' => $user->id,
+                'reject_reason' => 'dni_mismatch',
+                'mp_payload' => ['k' => 'v'.$i],
+            ]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/mercado-pago-rejected-validations')
+            ->assertOk()
+            ->assertJsonPath('meta.pagination.per_page', 20)
+            ->assertJsonPath('meta.pagination.current_page', 1)
+            ->assertJsonPath('meta.pagination.total', 21)
+            ->assertJsonCount(20, 'data');
     }
 
     public function test_show_returns_single_row_payload_and_review_approve_updates_user(): void

--- a/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminSupportTicketControllerIntegrationTest.php
@@ -150,6 +150,47 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->assertTrue($rows->every(fn (array $row): bool => (int) ($row['user_id'] ?? 0) === $target->id));
     }
 
+    public function test_index_paginates_with_default_twenty_per_page(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+
+        for ($i = 0; $i < 25; $i++) {
+            $this->makeTicket($owner, ['subject' => 'ticket-'.$i]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/support/tickets')
+            ->assertOk()
+            ->assertJsonPath('meta.pagination.per_page', 20)
+            ->assertJsonPath('meta.pagination.current_page', 1)
+            ->assertJsonPath('meta.pagination.total', 25)
+            ->assertJsonPath('meta.pagination.total_pages', 2)
+            ->assertJsonCount(20, 'data');
+    }
+
+    public function test_index_paginates_with_requested_per_page(): void
+    {
+        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+
+        for ($i = 0; $i < 12; $i++) {
+            $this->makeTicket($owner, ['subject' => 'ticket-'.$i]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->getJson('api/admin/support/tickets?per_page=10&page=2')
+            ->assertOk()
+            ->assertJsonPath('meta.pagination.per_page', 10)
+            ->assertJsonPath('meta.pagination.current_page', 2)
+            ->assertJsonPath('meta.pagination.total', 12)
+            ->assertJsonCount(2, 'data');
+    }
+
     public function test_index_returns_data_ordered_newest_first(): void
     {
         $admin = $this->adminUser();
@@ -161,7 +202,8 @@ class AdminSupportTicketControllerIntegrationTest extends TestCase
         $this->withoutMiddleware(UserAdmin::class);
 
         $indexResponse = $this->getJson('api/admin/support/tickets')->assertOk();
-        $this->assertSame(['data'], array_keys($indexResponse->json()));
+        $this->assertArrayHasKey('data', $indexResponse->json());
+        $this->assertArrayHasKey('meta', $indexResponse->json());
 
         $rows = collect($indexResponse->json('data'));
 

--- a/tests/Unit/Support/AdminPaginationTest.php
+++ b/tests/Unit/Support/AdminPaginationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use STS\Support\AdminPagination;
+use Tests\TestCase;
+
+class AdminPaginationTest extends TestCase
+{
+    public function test_default_per_page_is_twenty(): void
+    {
+        $this->assertSame(20, AdminPagination::DEFAULT_PER_PAGE);
+    }
+
+    public function test_allowed_per_page_options(): void
+    {
+        $this->assertSame([10, 20, 30, 50, 100], AdminPagination::ALLOWED_PER_PAGE_OPTIONS);
+    }
+
+    public function test_resolve_per_page_uses_default_when_missing(): void
+    {
+        $this->assertSame(20, AdminPagination::resolvePerPage(null));
+    }
+
+    public function test_resolve_per_page_accepts_allowed_values(): void
+    {
+        foreach ([10, 20, 30, 50, 100] as $perPage) {
+            $this->assertSame($perPage, AdminPagination::resolvePerPage($perPage));
+        }
+    }
+
+    public function test_resolve_per_page_falls_back_to_default_for_invalid_values(): void
+    {
+        $this->assertSame(20, AdminPagination::resolvePerPage(0));
+        $this->assertSame(20, AdminPagination::resolvePerPage(15));
+        $this->assertSame(20, AdminPagination::resolvePerPage(500));
+    }
+
+    public function test_resolve_page_defaults_to_one_and_clamps_to_minimum_one(): void
+    {
+        $this->assertSame(1, AdminPagination::resolvePage(null));
+        $this->assertSame(1, AdminPagination::resolvePage(0));
+        $this->assertSame(3, AdminPagination::resolvePage(3));
+    }
+
+    public function test_pagination_meta_from_paginator(): void
+    {
+        $paginator = new LengthAwarePaginator(['a', 'b'], 25, 10, 2);
+
+        $this->assertSame([
+            'current_page' => 2,
+            'per_page' => 10,
+            'total' => 25,
+            'total_pages' => 3,
+        ], AdminPagination::paginationMeta($paginator));
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared `AdminPagination` helper with allowed per-page options (10, 20, 30, 50, 100) and default 20
- Paginate admin list endpoints for support tickets, manual identity validations, and Mercado Pago rejections
- Move manual validation `show_resolved` filtering to the API so pagination stays accurate
- Reuse the helper in user migrations list

## Test plan
- [x] `./vendor/bin/phpunit` (3395 tests pass)
- [x] New integration tests for pagination on support tickets, manual validations, and MP rejections
- [x] `AdminPagination` unit tests

## Related PR
- Frontend: https://github.com/STS-Rosario/carpoolear/pull/new/admin-pagination