### PR TITLE
Add Laravel Pulse monitoring with admin web login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,3 +168,8 @@ SLACK_FORBIDDEN_EDIT_WEBHOOK_URL=
 # GOOGLE_ROUTES_REGION_CODE=AR
 
 TRIP_ROUTE_CACHE_BYPASS="false"
+
+# Laravel Pulse — application performance monitoring dashboard at /pulse
+PULSE_ENABLED=true
+# Optional later: PULSE_DB_CONNECTION=pulse
+# Optional later: PULSE_INGEST_DRIVER=redis

--- a/after_deploy.sh
+++ b/after_deploy.sh
@@ -3,6 +3,8 @@
 #ssh movilizame@104.131.15.228 -p 2200 'cd  /home/movilizame/sites/carpoolear_dev && ./after_deploy.sh'
 
 composer dump-autoload
+php artisan migrate --force
 php artisan optimize 
 php artisan api:cache
 php artisan config:cache
+php artisan pulse:restart

--- a/app/Http/Controllers/Web/PulseAuthController.php
+++ b/app/Http/Controllers/Web/PulseAuthController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace STS\Http\Controllers\Web;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+use STS\Http\Controllers\Controller;
+
+class PulseAuthController extends Controller
+{
+    public function showLoginForm(): View
+    {
+        return view('pulse.login');
+    }
+
+    public function login(Request $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if (! Auth::guard('web')->attempt($credentials, $request->boolean('remember'))) {
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => __('auth.failed')]);
+        }
+
+        $user = Auth::guard('web')->user();
+
+        if ($user->banned || ! $user->active) {
+            Auth::guard('web')->logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => __('auth.failed')]);
+        }
+
+        if (! $user->is_admin) {
+            Auth::guard('web')->logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => __('auth.failed')]);
+        }
+
+        $request->session()->regenerate();
+
+        return redirect()->intended('/pulse');
+    }
+
+    public function logout(Request $request): RedirectResponse
+    {
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('pulse.login');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,13 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Pulse\Entry;
+use Laravel\Pulse\Facades\Pulse;
+use Laravel\Pulse\Value;
 use STS\Contracts\Logic\Social;
+use STS\Models\User;
 use STS\Services\Logic\SocialManager;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,6 +26,20 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::define('viewPulse', fn (?User $user) => (bool) ($user?->is_admin));
+
+        Pulse::user(fn (User $user) => [
+            'name' => $user->name,
+            'extra' => $user->email,
+            'avatar' => $user->image ? url('/image/profile/'.$user->image) : null,
+        ]);
+
+        Pulse::filter(function (Entry|Value $entry) {
+            if (! $entry instanceof Entry) {
+                return true;
+            }
+
+            return ! preg_match('#/pulse(?:/|$)#', $entry->key);
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,8 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->redirectGuestsTo('/pulse/login');
+
         $middleware->alias([
             'update.connection' => \STS\Http\Middleware\UpdateConnection::class,
             'check.userbanned' => \STS\Http\Middleware\CheckUserBanned::class,

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "google/apiclient": "^2.17",
         "guzzlehttp/guzzle": "^7.9",
         "laravel/framework": "^12.0",
+        "laravel/pulse": "^1.7",
         "laravel/tinker": "^2.9",
         "league/fractal": "^0.20.1",
         "mercadopago/dx-php": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "889b76c5f42a64ac9dbb4466353cc4e7",
+    "content-hash": "5a41b43b9327e219df6684521333c9f3",
     "packages": [
         {
             "name": "brick/math",
@@ -376,6 +376,61 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "doctrine/sql-formatter",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/sql-formatter.git",
+                "reference": "9563949f5cd3bd12a17d12fb980528bc141c5806"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/sql-formatter/zipball/9563949f5cd3bd12a17d12fb980528bc141c5806",
+                "reference": "9563949f5cd3bd12a17d12fb980528bc141c5806",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ergebnis/phpunit-slow-test-detector": "^2.20",
+                "phpstan/phpstan": "^2.1.31",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "bin": [
+                "bin/sql-formatter"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\SqlFormatter\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Dorn",
+                    "email": "jeremy@jeremydorn.com",
+                    "homepage": "https://jeremydorn.com/"
+                }
+            ],
+            "description": "a PHP SQL highlighting library",
+            "homepage": "https://github.com/doctrine/sql-formatter/",
+            "keywords": [
+                "highlight",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/sql-formatter/issues",
+                "source": "https://github.com/doctrine/sql-formatter/tree/1.5.4"
+            },
+            "time": "2026-02-08T16:21:46+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -1573,6 +1628,150 @@
             "time": "2026-04-20T16:07:33+00:00"
         },
         {
+            "name": "laravel/pulse",
+            "version": "v1.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pulse.git",
+                "reference": "6daab88ef368c0a1272a4401d90d514b30829225"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pulse/zipball/6daab88ef368c0a1272a4401d90d514b30829225",
+                "reference": "6daab88ef368c0a1272a4401d90d514b30829225",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/sql-formatter": "^1.4.1",
+                "guzzlehttp/promises": "^1.0|^2.0",
+                "illuminate/auth": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/cache": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/config": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/console": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/contracts": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/database": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/events": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/http": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/queue": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/redis": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/routing": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/support": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "illuminate/view": "^10.48.4|^11.0.8|^12.0|^13.0",
+                "laravel/sentinel": "^1.0",
+                "livewire/livewire": "^3.6.4|^4.0",
+                "nesbot/carbon": "^2.67|^3.0",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "nunomaduro/collision": "<7.7.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.7",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^2.2|^3.0|^4.0",
+                "phpstan/phpstan": "^1.12.21",
+                "predis/predis": "^1.0|^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Pulse": "Laravel\\Pulse\\Facades\\Pulse"
+                    },
+                    "providers": [
+                        "Laravel\\Pulse\\PulseServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Pulse\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Pulse is a real-time application performance monitoring tool and dashboard for your Laravel application.",
+            "homepage": "https://github.com/laravel/pulse",
+            "keywords": [
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pulse/issues",
+                "source": "https://github.com/laravel/pulse"
+            },
+            "time": "2026-06-03T14:04:01+00:00"
+        },
+        {
+            "name": "laravel/sentinel",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sentinel.git",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sentinel/zipball/972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/container": "^8.37|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.27",
+                "orchestra/testbench": "^6.47.1|^7.56|^8.37|^9.16|^10.9|^11.0",
+                "phpstan/phpstan": "^2.1.33"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sentinel\\SentinelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sentinel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "mior@laravel.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/laravel/sentinel/tree/v1.1.0"
+            },
+            "time": "2026-03-24T14:03:38+00:00"
+        },
+        {
             "name": "laravel/serializable-closure",
             "version": "v2.0.13",
             "source": {
@@ -2465,6 +2664,82 @@
                 }
             ],
             "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "livewire/livewire",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "8021f2561865c4c297a3bfca37212a99034377e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/8021f2561865c4c297a3bfca37212a99034377e7",
+                "reference": "8021f2561865c4c297a3bfca37212a99034377e7",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v4.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:16:11+00:00"
         },
         {
             "name": "mercadopago/dx-php",

--- a/config/pulse.php
+++ b/config/pulse.php
@@ -1,0 +1,249 @@
+<?php
+
+use Laravel\Pulse\Http\Middleware\Authorize;
+use Laravel\Pulse\Pulse;
+use Laravel\Pulse\Recorders;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain which the Pulse dashboard will be accessible from.
+    | When set to null, the dashboard will reside under the same domain as
+    | the application. Remember to configure your DNS entries correctly.
+    |
+    */
+
+    'domain' => env('PULSE_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the path which the Pulse dashboard will be accessible from. Feel
+    | free to change this path to anything you'd like. Note that this won't
+    | affect the path of the internal API that is never exposed to users.
+    |
+    */
+
+    'path' => env('PULSE_PATH', 'pulse'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option may be used to completely disable all Pulse
+    | data recorders regardless of their individual configurations. This
+    | provides a single option to quickly disable all Pulse recording.
+    |
+    */
+
+    'enabled' => env('PULSE_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Storage Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option determines which storage driver will be used
+    | while storing entries from Pulse's recorders. In addition, you also
+    | may provide any options to configure the selected storage driver.
+    |
+    */
+
+    'storage' => [
+        'driver' => env('PULSE_STORAGE_DRIVER', 'database'),
+
+        'trim' => [
+            'keep' => env('PULSE_STORAGE_KEEP', '7 days'),
+        ],
+
+        'database' => [
+            'connection' => env('PULSE_DB_CONNECTION'),
+            'chunk' => 1000,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Ingest Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the ingest driver that will be used
+    | to capture entries from Pulse's recorders. Ingest drivers are great to
+    | free up your request workers quickly by offloading the data storage.
+    |
+    */
+
+    'ingest' => [
+        'driver' => env('PULSE_INGEST_DRIVER', 'storage'),
+
+        'buffer' => env('PULSE_INGEST_BUFFER', 5_000),
+
+        'trim' => [
+            'lottery' => [1, 1_000],
+            'keep' => env('PULSE_INGEST_KEEP', '7 days'),
+        ],
+
+        'redis' => [
+            'connection' => env('PULSE_REDIS_CONNECTION'),
+            'chunk' => 1000,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Cache Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option determines the cache driver that will be used
+    | for various tasks, including caching dashboard results, establishing
+    | locks for events that should only occur on one server and signals.
+    |
+    */
+
+    'cache' => env('PULSE_CACHE_DRIVER'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will be assigned to every Pulse route, giving you the
+    | chance to add your own middleware to this list or change any of the
+    | existing middleware. Of course, reasonable defaults are provided.
+    |
+    */
+
+    'middleware' => [
+        'web',
+        'auth',
+        Authorize::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pulse Recorders
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the "recorders" that will be registered with
+    | Pulse, along with their configuration. Recorders gather application
+    | event data from requests and tasks to pass to your ingest driver.
+    |
+    */
+
+    'recorders' => [
+        Recorders\CacheInteractions::class => [
+            'enabled' => env('PULSE_CACHE_INTERACTIONS_ENABLED', true),
+            'sample_rate' => env('PULSE_CACHE_INTERACTIONS_SAMPLE_RATE', 1),
+            'ignore' => [
+                ...Pulse::defaultVendorCacheKeys(),
+            ],
+            'groups' => [
+                '/^job-exceptions:.*/' => 'job-exceptions:*',
+                '/^user:\d+:notification_unread_count$/' => 'user:*:notification_unread_count',
+            ],
+        ],
+
+        Recorders\Exceptions::class => [
+            'enabled' => env('PULSE_EXCEPTIONS_ENABLED', true),
+            'sample_rate' => env('PULSE_EXCEPTIONS_SAMPLE_RATE', 1),
+            'location' => env('PULSE_EXCEPTIONS_LOCATION', true),
+            'ignore' => [
+                // '/^Package\\\\Exceptions\\\\/',
+            ],
+        ],
+
+        Recorders\Queues::class => [
+            'enabled' => env('PULSE_QUEUES_ENABLED', true),
+            'sample_rate' => env('PULSE_QUEUES_SAMPLE_RATE', 1),
+            'ignore' => [
+                // '/^Package\\\\Jobs\\\\/',
+            ],
+        ],
+
+        Recorders\Servers::class => [
+            'server_name' => env('PULSE_SERVER_NAME', gethostname()),
+            'directories' => explode(':', env('PULSE_SERVER_DIRECTORIES', '/')),
+        ],
+
+        Recorders\SlowJobs::class => [
+            'enabled' => env('PULSE_SLOW_JOBS_ENABLED', true),
+            'sample_rate' => env('PULSE_SLOW_JOBS_SAMPLE_RATE', 1),
+            'threshold' => [
+                '#^STS\\\\Jobs\\\\SyncArgautosCarCatalogJob$#' => 120_000,
+                'default' => env('PULSE_SLOW_JOBS_THRESHOLD', 1000),
+            ],
+            'ignore' => [
+                // '/^Package\\\\Jobs\\\\/',
+            ],
+        ],
+
+        Recorders\SlowOutgoingRequests::class => [
+            'enabled' => env('PULSE_SLOW_OUTGOING_REQUESTS_ENABLED', true),
+            'sample_rate' => env('PULSE_SLOW_OUTGOING_REQUESTS_SAMPLE_RATE', 1),
+            'threshold' => env('PULSE_SLOW_OUTGOING_REQUESTS_THRESHOLD', 1000),
+            'ignore' => [
+                // '#^http://127\.0\.0\.1:13714#', // Inertia SSR...
+            ],
+            'groups' => [
+                '#^https?://[^/]*mapbox[^/]*#' => 'mapbox/*',
+                '#^https?://[^/]*googleapis\.com#' => 'google/*',
+                '#^https?://[^/]*mercadopago[^/]*#' => 'mercadopago/*',
+                '#^https?://[^/]*smsmasivos[^/]*#' => 'sms/*',
+                '#/\d+#' => '/*',
+            ],
+        ],
+
+        Recorders\SlowQueries::class => [
+            'enabled' => env('PULSE_SLOW_QUERIES_ENABLED', true),
+            'sample_rate' => env('PULSE_SLOW_QUERIES_SAMPLE_RATE', 1),
+            'threshold' => env('PULSE_SLOW_QUERIES_THRESHOLD', 1000),
+            'location' => env('PULSE_SLOW_QUERIES_LOCATION', true),
+            'max_query_length' => env('PULSE_SLOW_QUERIES_MAX_QUERY_LENGTH'),
+            'ignore' => [
+                '/(["`])pulse_[\w]+?\1/', // Pulse tables...
+                '/(["`])telescope_[\w]+?\1/', // Telescope tables...
+            ],
+        ],
+
+        Recorders\SlowRequests::class => [
+            'enabled' => env('PULSE_SLOW_REQUESTS_ENABLED', true),
+            'sample_rate' => env('PULSE_SLOW_REQUESTS_SAMPLE_RATE', 1),
+            'threshold' => [
+                '#^/api/admin/#' => 3000,
+                'default' => env('PULSE_SLOW_REQUESTS_THRESHOLD', 1000),
+            ],
+            'ignore' => [
+                '#^/up$#',
+                '#^/'.env('PULSE_PATH', 'pulse').'#',
+                '#^/app/#',
+                '#^/telescope#',
+            ],
+        ],
+
+        Recorders\UserJobs::class => [
+            'enabled' => env('PULSE_USER_JOBS_ENABLED', true),
+            'sample_rate' => env('PULSE_USER_JOBS_SAMPLE_RATE', 1),
+            'ignore' => [
+                // '/^Package\\\\Jobs\\\\/',
+            ],
+        ],
+
+        Recorders\UserRequests::class => [
+            'enabled' => env('PULSE_USER_REQUESTS_ENABLED', true),
+            'sample_rate' => env('PULSE_USER_REQUESTS_SAMPLE_RATE', 1),
+            'ignore' => [
+                '#^/up$#',
+                '#^/'.env('PULSE_PATH', 'pulse').'#',
+                '#^/app/#',
+                '#^/telescope#',
+            ],
+        ],
+    ],
+];

--- a/database/migrations/2026_07_26_200712_create_pulse_tables.php
+++ b/database/migrations/2026_07_26_200712_create_pulse_tables.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pulse\Support\PulseMigration;
+
+return new class extends PulseMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! $this->shouldRun()) {
+            return;
+        }
+
+        Schema::create('pulse_values', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('timestamp');
+            $table->string('type');
+            $table->mediumText('key');
+            match ($this->driver()) {
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'sqlite' => $table->string('key_hash'),
+            };
+            $table->mediumText('value');
+
+            $table->index('timestamp'); // For trimming...
+            $table->index('type'); // For fast lookups and purging...
+            $table->unique(['type', 'key_hash']); // For data integrity and upserts...
+        });
+
+        Schema::create('pulse_entries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('timestamp');
+            $table->string('type');
+            $table->mediumText('key');
+            match ($this->driver()) {
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'sqlite' => $table->string('key_hash'),
+            };
+            $table->bigInteger('value')->nullable();
+
+            $table->index('timestamp'); // For trimming...
+            $table->index('type'); // For purging...
+            $table->index('key_hash'); // For mapping...
+            $table->index(['timestamp', 'type', 'key_hash', 'value']); // For aggregate queries...
+        });
+
+        Schema::create('pulse_aggregates', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('bucket');
+            $table->unsignedMediumInteger('period');
+            $table->string('type');
+            $table->mediumText('key');
+            match ($this->driver()) {
+                'mariadb', 'mysql' => $table->char('key_hash', 16)->charset('binary')->virtualAs('unhex(md5(`key`))'),
+                'pgsql' => $table->uuid('key_hash')->storedAs('md5("key")::uuid'),
+                'sqlite' => $table->string('key_hash'),
+            };
+            $table->string('aggregate');
+            $table->decimal('value', 20, 2);
+            $table->unsignedInteger('count')->nullable();
+
+            $table->unique(['bucket', 'period', 'type', 'aggregate', 'key_hash']); // Force "on duplicate update"...
+            $table->index(['period', 'bucket']); // For trimming...
+            $table->index('type'); // For purging...
+            $table->index(['period', 'type', 'aggregate', 'bucket']); // For aggregate queries...
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pulse_values');
+        Schema::dropIfExists('pulse_entries');
+        Schema::dropIfExists('pulse_aggregates');
+    }
+};

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,9 @@ git fetch
 git reset --hard origin/laravel-11
 
 composer dump-autoload
+php artisan migrate --force
 php artisan optimize 
 php artisan config:cache
+php artisan pulse:restart
 
 t

--- a/docs/PULSE_SETUP.md
+++ b/docs/PULSE_SETUP.md
@@ -1,0 +1,351 @@
+# Laravel Pulse Setup
+
+Laravel Pulse provides a real-time performance dashboard for the Carpoolear backend at `/pulse`.
+
+## What Pulse shows
+
+- **Slow requests** — API endpoints exceeding the configured threshold
+- **Slow queries** — heavy SQL with source location
+- **Exceptions** — frequency and recency of application errors
+- **Queues** — throughput and failures (works with the `database` queue driver and `emails` queue)
+- **Slow jobs** — long-running queued jobs
+- **Slow outgoing requests** — external HTTP calls made via Laravel's `Http` facade (MercadoPago, Mapbox, Google, SMS, etc.)
+- **Cache** — hit/miss statistics
+- **Application usage** — most active users by requests and jobs
+- **Servers** — CPU, memory, and disk (requires `pulse:check` via Supervisor)
+
+## What Pulse does not show
+
+- Scheduled Artisan command performance (`rating:availables`, `live-location:process`, etc.)
+- Raw Guzzle HTTP calls (for example `BuildNodes`); only `Http::` facade calls are tracked
+- Mobile app or frontend metrics
+- Business KPIs (trips created, signups, etc.)
+
+## Admin access
+
+Pulse is admin-only (`is_admin = true`).
+
+1. Open `/pulse/login`
+2. Sign in with an admin user's email and password (same credentials as the API)
+3. After login you are redirected to `/pulse`
+4. Sign out with `POST /pulse/logout`
+
+Non-admin users, banned users, and inactive users cannot sign in to Pulse even with valid credentials.
+
+Login is rate-limited to 6 attempts per minute.
+
+## Environment variables
+
+```env
+PULSE_ENABLED=true
+```
+
+Optional (not required for v1):
+
+```env
+# PULSE_DB_CONNECTION=pulse
+# PULSE_INGEST_DRIVER=redis
+# PULSE_REDIS_CONNECTION=pulse
+```
+
+Disable recording entirely with `PULSE_ENABLED=false` (useful in CI or local dev if desired).
+
+## Production deploy checklist
+
+1. Deploy code with `laravel/pulse` installed
+2. Set `PULSE_ENABLED=true` in production `.env`
+3. Run migrations: `php artisan migrate --force`
+4. Clear/rebuild config cache: `php artisan config:cache`
+5. Restart Pulse worker: `php artisan pulse:restart`
+6. Ensure `storage/` and cache directories are writable by PHP-FPM (`www-data`) — see [PRODUCTION_STORAGE_AND_CACHE.md](PRODUCTION_STORAGE_AND_CACHE.md)
+7. Add Supervisor program for `pulse:check` (see below)
+8. Smoke test: sign in at `/pulse/login` and confirm the dashboard loads
+
+`deploy.sh` and `after_deploy.sh` already run `migrate --force` and `pulse:restart`.
+
+## Supervisor: `pulse:check` (step by step)
+
+The **Servers** card in Pulse needs a long-running `pulse:check` process on each machine you want to monitor. That process samples CPU, memory, and disk usage and writes the results to Pulse's database.
+
+**Important:** `routes/console.php` also schedules `pulse:check` every minute, but that only helps if Laravel's scheduler is running (`* * * * * php artisan schedule:run`). Even then, `pulse:check` is designed to stay alive and report continuously — **Supervisor is the correct way to run it in production.**
+
+`pulse:restart` (run on deploy via `after_deploy.sh`) tells an already-running `pulse:check` process to exit so Supervisor starts a fresh one with the new code. It does **not** start the process if Supervisor is not configured.
+
+### What you need before starting
+
+| Item | Typical Carpoolear value | How to confirm |
+|------|--------------------------|----------------|
+| App root on server | `/home/movilizame/sites/carpoolear_dev` | Same directory you `cd` into for deploys |
+| PHP binary | `/usr/bin/php` | `which php` on the server |
+| Process user | `www-data` | Same user as PHP-FPM / queue workers — see [PRODUCTION_STORAGE_AND_CACHE.md](PRODUCTION_STORAGE_AND_CACHE.md) |
+| Supervisor installed | yes | `sudo supervisorctl version` |
+| Pulse deployed | migrations run, `PULSE_ENABLED=true` | `php artisan pulse:check --help` should work |
+
+Use the **same app path and `www-data` user** as your existing queue worker Supervisor program (see [PASSWORD_RESET_ERROR_SOLUTION.md](PASSWORD_RESET_ERROR_SOLUTION.md)).
+
+---
+
+### Step 1 — SSH into the app server
+
+```bash
+ssh movilizame@104.131.15.228 -p 2200
+cd /home/movilizame/sites/carpoolear_dev
+```
+
+Replace host, port, and path with your real production values.
+
+---
+
+### Step 2 — Confirm `pulse:check` works manually
+
+Run it in the foreground for a few seconds, then stop with `Ctrl+C`:
+
+```bash
+php artisan pulse:check
+```
+
+You should see no errors. If you get a database or config error, fix that before continuing (run `php artisan migrate --force`, check `PULSE_ENABLED=true`, run `php artisan config:cache`).
+
+Optional sanity check:
+
+```bash
+php artisan pulse:check --help
+```
+
+---
+
+### Step 3 — Create the Supervisor program file
+
+On Ubuntu/Debian, program configs usually live under `/etc/supervisor/conf.d/`.
+
+```bash
+sudo nano /etc/supervisor/conf.d/carpoolear-pulse-check.conf
+```
+
+Paste the following and **replace `/home/movilizame/sites/carpoolear_dev`** with your app root if different:
+
+```ini
+[program:carpoolear-pulse-check]
+process_name=%(program_name)s
+command=/usr/bin/php /home/movilizame/sites/carpoolear_dev/artisan pulse:check
+directory=/home/movilizame/sites/carpoolear_dev
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=www-data
+numprocs=1
+redirect_stderr=true
+stdout_logfile=/home/movilizame/sites/carpoolear_dev/storage/logs/pulse-check.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stopwaitsecs=10
+```
+
+**Why these options matter:**
+
+- `directory=` — ensures relative paths and `.env` resolve correctly
+- `user=www-data` — matches PHP-FPM; avoids permission issues on `storage/logs`
+- `stopasgroup` / `killasgroup` — clean shutdown when Supervisor restarts the process
+- `numprocs=1` — only one `pulse:check` per server (do not scale this horizontally on the same host)
+- `stdout_logfile=` — if the process crashes, check this file first
+
+If `which php` returns a different path, update `command=` accordingly.
+
+---
+
+### Step 4 — Ensure the log file is writable
+
+```bash
+sudo touch /home/movilizame/sites/carpoolear_dev/storage/logs/pulse-check.log
+sudo chown www-data:www-data /home/movilizame/sites/carpoolear_dev/storage/logs/pulse-check.log
+```
+
+If `storage/logs` itself is not writable by `www-data`, follow the permission steps in [PRODUCTION_STORAGE_AND_CACHE.md](PRODUCTION_STORAGE_AND_CACHE.md).
+
+---
+
+### Step 5 — Load the new Supervisor config
+
+```bash
+sudo supervisorctl reread
+sudo supervisorctl update
+```
+
+Expected output includes something like:
+
+```text
+carpoolear-pulse-check: added process group
+```
+
+---
+
+### Step 6 — Start the program and verify status
+
+```bash
+sudo supervisorctl start carpoolear-pulse-check
+sudo supervisorctl status carpoolear-pulse-check
+```
+
+Expected status: **`RUNNING`**.
+
+Other useful commands:
+
+```bash
+# Full status of all programs
+sudo supervisorctl status
+
+# Follow logs live
+sudo tail -f /home/movilizame/sites/carpoolear_dev/storage/logs/pulse-check.log
+```
+
+---
+
+### Step 7 — Confirm data appears in Pulse
+
+1. Sign in at `https://your-domain/pulse/login` with an admin account
+2. Open the **Servers** card at the top of the dashboard
+3. Within a minute or two you should see this host (hostname from `PULSE_SERVER_NAME` or the server's system hostname)
+
+To set a friendly server name in `.env`:
+
+```env
+PULSE_SERVER_NAME=carpoolear-prod-1
+```
+
+Then run `php artisan config:cache` and `php artisan pulse:restart`.
+
+---
+
+### Step 8 — How deploys interact with Supervisor
+
+`after_deploy.sh` and `deploy.sh` already run:
+
+```bash
+php artisan pulse:restart
+```
+
+**Deploy flow:**
+
+1. Code is pulled / deployed
+2. `php artisan migrate --force` runs
+3. `php artisan config:cache` runs
+4. `php artisan pulse:restart` signals the running `pulse:check` to stop
+5. Supervisor sees the process exited and **automatically starts a new one** (`autorestart=true`)
+
+You do **not** need to run `supervisorctl restart` on every deploy unless `pulse:restart` fails (for example cache not writable).
+
+Manual restart after config changes:
+
+```bash
+sudo supervisorctl restart carpoolear-pulse-check
+```
+
+---
+
+### Step 9 — Multiple servers (if applicable)
+
+Run **one** `carpoolear-pulse-check` Supervisor program **on each application server** you want in the Servers card. Give each server a unique name:
+
+```env
+# Server A .env
+PULSE_SERVER_NAME=carpoolear-web-1
+
+# Server B .env
+PULSE_SERVER_NAME=carpoolear-web-2
+```
+
+All can write to the same Pulse database; the dashboard aggregates them.
+
+---
+
+### Troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| Status `FATAL` or `BACKOFF` | Wrong path, PHP error, or permissions | Read `storage/logs/pulse-check.log`; run `php artisan pulse:check` manually as `www-data` |
+| Status `RUNNING` but Servers card empty | `PULSE_ENABLED=false` or DB issue | Check `.env`, `php artisan config:clear && php artisan config:cache` |
+| Process keeps restarting | Crash on boot (missing tables, bad config) | `php artisan migrate --force`; check Laravel log in `storage/logs/laravel.log` |
+| `pulse:restart` has no effect | Cache driver not writable | Fix file cache permissions per production runbook; or use `supervisorctl restart` |
+| Log permission denied | `www-data` cannot write log file | Repeat Step 4; fix `storage/logs` ownership |
+
+Run `pulse:check` as the same user Supervisor uses:
+
+```bash
+sudo -u www-data -H bash -lc 'cd /home/movilizame/sites/carpoolear_dev && php artisan pulse:check'
+```
+
+Stop with `Ctrl+C` once you confirm it starts cleanly.
+
+---
+
+### Stopping or removing the program
+
+Temporary stop (keeps config):
+
+```bash
+sudo supervisorctl stop carpoolear-pulse-check
+```
+
+Remove permanently:
+
+```bash
+sudo supervisorctl stop carpoolear-pulse-check
+sudo rm /etc/supervisor/conf.d/carpoolear-pulse-check.conf
+sudo supervisorctl reread
+sudo supervisorctl update
+```
+
+The rest of Pulse (slow requests, exceptions, queues, etc.) continues to work without `pulse:check`; only the **Servers** card will be empty.
+
+---
+
+### Coexistence with the queue worker
+
+You likely already have a program similar to this for emails:
+
+```ini
+[program:carpoolear-queue-worker]
+command=php /home/movilizame/sites/carpoolear_dev/artisan queue:work --queue=emails ...
+user=www-data
+```
+
+`carpoolear-pulse-check` is a **separate** Supervisor program. Both can run at the same time. They serve different purposes:
+
+| Program | Command | Purpose |
+|---------|---------|---------|
+| `carpoolear-queue-worker` | `queue:work` | Process queued jobs (emails, etc.) |
+| `carpoolear-pulse-check` | `pulse:check` | Report server CPU/RAM/disk to Pulse |
+
+Do not merge them into a single Supervisor entry.
+
+## Carpoolear-specific tuning
+
+Configured in `config/pulse.php`:
+
+- Slow requests ignore `/up`, `/pulse`, and `/app/` paths
+- Admin API routes (`/api/admin/*`) use a 3s slow threshold
+- Outgoing requests are grouped by provider (mapbox, google, mercadopago, sms)
+- `SyncArgautosCarCatalogJob` uses a 120s slow-job threshold
+- Notification count cache keys are grouped per user
+
+## Future upgrades
+
+If Pulse DB writes become noticeable under high traffic:
+
+1. Set `PULSE_INGEST_DRIVER=redis` with a dedicated Redis connection
+2. Run `php artisan pulse:work` via Supervisor (separate from `pulse:check`)
+3. Optionally use `PULSE_DB_CONNECTION` for a dedicated MySQL database
+
+## Security notes
+
+- Pulse uses web session auth, separate from JWT API auth
+- Only `is_admin` users pass the `viewPulse` gate
+- Do not expose `/pulse` without HTTPS in production
+- Consider IP allowlisting at the web server if you want an extra layer beyond admin login
+
+## Related docs
+
+- [Laravel Pulse documentation](https://laravel.com/docs/pulse)
+- [PASSWORD_RESET_ERROR_SOLUTION.md](PASSWORD_RESET_ERROR_SOLUTION.md) — existing Supervisor queue worker example
+- [PRODUCTION_STORAGE_AND_CACHE.md](PRODUCTION_STORAGE_AND_CACHE.md) — file cache permissions on production

--- a/resources/views/pulse/login.blade.php
+++ b/resources/views/pulse/login.blade.php
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Pulse Login - {{ config('app.name') }}</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: #f5f5f5;
+            color: #111827;
+        }
+
+        .card {
+            width: min(100%, 24rem);
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 0.75rem;
+            padding: 2rem;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
+        }
+
+        h1 {
+            margin: 0 0 0.5rem;
+            font-size: 1.5rem;
+        }
+
+        p {
+            margin: 0 0 1.5rem;
+            color: #6b7280;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }
+
+        input[type="email"],
+        input[type="password"] {
+            width: 100%;
+            box-sizing: border-box;
+            margin-bottom: 1rem;
+            padding: 0.75rem 0.875rem;
+            border: 1px solid #d1d5db;
+            border-radius: 0.5rem;
+            font: inherit;
+        }
+
+        button {
+            width: 100%;
+            border: 0;
+            border-radius: 0.5rem;
+            padding: 0.75rem 1rem;
+            background: #111827;
+            color: #fff;
+            font: inherit;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .error {
+            margin-bottom: 1rem;
+            padding: 0.75rem 0.875rem;
+            border-radius: 0.5rem;
+            background: #fef2f2;
+            color: #b91c1c;
+            font-size: 0.875rem;
+        }
+    </style>
+</head>
+<body>
+    <main class="card">
+        <h1>Pulse</h1>
+        <p>Admin access to application monitoring.</p>
+
+        @if ($errors->any())
+            <div class="error">{{ $errors->first() }}</div>
+        @endif
+
+        <form method="POST" action="{{ route('pulse.login') }}">
+            @csrf
+
+            <label for="email">Email</label>
+            <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus autocomplete="username">
+
+            <label for="password">Password</label>
+            <input id="password" type="password" name="password" required autocomplete="current-password">
+
+            <button type="submit">Sign in</button>
+        </form>
+    </main>
+</body>
+</html>

--- a/resources/views/vendor/pulse/dashboard.blade.php
+++ b/resources/views/vendor/pulse/dashboard.blade.php
@@ -1,0 +1,19 @@
+<x-pulse>
+    <livewire:pulse.servers cols="full" />
+
+    <livewire:pulse.usage cols="4" rows="2" />
+
+    <livewire:pulse.queues cols="4" />
+
+    <livewire:pulse.cache cols="4" />
+
+    <livewire:pulse.slow-queries cols="8" />
+
+    <livewire:pulse.exceptions cols="6" />
+
+    <livewire:pulse.slow-requests cols="6" />
+
+    <livewire:pulse.slow-jobs cols="6" />
+
+    <livewire:pulse.slow-outgoing-requests cols="6" />
+</x-pulse>

--- a/routes/console.php
+++ b/routes/console.php
@@ -57,3 +57,5 @@ Schedule::command('support-tickets:release-expired-assignments')
 Schedule::command('car-catalog:sync-argautos --mode=incremental')
     ->weeklyOn(1, '03:00')
     ->timezone('America/Argentina/Buenos_Aires');
+
+Schedule::command('pulse:check')->everyMinute();

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,16 @@ use STS\Http\Controllers\Api\v1\DataController;
 use STS\Http\Controllers\Api\v1\MercadoPagoWebhookController;
 use STS\Http\Controllers\Api\v1\WhatsAppWebhookController;
 use STS\Http\Controllers\HomeController;
+use STS\Http\Controllers\Web\PulseAuthController;
+
+Route::middleware('guest')->group(function () {
+    Route::get('pulse/login', [PulseAuthController::class, 'showLoginForm'])->name('pulse.login');
+    Route::post('pulse/login', [PulseAuthController::class, 'login'])->middleware('throttle:6,1');
+});
+
+Route::post('pulse/logout', [PulseAuthController::class, 'logout'])
+    ->middleware('auth')
+    ->name('pulse.logout');
 
 Route::get('/', [HomeController::class, 'home']);
 Route::get('/home', [HomeController::class, 'home']);

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -68,6 +68,12 @@ class ScheduleTest extends TestCase
         $this->assertEquals('* * * * *', $event->expression);
     }
 
+    public function test_pulse_check_is_scheduled_every_minute()
+    {
+        $event = $this->findEvent('pulse:check');
+        $this->assertEquals('* * * * *', $event->expression);
+    }
+
     public function test_messages_email_is_scheduled_every_ten_minutes()
     {
         $event = $this->findEvent('messages:email');
@@ -154,6 +160,7 @@ class ScheduleTest extends TestCase
             'rating:availables',
             'live-location:process',
             'maintenance:tick',
+            'pulse:check',
             'trip:request',
             'trip:visibilityclean',
             'node:buildweights',

--- a/tests/Feature/Http/PulseAuthTest.php
+++ b/tests/Feature/Http/PulseAuthTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use STS\Models\User;
+use Tests\TestCase;
+
+class PulseAuthTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(ThrottleRequests::class);
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_guest_cannot_access_pulse(): void
+    {
+        $response = $this->get('/pulse');
+
+        $response->assertRedirect('/pulse/login');
+    }
+
+    public function test_admin_can_login_and_access_pulse(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->post('/pulse/login', [
+            'email' => $admin->email,
+            'password' => '123456',
+        ]);
+
+        $response->assertRedirect('/pulse');
+        $this->get('/pulse')->assertOk();
+    }
+
+    public function test_non_admin_cannot_login_to_pulse(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'member@example.com',
+        ]);
+
+        $response = $this->from('/pulse/login')->post('/pulse/login', [
+            'email' => $user->email,
+            'password' => '123456',
+        ]);
+
+        $response->assertRedirect('/pulse/login');
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest('web');
+    }
+
+    public function test_banned_admin_cannot_login(): void
+    {
+        $admin = $this->adminUser();
+        $admin->forceFill(['banned' => true])->saveQuietly();
+
+        $response = $this->from('/pulse/login')->post('/pulse/login', [
+            'email' => $admin->email,
+            'password' => '123456',
+        ]);
+
+        $response->assertRedirect('/pulse/login');
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest('web');
+    }
+
+    public function test_logout_clears_session(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin, 'web')
+            ->post('/pulse/logout')
+            ->assertRedirect(route('pulse.login'));
+
+        $this->get('/pulse')->assertRedirect('/pulse/login');
+    }
+}

--- a/tests/Feature/Http/PulseAuthorizationTest.php
+++ b/tests/Feature/Http/PulseAuthorizationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Models\User;
+use Tests\TestCase;
+
+class PulseAuthorizationTest extends TestCase
+{
+    public function test_non_admin_session_cannot_view_pulse(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'web')
+            ->get('/pulse')
+            ->assertForbidden();
+    }
+
+    public function test_admin_session_can_view_pulse(): void
+    {
+        $admin = User::factory()->create();
+        $admin->forceFill(['is_admin' => true])->saveQuietly();
+
+        $this->actingAs($admin->fresh(), 'web')
+            ->get('/pulse')
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `laravel/pulse` with a Carpoolear-tuned dashboard at `/pulse` for slow requests/queries, exceptions, queues, outgoing HTTP calls, and cache stats
- Introduces admin-only web session login at `/pulse/login` (mirrors API auth rules: `is_admin`, active, not banned) since the backend is JWT API-first today
- Documents production setup in `docs/PULSE_SETUP.md`, including detailed Supervisor steps for `pulse:check` and deploy hooks (`migrate --force`, `pulse:restart`)

## Test plan

- [x] `php artisan test --filter=Pulse` (7 tests)
- [x] Deploy to staging/production and run `php artisan migrate --force`
- [x] Set `PULSE_ENABLED=true` in production `.env`
- [x] Add Supervisor program `carpoolear-pulse-check` per `docs/PULSE_SETUP.md`
- [x] Sign in at `/pulse/login` with an admin account and confirm dashboard loads
- [x] Confirm **Servers** card populates after `pulse:check` is running
- [x] Trigger a slow external call (e.g. trip route) and verify **Slow Outgoing Requests** groups (mapbox/google/mercadopago)