### PR TITLE
Fix duplicate subscription match notifications

### DIFF
--- a/app/Listeners/Subscriptions/OnNewTrip.php
+++ b/app/Listeners/Subscriptions/OnNewTrip.php
@@ -4,9 +4,11 @@ namespace STS\Listeners\Subscriptions;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use STS\Events\Trip\Create;
+use STS\Models\Trip;
 use STS\Notifications\SubscriptionMatchNotification;
 use STS\Repository\SubscriptionsRepository;
 use STS\Repository\UserRepository;
+use STS\Services\Notifications\Models\DatabaseNotification;
 
 class OnNewTrip implements ShouldQueue
 {
@@ -39,6 +41,10 @@ class OnNewTrip implements ShouldQueue
         foreach ($subscriptions as $s) {
             // \Log::info($trip->to_town . ': ' . $s->user->id . ' - ' . $s->user->name);
             // FIXME
+            if ($this->alreadyNotified($s->user->id, $trip->id)) {
+                continue;
+            }
+
             $notification = new SubscriptionMatchNotification;
             $notification->setAttribute('trip', $trip);
             try {
@@ -47,5 +53,19 @@ class OnNewTrip implements ShouldQueue
                 \Log::warning('Subscription notification failed', ['trip_id' => $trip->id, 'user_id' => $s->user->id]);
             }
         }
+    }
+
+    private function alreadyNotified(int $userId, int $tripId): bool
+    {
+        return DatabaseNotification::query()
+            ->where('user_id', $userId)
+            ->where('type', SubscriptionMatchNotification::class)
+            ->whereNull('deleted_at')
+            ->whereHas('plain_values', function ($query) use ($tripId) {
+                $query->where('key', 'trip')
+                    ->where('value_type', Trip::class)
+                    ->where('value_id', $tripId);
+            })
+            ->exists();
     }
 }

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -5,7 +5,6 @@ namespace STS\Repository;
 use Carbon\Carbon;
 use DB;
 use Illuminate\Support\Facades\Http;
-use STS\Events\Trip\Create as CreateEvent;
 use STS\Helpers\OngoingTripHelper;
 use STS\Helpers\TripPriceHelper;
 use STS\Models\NodeGeo;
@@ -163,11 +162,6 @@ class TripRepository
 
                     $nodes = [$origin->id, $destiny->id];
                     $route->nodes()->sync($nodes);
-
-                } else {
-                    if ($route->processed) {
-                        event(new CreateEvent($trip));
-                    }
                 }
                 $routeIds[] = $route->id;
             }

--- a/tests/Unit/Listeners/Subscriptions/OnNewTripListenerTest.php
+++ b/tests/Unit/Listeners/Subscriptions/OnNewTripListenerTest.php
@@ -11,6 +11,8 @@ use STS\Models\User;
 use STS\Notifications\SubscriptionMatchNotification;
 use STS\Repository\SubscriptionsRepository;
 use STS\Repository\UserRepository;
+use STS\Services\Notifications\Models\DatabaseNotification;
+use STS\Services\Notifications\Models\ValueNotification;
 use STS\Services\Notifications\NotificationServices;
 use Tests\TestCase;
 
@@ -68,6 +70,36 @@ class OnNewTripListenerTest extends TestCase
                     && $users->is($subscriber)
                     && is_string($channel);
             });
+
+        (new OnNewTrip($userRepo, $subRepo))->handle(new TripCreated($trip));
+    }
+
+    public function test_handle_skips_subscriber_already_notified_for_same_trip(): void
+    {
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $driver->id]);
+        $trip = $trip->fresh();
+
+        $subscriber = User::factory()->create();
+
+        $existing = new DatabaseNotification;
+        $existing->user_id = $subscriber->id;
+        $existing->type = SubscriptionMatchNotification::class;
+        $existing->save();
+
+        $param = new ValueNotification;
+        $param->notification_id = $existing->id;
+        $param->key = 'trip';
+        $param->value()->associate($trip);
+        $param->save();
+
+        $userRepo = Mockery::mock(UserRepository::class);
+        $subRepo = Mockery::mock(SubscriptionsRepository::class);
+        $subRepo->shouldReceive('search')
+            ->once()
+            ->andReturn(collect([(object) ['user' => $subscriber]]));
+
+        $this->mock(NotificationServices::class)->shouldNotReceive('send');
 
         (new OnNewTrip($userRepo, $subRepo))->handle(new TripCreated($trip));
     }

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -3045,9 +3045,10 @@ class TripRepositoryTest extends TestCase
         $this->assertTrue($createdRoute->nodes->pluck('id')->contains($to->id));
     }
 
-    public function test_create_reuses_processed_route_and_dispatches_create_event(): void
+    public function test_create_reuses_processed_route_without_dispatching_create_event(): void
     {
-        // Mutation intent: preserve existing-route branch, processed event trigger and trip_routes sync.
+        // Mutation intent: preserve existing-route branch and trip_routes sync without Create event.
+        // Create is owned by TripsManager to avoid duplicate subscription notifications.
         // Kills: c3ab61b50d2e29e6, 4e2796064a396e48, 2de3deecc5bf329b, 52810aad74f43a6a, 7afd019bd08af694.
         Event::fake();
         Config::set('carpoolear.module_max_price_enabled', false);
@@ -3090,7 +3091,7 @@ class TripRepositoryTest extends TestCase
             ],
         ]);
 
-        Event::assertDispatched(CreateEvent::class);
+        Event::assertNotDispatched(CreateEvent::class);
         $this->assertSame(1, Route::query()->where('from_id', $from->id)->where('to_id', $to->id)->count());
 
         $trip->refresh();


### PR DESCRIPTION
## Summary
- Stop firing `Trip\Create` from `TripRepository` when reusing an already-processed route; `TripsManager` remains the single create-time dispatcher so matching subscribers are not notified twice.
- Add idempotency in `OnNewTrip` so a user who already received a `SubscriptionMatchNotification` for a trip is skipped (covers later `BuildRoutes` re-fires).

## Test plan
- [x] Confirm `OnNewTripListenerTest` and the updated `TripRepositoryTest` pass
- [x] Create a trip on a corridor with an already-processed route while a user has a matching subscription → expect one in-app notification (not two)
- [x] Optionally run `georoute:build` after create → expect no second subscription-match notification for the same user/trip