### PR TITLE
Fix Mensajes unread badge to use message-level read state

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -49,6 +49,14 @@ class Conversation extends Model
         return $userRelation ? $userRelation->pivot->read : false;
     }
 
+    public function hasUnreadMessagesFor(UserModel $user): bool
+    {
+        return $this->messages()->whereHas('users', function ($q) use ($user) {
+            $q->where('user_id', $user->id)
+                ->where('read', false);
+        })->exists();
+    }
+
     public function notificationsEnabled(UserModel $user)
     {
         $userRelation = $this->users()->whereKey($user->id)->first();

--- a/app/Repository/MessageRepository.php
+++ b/app/Repository/MessageRepository.php
@@ -42,6 +42,16 @@ class MessageRepository
         })->orderBy('created_at', 'desc')->orderBy('id', 'desc')->get();
     }
 
+    public function countConversationsWithUnreadMessages(User $user): int
+    {
+        return (int) Message::query()
+            ->whereHas('users', fn ($q) => $q
+                ->where('user_id', $user->id)
+                ->where('read', false))
+            ->distinct()
+            ->count('conversation_id');
+    }
+
     public function changeMessageReadState(Message $message, User $user, $read_state)
     {
         $message->users()->updateExistingPivot($user->id, ['read' => $read_state]);

--- a/app/Repository/MessageRepository.php
+++ b/app/Repository/MessageRepository.php
@@ -36,18 +36,16 @@ class MessageRepository
 
     public function getUnreadMessages(Conversation $conversation, User $user)
     {
-        return $conversation->messages()->whereHas('users', function ($q) use ($user) {
-            $q->where('user_id', $user->id)
-                ->where('read', false);
-        })->orderBy('created_at', 'desc')->orderBy('id', 'desc')->get();
+        return $conversation->messages()
+            ->whereHas('users', $this->unreadForUserConstraint($user))
+            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->get();
     }
 
     public function countConversationsWithUnreadMessages(User $user): int
     {
-        return (int) Message::query()
-            ->whereHas('users', fn ($q) => $q
-                ->where('user_id', $user->id)
-                ->where('read', false))
+        return (int) $this->queryUnreadMessagesForUser($user)
             ->distinct()
             ->count('conversation_id');
     }
@@ -64,10 +62,7 @@ class MessageRepository
 
     public function getMessagesUnread(User $user, $timestamp)
     {
-        $msgs = Message::whereHas('users', function ($q) use ($user) {
-            $q->where('user_id', $user->id)
-                ->where('read', false);
-        });
+        $msgs = $this->queryUnreadMessagesForUser($user);
 
         if ($timestamp) {
             $msgs->where('created_at', '>', $timestamp);
@@ -81,11 +76,7 @@ class MessageRepository
     public function markMessages(User $user, $conversation_id)
     {
         $msgs = Message::where('conversation_id', $conversation_id)
-            ->whereHas('users',
-                function ($q) use ($user) {
-                    $q->where('user_id', $user->id)
-                        ->where('read', false);
-                })
+            ->whereHas('users', $this->unreadForUserConstraint($user))
             ->pluck('id');
         DB::table('user_message_read')
             ->whereIn('message_id', $msgs)
@@ -94,5 +85,18 @@ class MessageRepository
                 'read' => true,
                 'updated_at' => Carbon::Now(),
             ]);
+    }
+
+    private function queryUnreadMessagesForUser(User $user)
+    {
+        return Message::query()->whereHas('users', $this->unreadForUserConstraint($user));
+    }
+
+    private function unreadForUserConstraint(User $user): \Closure
+    {
+        return function ($q) use ($user) {
+            $q->where('user_id', $user->id)
+                ->where('read', false);
+        };
     }
 }

--- a/app/Repository/MessageRepository.php
+++ b/app/Repository/MessageRepository.php
@@ -64,22 +64,10 @@ class MessageRepository
 
     public function getMessagesUnread(User $user, $timestamp)
     {
-        /* $msgs = Message::whereHas('users', function ($q) use ($user) {
+        $msgs = Message::whereHas('users', function ($q) use ($user) {
             $q->where('user_id', $user->id)
                 ->where('read', false);
-        }); */
-
-        $conversations = $user->conversations;
-
-        $conversations_id = [];
-
-        $conversations->each(function ($item, $key) use (&$conversations_id) {
-            if ($item->pivot->read == 0) {
-                $conversations_id[] = $item->id;
-            }
         });
-
-        $msgs = Message::whereIn('conversation_id', $conversations_id);
 
         if ($timestamp) {
             $msgs->where('created_at', '>', $timestamp);

--- a/app/Services/Logic/NotificationManager.php
+++ b/app/Services/Logic/NotificationManager.php
@@ -2,6 +2,7 @@
 
 namespace STS\Services\Logic;
 
+use STS\Repository\MessageRepository;
 use STS\Repository\NotificationRepository;
 use STS\Repository\PassengersRepository;
 use STS\Repository\RatingRepository;
@@ -16,14 +17,18 @@ class NotificationManager
 
     protected RatingRepository $ratingRepository;
 
+    protected MessageRepository $messageRepository;
+
     public function __construct(
         NotificationRepository $repo,
         ?PassengersRepository $passengersRepository = null,
-        ?RatingRepository $ratingRepository = null
+        ?RatingRepository $ratingRepository = null,
+        ?MessageRepository $messageRepository = null
     ) {
         $this->repo = $repo;
         $this->passengersRepository = $passengersRepository ?? new PassengersRepository;
         $this->ratingRepository = $ratingRepository ?? new RatingRepository;
+        $this->messageRepository = $messageRepository ?? new MessageRepository;
     }
 
     public function getNotifications($user, $data)
@@ -88,9 +93,7 @@ class NotificationManager
 
     protected function countUnreadConversations($user): int
     {
-        return (int) $user->conversations()
-            ->wherePivot('read', 0)
-            ->count();
+        return $this->messageRepository->countConversationsWithUnreadMessages($user);
     }
 
     public function delete($user, $id)

--- a/app/Transformers/ConversationsTransformer.php
+++ b/app/Transformers/ConversationsTransformer.php
@@ -74,7 +74,7 @@ class ConversationsTransformer extends TransformerAbstract
                 break;
         }
 
-        $data['unread'] = ! $conversation->read($this->user);
+        $data['unread'] = $conversation->hasUnreadMessagesFor($this->user);
         $data['notifications_enabled'] = $conversation->notificationsEnabled($this->user);
         $data['update_at'] = $conversation->updated_at ? $conversation->updated_at->toDateTimeString() : null;
 

--- a/tests/Unit/Repository/MessageRepositoryTest.php
+++ b/tests/Unit/Repository/MessageRepositoryTest.php
@@ -244,6 +244,8 @@ class MessageRepositoryTest extends TestCase
 
         $mOld = $this->makeMessage($convUnread, $sender, 'a', Carbon::parse('2019-01-01 08:00:00'));
         $mNew = $this->makeMessage($convUnread, $sender, 'b', Carbon::parse('2019-01-05 08:00:00'));
+        $mOld->users()->attach($reader->id, ['read' => false]);
+        $mNew->users()->attach($reader->id, ['read' => false]);
 
         $allUnreadConv = $this->repo()->getMessagesUnread($reader, null);
         $this->assertTrue($allUnreadConv->pluck('id')->contains($mOld->id));
@@ -253,6 +255,37 @@ class MessageRepositoryTest extends TestCase
         $afterTs = $this->repo()->getMessagesUnread($reader, $since);
         $this->assertCount(1, $afterTs);
         $this->assertSame($mNew->id, $afterTs->first()->id);
+    }
+
+    public function test_get_messages_unread_ignores_conversation_pivot_when_messages_are_read(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+
+        $conv = Conversation::factory()->create();
+        $reader->conversations()->attach($conv->id, ['read' => false]);
+
+        $message = $this->makeMessage($conv, $sender, 'already-read');
+        $message->users()->attach($reader->id, ['read' => true]);
+
+        $this->assertCount(0, $this->repo()->getMessagesUnread($reader, null));
+    }
+
+    public function test_get_messages_unread_includes_unread_messages_when_conversation_pivot_is_read(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+
+        $conv = Conversation::factory()->create();
+        $reader->conversations()->attach($conv->id, ['read' => true]);
+
+        $message = $this->makeMessage($conv, $sender, 'still-unread');
+        $message->users()->attach($reader->id, ['read' => false]);
+
+        $rows = $this->repo()->getMessagesUnread($reader, null);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($message->id, $rows->first()->id);
     }
 
     public function test_get_messages_unread_returns_empty_when_user_has_no_conversations(): void
@@ -387,49 +420,54 @@ class MessageRepositoryTest extends TestCase
         );
     }
 
-    public function test_get_messages_unread_includes_conversation_when_pivot_read_is_loosely_zero(): void
+    public function test_get_messages_unread_includes_message_when_user_message_read_pivot_is_loosely_zero(): void
     {
-        // Mutation intent: preserve `$item->pivot->read == 0` — strict `=== 0` skips numeric-string pivots that still mean unread.
         $reader = User::factory()->create();
         $sender = User::factory()->create();
 
-        $convUnread = Conversation::factory()->create();
-        $reader->conversations()->attach($convUnread->id, ['read' => false]);
+        $conv = Conversation::factory()->create();
+        $reader->conversations()->attach($conv->id, ['read' => true]);
 
-        DB::table('conversations_users')
+        $message = $this->makeMessage($conv, $sender, 'ping', Carbon::parse('2019-02-01 08:00:00'));
+        $message->users()->attach($reader->id, ['read' => false]);
+
+        DB::table('user_message_read')
+            ->where('message_id', $message->id)
             ->where('user_id', $reader->id)
-            ->where('conversation_id', $convUnread->id)
             ->update(['read' => '0']);
-
-        $reader = User::query()->findOrFail($reader->id);
-
-        $this->makeMessage($convUnread, $sender, 'ping', Carbon::parse('2019-02-01 08:00:00'));
 
         $rows = $this->repo()->getMessagesUnread($reader, null);
 
         $this->assertSame(1, $rows->count());
     }
 
-    public function test_get_messages_unread_includes_unread_conversation_when_pdo_stringifies_tinyint_as_string_zero(): void
+    public function test_get_messages_unread_includes_unread_message_when_pdo_stringifies_tinyint_as_string_zero(): void
     {
-        // Mutation intent: `Line 67: EqualToIdentical` — `== 0` must stay loose; `=== 0` fails when PDO returns pivot `read` as string "0" (`"0" == 0` true, `"0" === 0` false).
         $reader = User::factory()->create();
         $sender = User::factory()->create();
         $conv = Conversation::factory()->create();
-        $reader->conversations()->attach($conv->id, ['read' => false]);
+        $reader->conversations()->attach($conv->id, ['read' => true]);
+
+        $message = $this->makeMessage($conv, $sender, 'body', Carbon::parse('2018-05-01 09:00:00'));
+        $message->users()->attach($reader->id, ['read' => false]);
 
         $pdo = DB::connection()->getPdo();
         $previous = $pdo->getAttribute(PDO::ATTR_STRINGIFY_FETCHES);
         $pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
         try {
-            $reader = User::query()->with('conversations')->findOrFail($reader->id);
-            $pivotRead = $reader->conversations->first()->pivot->read;
+            DB::table('user_message_read')
+                ->where('message_id', $message->id)
+                ->where('user_id', $reader->id)
+                ->update(['read' => '0']);
+
+            $pivotRead = DB::table('user_message_read')
+                ->where('message_id', $message->id)
+                ->where('user_id', $reader->id)
+                ->value('read');
             $this->assertIsString($pivotRead);
             $this->assertTrue($pivotRead == 0);
             $this->assertFalse($pivotRead === 0);
-
-            $this->makeMessage($conv, $sender, 'body', Carbon::parse('2018-05-01 09:00:00'));
 
             $rows = $this->repo()->getMessagesUnread($reader, null);
         } finally {

--- a/tests/Unit/Repository/MessageRepositoryTest.php
+++ b/tests/Unit/Repository/MessageRepositoryTest.php
@@ -160,6 +160,37 @@ class MessageRepositoryTest extends TestCase
         $this->assertSame($unread->id, $rows->first()->id);
     }
 
+    public function test_count_conversations_with_unread_messages_returns_zero_when_no_unread_messages(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+
+        $conv = Conversation::factory()->create();
+        $reader->conversations()->attach($conv->id, ['read' => false]);
+
+        $this->assertSame(0, $this->repo()->countConversationsWithUnreadMessages($reader));
+    }
+
+    public function test_count_conversations_with_unread_messages_counts_distinct_conversations(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+
+        $conv1 = Conversation::factory()->create();
+        $conv2 = Conversation::factory()->create();
+        $reader->conversations()->attach($conv1->id, ['read' => true]);
+        $reader->conversations()->attach($conv2->id, ['read' => true]);
+
+        $m1 = $this->makeMessage($conv1, $sender);
+        $m2 = $this->makeMessage($conv1, $sender);
+        $m3 = $this->makeMessage($conv2, $sender);
+        $m1->users()->attach($reader->id, ['read' => false]);
+        $m2->users()->attach($reader->id, ['read' => false]);
+        $m3->users()->attach($reader->id, ['read' => false]);
+
+        $this->assertSame(2, $this->repo()->countConversationsWithUnreadMessages($reader));
+    }
+
     public function test_get_unread_messages_returns_empty_when_no_unread_for_user(): void
     {
         // Mutation intent: preserve whereHas users read=false (~37–42).

--- a/tests/Unit/Services/Logic/NotificationManagerTest.php
+++ b/tests/Unit/Services/Logic/NotificationManagerTest.php
@@ -5,10 +5,12 @@ namespace Tests\Unit\Services\Logic;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
+use STS\Models\Message;
 use STS\Models\Trip;
 use STS\Models\User;
 use STS\Notifications\AcceptPassengerNotification;
 use STS\Notifications\DummyNotification;
+use STS\Repository\MessageRepository;
 use STS\Repository\NotificationRepository;
 use STS\Services\Logic\NotificationManager;
 use STS\Support\NotificationCountCache;
@@ -16,9 +18,14 @@ use Tests\TestCase;
 
 class NotificationManagerTest extends TestCase
 {
-    private function manager(): NotificationManager
+    private function manager(?MessageRepository $messageRepository = null): NotificationManager
     {
-        return new NotificationManager(new NotificationRepository);
+        return new NotificationManager(
+            new NotificationRepository,
+            null,
+            null,
+            $messageRepository
+        );
     }
 
     private function sendDummy(User $user, string $dummyValue): void
@@ -284,6 +291,14 @@ class NotificationManagerTest extends TestCase
         $driver->conversations()->attach($conversation->id, ['read' => false]);
         $passenger->conversations()->attach($conversation->id, ['read' => true]);
 
+        $message = Message::create([
+            'user_id' => $passenger->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Unread for driver',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+        $message->users()->attach($driver->id, ['read' => false]);
+
         $trip = Trip::factory()->create([
             'user_id' => $driver->id,
             'trip_date' => Carbon::now()->addDays(2),
@@ -304,6 +319,22 @@ class NotificationManagerTest extends TestCase
             'messages' => 1,
             'my_trips' => 2,
         ], $counts);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_get_navigation_badge_counts_does_not_count_empty_unread_conversation(): void
+    {
+        Cache::flush();
+        Carbon::setTestNow('2026-06-16 12:00:00');
+
+        $user = User::factory()->create();
+        $conversation = \STS\Models\Conversation::factory()->create();
+        $user->conversations()->attach($conversation->id, ['read' => false]);
+
+        $counts = $this->manager()->getNavigationBadgeCounts($user);
+
+        $this->assertSame(0, $counts['messages']);
 
         Carbon::setTestNow();
     }

--- a/tests/Unit/Transformers/ConversationsTransformerTest.php
+++ b/tests/Unit/Transformers/ConversationsTransformerTest.php
@@ -36,6 +36,7 @@ class ConversationsTransformerTest extends TestCase
             'text' => 'Latest text',
             'estado' => Message::STATE_NOLEIDO,
         ]);
+        $message->users()->attach($viewer->id, ['read' => false]);
         $message->forceFill(['created_at' => Carbon::parse('2026-04-30 12:00:00')])->saveQuietly();
 
         $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
@@ -355,5 +356,53 @@ class ConversationsTransformerTest extends TestCase
 
         $this->assertSame('Hertha Wolf', $payload['title']);
         $this->assertSame('/image/profile/hertha.png', $payload['image']);
+    }
+
+    public function test_transform_unread_is_false_when_conversation_pivot_unread_but_messages_are_read(): void
+    {
+        $viewer = User::factory()->create();
+        $other = User::factory()->create();
+        $conversation = Conversation::query()->create([
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+            'title' => 'Stale pivot',
+        ]);
+        $conversation->users()->attach($viewer->id, ['read' => false]);
+        $conversation->users()->attach($other->id, ['read' => true]);
+
+        $message = Message::query()->create([
+            'user_id' => $other->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Already read',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+        $message->users()->attach($viewer->id, ['read' => true]);
+
+        $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
+
+        $this->assertFalse($payload['unread']);
+    }
+
+    public function test_transform_unread_is_true_when_conversation_pivot_read_but_messages_are_unread(): void
+    {
+        $viewer = User::factory()->create();
+        $other = User::factory()->create();
+        $conversation = Conversation::query()->create([
+            'type' => Conversation::TYPE_PRIVATE_CONVERSATION,
+            'title' => 'Stale pivot read',
+        ]);
+        $conversation->users()->attach($viewer->id, ['read' => true]);
+        $conversation->users()->attach($other->id, ['read' => true]);
+
+        $message = Message::query()->create([
+            'user_id' => $other->id,
+            'conversation_id' => $conversation->id,
+            'text' => 'Still unread',
+            'estado' => Message::STATE_NOLEIDO,
+        ]);
+        $message->users()->attach($viewer->id, ['read' => false]);
+
+        $payload = (new ConversationsTransformer($viewer))->transform($conversation->fresh());
+
+        $this->assertTrue($payload['unread']);
     }
 }


### PR DESCRIPTION
## Summary
- Fix navigation badge `messages` count to count conversations with unread messages (`user_message_read.read = false`) instead of stale `conversations_users.read = 0` pivot rows
- Align `getMessagesUnread()` and conversation list `unread` flag with the same message-level definition via `MessageRepository::countConversationsWithUnreadMessages()` and `Conversation::hasUnreadMessagesFor()`
- Add unit tests covering empty unread conversations, stale pivot state, and distinct conversation counting

## Test plan
- [x] `php artisan test` — 3467 tests passed
- [x] `php artisan test --filter="MessageRepositoryTest|NotificationManagerTest|ConversationsTransformerTest"`
- [ ] Verify `GET /api/notifications/count` returns `messages: 0` for users with empty threads marked unread at conversation level
- [ ] Verify badge count matches highlighted threads in the Mensajes conversation list for users with stale pivot data