### PR TITLE
Fix server-side sorting for paginated manual identity validations

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -13,6 +13,7 @@ use STS\Services\ManualIdentityValidationDeletion;
 use STS\Services\ManualIdentityValidationReviewNotifier;
 use STS\Services\UserIdentityVerificationSuccessService;
 use STS\Support\AdminPagination;
+use STS\Support\ManualIdentityValidationSort;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ManualIdentityValidationController extends Controller
@@ -27,12 +28,7 @@ class ManualIdentityValidationController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $query = ManualIdentityValidation::with('user:id,name')
-            ->orderByRaw('CASE WHEN paid = 1 THEN 0 ELSE 1 END')
-            ->orderByRaw('CASE WHEN submitted_at IS NOT NULL THEN 0 ELSE 1 END')
-            ->orderByRaw("CASE WHEN COALESCE(review_status, '') = 'approved' THEN 1 WHEN COALESCE(review_status, '') = 'rejected' THEN 2 ELSE 0 END")
-            ->orderByRaw('COALESCE(submitted_at, paid_at, created_at) ASC')
-            ->orderBy('created_at', 'asc');
+        $query = ManualIdentityValidation::with('user:id,name');
 
         if (! $this->queryFlagIsTruthy($request->query('show_resolved'))) {
             $query->where(function ($builder) {
@@ -40,6 +36,12 @@ class ManualIdentityValidationController extends Controller
                     ->orWhereNotIn('review_status', ['approved', 'approve', 'rejected', 'reject']);
             });
         }
+
+        ManualIdentityValidationSort::apply(
+            $query,
+            $request->query('sort'),
+            $request->query('direction')
+        );
 
         $perPage = AdminPagination::resolvePerPage($request->query('per_page'));
         $page = AdminPagination::resolvePage($request->query('page'));

--- a/app/Support/ManualIdentityValidationSort.php
+++ b/app/Support/ManualIdentityValidationSort.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace STS\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use STS\Models\ManualIdentityValidation;
+
+class ManualIdentityValidationSort
+{
+    /** @var list<string> */
+    public const ALLOWED_SORTS = [
+        'id',
+        'user_name',
+        'paid_at',
+        'submitted_at',
+        'waiting_time',
+        'paid',
+        'review_status',
+    ];
+
+    public static function resolveSort(?string $sort): ?string
+    {
+        return in_array($sort, self::ALLOWED_SORTS, true) ? $sort : null;
+    }
+
+    public static function resolveDirection(?string $direction): string
+    {
+        return strtolower((string) $direction) === 'asc' ? 'asc' : 'desc';
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     * @return Builder<ManualIdentityValidation>
+     */
+    public static function apply(Builder $query, ?string $sort, ?string $direction): Builder
+    {
+        $resolvedSort = self::resolveSort($sort);
+        $resolvedDirection = self::resolveDirection($direction);
+
+        if ($resolvedSort === null) {
+            return self::applyDefaultOrder($query);
+        }
+
+        return self::applyExplicitOrder($query, $resolvedSort, $resolvedDirection);
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     * @return Builder<ManualIdentityValidation>
+     */
+    private static function applyDefaultOrder(Builder $query): Builder
+    {
+        return $query
+            ->orderByRaw('CASE WHEN paid = 1 THEN 0 ELSE 1 END')
+            ->orderByRaw('CASE WHEN submitted_at IS NOT NULL THEN 0 ELSE 1 END')
+            ->orderByRaw("CASE WHEN COALESCE(review_status, '') = 'approved' THEN 1 WHEN COALESCE(review_status, '') = 'rejected' THEN 2 ELSE 0 END")
+            ->orderByRaw('COALESCE(submitted_at, paid_at, created_at) ASC')
+            ->orderBy('manual_identity_validations.created_at', 'asc');
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     * @return Builder<ManualIdentityValidation>
+     */
+    private static function applyExplicitOrder(Builder $query, string $sort, string $direction): Builder
+    {
+        $table = 'manual_identity_validations';
+
+        switch ($sort) {
+            case 'id':
+                $query->orderBy("{$table}.id", $direction);
+                break;
+            case 'user_name':
+                self::joinUsers($query);
+                $query
+                    ->orderByRaw('users.name IS NULL')
+                    ->orderBy('users.name', $direction);
+                break;
+            case 'paid_at':
+                $query
+                    ->orderByRaw("{$table}.paid_at IS NULL")
+                    ->orderBy("{$table}.paid_at", $direction);
+                break;
+            case 'submitted_at':
+                $query
+                    ->orderByRaw("{$table}.submitted_at IS NULL")
+                    ->orderBy("{$table}.submitted_at", $direction);
+                break;
+            case 'waiting_time':
+                $query
+                    ->orderByRaw("{$table}.submitted_at IS NULL")
+                    ->orderByRaw(
+                        "TIMESTAMPDIFF(SECOND, {$table}.submitted_at, COALESCE({$table}.manual_validation_started_at, NOW())) {$direction}"
+                    );
+                break;
+            case 'paid':
+                $query->orderBy("{$table}.paid", $direction);
+                break;
+            case 'review_status':
+                $query->orderByRaw(
+                    "CASE
+                        WHEN {$table}.paid = 0 THEN 0
+                        WHEN {$table}.review_status IS NULL OR {$table}.review_status = '' THEN 1
+                        WHEN {$table}.review_status IN ('approved', 'approve') THEN 2
+                        WHEN {$table}.review_status IN ('rejected', 'reject') THEN 3
+                        ELSE 1
+                    END {$direction}"
+                );
+                break;
+        }
+
+        return $query->orderBy("{$table}.id", 'asc');
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     */
+    private static function joinUsers(Builder $query): void
+    {
+        if (self::queryHasUsersJoin($query)) {
+            return;
+        }
+
+        $query
+            ->leftJoin('users', 'users.id', '=', 'manual_identity_validations.user_id')
+            ->select('manual_identity_validations.*');
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     */
+    private static function queryHasUsersJoin(Builder $query): bool
+    {
+        $joins = $query->getQuery()->joins ?? [];
+
+        foreach ($joins as $join) {
+            if ($join->table === 'users') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -126,6 +126,42 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->assertContains($approvedUser->id, $resolvedIds);
     }
 
+    public function test_index_sorts_by_id_across_pages_not_only_within_page(): void
+    {
+        $admin = $this->admin();
+        $rows = [];
+
+        for ($i = 1; $i <= 25; $i++) {
+            $user = User::factory()->create();
+            $rows[] = ManualIdentityValidation::create([
+                'user_id' => $user->id,
+                'paid' => true,
+                'paid_at' => now(),
+                'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+            ]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $pageOneIds = collect(
+            $this->getJson('api/admin/manual-identity-validations?sort=id&direction=desc&per_page=10&page=1')
+                ->assertOk()
+                ->json('data')
+        )->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $pageTwoIds = collect(
+            $this->getJson('api/admin/manual-identity-validations?sort=id&direction=desc&per_page=10&page=2')
+                ->assertOk()
+                ->json('data')
+        )->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertCount(10, $pageOneIds);
+        $this->assertCount(10, $pageTwoIds);
+        $this->assertSame(max($pageOneIds), $pageOneIds[0]);
+        $this->assertTrue(min($pageOneIds) > max($pageTwoIds));
+    }
+
     public function test_show_builds_image_urls_from_rtrimmed_app_url_without_double_slash(): void
     {
         Config::set('app.url', 'https://app.example.com/');

--- a/tests/Unit/Support/ManualIdentityValidationSortTest.php
+++ b/tests/Unit/Support/ManualIdentityValidationSortTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use STS\Support\ManualIdentityValidationSort;
+use Tests\TestCase;
+
+class ManualIdentityValidationSortTest extends TestCase
+{
+    public function test_resolve_sort_accepts_allowed_columns(): void
+    {
+        $this->assertSame('id', ManualIdentityValidationSort::resolveSort('id'));
+        $this->assertSame('user_name', ManualIdentityValidationSort::resolveSort('user_name'));
+        $this->assertSame('waiting_time', ManualIdentityValidationSort::resolveSort('waiting_time'));
+    }
+
+    public function test_resolve_sort_returns_null_for_invalid_columns(): void
+    {
+        $this->assertNull(ManualIdentityValidationSort::resolveSort('not_a_column'));
+        $this->assertNull(ManualIdentityValidationSort::resolveSort(null));
+    }
+
+    public function test_resolve_direction_defaults_to_desc_and_accepts_asc(): void
+    {
+        $this->assertSame('desc', ManualIdentityValidationSort::resolveDirection(null));
+        $this->assertSame('asc', ManualIdentityValidationSort::resolveDirection('asc'));
+        $this->assertSame('desc', ManualIdentityValidationSort::resolveDirection('DESC'));
+    }
+
+    public function test_apply_uses_default_queue_order_when_sort_is_missing(): void
+    {
+        $query = ManualIdentityValidationSort::apply(
+            \STS\Models\ManualIdentityValidation::query(),
+            null,
+            'asc'
+        );
+
+        $this->assertInstanceOf(Builder::class, $query);
+        $this->assertStringContainsString('CASE WHEN paid = 1 THEN 0 ELSE 1 END', $query->toSql());
+    }
+
+    public function test_apply_orders_by_id_when_sort_is_id(): void
+    {
+        $query = ManualIdentityValidationSort::apply(
+            \STS\Models\ManualIdentityValidation::query(),
+            'id',
+            'desc'
+        );
+
+        $this->assertStringContainsString('order by `manual_identity_validations`.`id` desc', strtolower($query->toSql()));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ManualIdentityValidationSort` so admin manual validation list sorting runs in the database across the full result set
- Accept `sort` and `direction` query params on `GET /api/admin/manual-identity-validations`
- Keep the existing default queue order when no sort column is provided

## Test plan
- [x] `./vendor/bin/phpunit` (3420 tests pass)
- [x] Unit tests for sort resolution and SQL ordering
- [x] Integration test verifies `sort=id&direction=desc` returns higher IDs on page 1 than page 2

## Related PR
- Frontend: https://github.com/STS-Rosario/carpoolear/pull/new/pagination-fix