### PR TITLE
Read reCAPTCHA secret from config and log verification failures

### DIFF
--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -182,8 +182,10 @@ class UsersManager extends BaseManager
 
                 $url = 'https://www.google.com/recaptcha/api/siteverify';
 
+                $recaptchaSecretKey = (string) config('carpoolear.recaptcha_secret_key', '');
+
                 $recaptchaData = [
-                    'secret' => env('RECAPTCHA_SECRET_KEY', ''),
+                    'secret' => $recaptchaSecretKey,
                     'response' => $_POST['token'],
                     'remoteip' => $_SERVER['REMOTE_ADDR'],
                 ];
@@ -199,7 +201,7 @@ class UsersManager extends BaseManager
                 // Creates and returns stream context with options supplied in options preset
                 $response = $this->fetchRecaptchaVerificationResponse($url, $options);
                 // Takes a JSON encoded string and converts it into a PHP variable
-                $res = json_decode($response, true);
+                $res = is_string($response) ? json_decode($response, true) : null;
 
                 // END setting reCaptcha v3 validation data
 
@@ -207,7 +209,7 @@ class UsersManager extends BaseManager
                 // since the successful score default is set at >= 0.5 by Google. Some developers want to
                 // be able to control score result conditions, so I included that in this example.
 
-                if ($res['success'] == true && $res['score'] >= 0.5) {
+                if (is_array($res) && ($res['success'] ?? false) === true && ($res['score'] ?? 0) >= 0.5) {
                     // if (true) {
                     $u = $this->repo->create($data);
 
@@ -227,13 +229,36 @@ class UsersManager extends BaseManager
                     event(new CreateEvent($u->id));
 
                     return $u;
-                } else {
-
-                    return false;
                 }
+
+                $this->logRecaptchaRegistrationFailure($data, $response, is_array($res) ? $res : null);
+
+                return false;
             }
 
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>|null  $res
+     */
+    protected function logRecaptchaRegistrationFailure(array $data, string|false $response, ?array $res): void
+    {
+        $captchaToken = (string) ($data['token'] ?? $_POST['token'] ?? '');
+
+        \Log::warning('Registration reCAPTCHA verification failed', [
+            'email' => $data['email'] ?? null,
+            'recaptcha_configured' => (string) config('carpoolear.recaptcha_secret_key', '') !== '',
+            'captcha_token_present' => $captchaToken !== '',
+            'captcha_token_length' => strlen($captchaToken),
+            'siteverify_response_received' => $response !== false,
+            'siteverify_raw_length' => is_string($response) ? strlen($response) : null,
+            'success' => is_array($res) ? ($res['success'] ?? null) : null,
+            'score' => is_array($res) ? ($res['score'] ?? null) : null,
+            'error_codes' => is_array($res) ? ($res['error-codes'] ?? null) : null,
+            'remote_ip' => $_SERVER['REMOTE_ADDR'] ?? null,
+        ]);
     }
 
     /**

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -16,6 +16,7 @@ return [
     'banner_image_cordova' => env('BANNER_IMAGE_CORDOVA', ''),
     'banner_image_cordova_mobile' => env('BANNER_IMAGE_CORDOVA_MOBILE', ''),
     'target_app' => env('TARGET_APP', 'carpoolear'),
+    'recaptcha_secret_key' => env('RECAPTCHA_SECRET_KEY', ''),
     'module_coordinate_by_message' => env('MODULE_COORDINATE_BY_MESSAGE', false),
     'module_user_request_limited_enabled' => env('MODULE_USER_REQUEST_LIMITED_ENABLED', false),
     'module_user_request_limited_hours_range' => (int) env('MODULE_USER_REQUEST_LIMITED_HOURS_RANGE', 2),

--- a/tests/Unit/Services/Logic/UsersManagerTest.php
+++ b/tests/Unit/Services/Logic/UsersManagerTest.php
@@ -1876,6 +1876,7 @@ class UsersManagerTest extends TestCase
     public function test_create_with_recaptcha_token_returns_false_when_siteverify_reports_failure(): void
     {
         Event::fake([CreateEvent::class]);
+        Log::spy();
         $email = 'captcha-fail-'.uniqid('', true).'@example.com';
         $payload = $this->validRegistrationPayload($email);
         $payload['token'] = 't-'.uniqid('', true);
@@ -1889,13 +1890,70 @@ class UsersManagerTest extends TestCase
             {
                 protected function fetchRecaptchaVerificationResponse(string $url, array $options): string|false
                 {
-                    return json_encode(['success' => false, 'score' => 0.1], JSON_THROW_ON_ERROR);
+                    return json_encode([
+                        'success' => false,
+                        'score' => 0.1,
+                        'error-codes' => ['invalid-input-response'],
+                    ], JSON_THROW_ON_ERROR);
                 }
             };
 
             $this->assertFalse($manager->create($payload));
             $this->assertNull(User::query()->where('email', $email)->first());
             Event::assertNotDispatched(CreateEvent::class);
+
+            Log::shouldHaveReceived('warning')
+                ->once()
+                ->with(
+                    'Registration reCAPTCHA verification failed',
+                    Mockery::on(function (array $context) use ($email, $payload): bool {
+                        return $context['email'] === $email
+                            && $context['success'] === false
+                            && $context['score'] === 0.1
+                            && $context['error_codes'] === ['invalid-input-response']
+                            && $context['captcha_token_length'] === strlen($payload['token'])
+                            && $context['siteverify_response_received'] === true;
+                    })
+                );
+        } finally {
+            $_POST = $prevPost;
+        }
+    }
+
+    public function test_create_with_recaptcha_token_logs_debug_context_when_siteverify_request_fails(): void
+    {
+        Event::fake([CreateEvent::class]);
+        Log::spy();
+        $email = 'captcha-http-fail-'.uniqid('', true).'@example.com';
+        $payload = $this->validRegistrationPayload($email);
+        $payload['token'] = 't-'.uniqid('', true);
+
+        $prevPost = $_POST;
+        $_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+        $_POST['token'] = $payload['token'];
+
+        try {
+            $manager = new class(app(UserRepository::class), app(TripRepository::class)) extends UsersManager
+            {
+                protected function fetchRecaptchaVerificationResponse(string $url, array $options): string|false
+                {
+                    return false;
+                }
+            };
+
+            $this->assertFalse($manager->create($payload));
+
+            Log::shouldHaveReceived('warning')
+                ->once()
+                ->with(
+                    'Registration reCAPTCHA verification failed',
+                    Mockery::on(function (array $context) use ($email): bool {
+                        return $context['email'] === $email
+                            && $context['siteverify_response_received'] === false
+                            && $context['success'] === null
+                            && $context['score'] === null;
+                    })
+                );
         } finally {
             $_POST = $prevPost;
         }


### PR DESCRIPTION
## Summary
- Fix signup failing in production when `RECAPTCHA_SECRET_KEY` is set in `.env` but config is cached
- Add structured logging when reCAPTCHA siteverify fails during registration

## Root cause
`UsersManager::create()` called `env('RECAPTCHA_SECRET_KEY')` directly. With `config:cache` in production, `env()` returns empty outside config files, so Google received an empty secret.

## Changes
- Add `carpoolear.recaptcha_secret_key` to `config/carpoolear.php`
- Use `config()` instead of `env()` in `UsersManager`
- Log reCAPTCHA failures with debug context (no secrets/tokens)
- Harden null handling when siteverify HTTP call fails
- Add unit tests for failure logging

## Deploy notes
- Ensure `RECAPTCHA_SECRET_KEY` is in production `.env`
- Run `php artisan config:cache` after deploy

## Test plan
- [ ] `php artisan test --filter=recaptcha_token`
- [ ] Register a new user on staging/production with reCAPTCHA enabled
- [ ] Confirm no `Registration reCAPTCHA verification failed` log on success