### PR TITLE
Mark conversation messages read when opening chat

### DIFF
--- a/app/Services/Logic/ConversationsManager.php
+++ b/app/Services/Logic/ConversationsManager.php
@@ -362,17 +362,13 @@ class ConversationsManager extends BaseManager
         if ($conversation) {
             if ($unreadMessages) {
                 $messages = $this->messageRepository->getUnreadMessages($conversation, $user);
-                if ($read) {
-                    foreach ($messages as $message) {
-                        $this->messageRepository->changeMessageReadState($message, $user, true);
-                    }
-                }
             } else {
                 $messages = $this->messageRepository->getMessages($conversation, $timestamp, $pageSize);
             }
 
             if ($read) {
                 $this->conversationRepository->changeConversationReadState($conversation, $user, true);
+                $this->messageRepository->markMessages($user, $conversation->id);
             }
         } else {
             $messages = null;

--- a/tests/Feature/Http/ConversationApiTest.php
+++ b/tests/Feature/Http/ConversationApiTest.php
@@ -542,6 +542,33 @@ class ConversationApiTest extends TestCase
         $this->assertTrue((bool) $pivotRead);
     }
 
+    public function test_get_conversation_messages_with_read_true_marks_user_message_read_rows(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+        $conversation = Conversation::factory()->create();
+        $this->conversationRepository->addUser($conversation, $reader);
+        $this->conversationRepository->addUser($conversation, $sender);
+        $reader->conversations()->updateExistingPivot($conversation->id, ['read' => false]);
+
+        $this->conversationManager->send($sender, $conversation->id, 'Open me');
+        $messageId = Message::where('conversation_id', $conversation->id)->value('id');
+
+        $this->assertFalse((bool) \DB::table('user_message_read')
+            ->where('message_id', $messageId)
+            ->where('user_id', $reader->id)
+            ->value('read'));
+
+        $this->actingAs($reader, 'api')
+            ->getJson('api/conversations/'.$conversation->id.'?read=true&unread=false&pageSize=20')
+            ->assertOk();
+
+        $this->assertTrue((bool) \DB::table('user_message_read')
+            ->where('message_id', $messageId)
+            ->where('user_id', $reader->id)
+            ->value('read'));
+    }
+
     public function test_users_method_returns_manager_payload_when_available(): void
     {
         $actor = User::factory()->create();

--- a/tests/Unit/Services/Logic/ConversationsManagerTest.php
+++ b/tests/Unit/Services/Logic/ConversationsManagerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services\Logic;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Mockery;
 use STS\Events\MessageSend;
@@ -460,6 +461,55 @@ class ConversationsManagerTest extends TestCase
 
         $updated = $this->manager()->setConversationNotifications($user, $conversation->id, true);
         $this->assertTrue($updated->notificationsEnabled($user));
+    }
+
+    public function test_get_all_messages_from_conversation_with_read_marks_user_message_read_rows(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+        $conversation = Conversation::factory()->create();
+        $conversation->users()->attach($reader->id, ['read' => false]);
+        $conversation->users()->attach($sender->id, ['read' => true]);
+
+        $this->manager()->send($sender, $conversation->id, 'Hello');
+        $this->manager()->send($sender, $conversation->id, 'Again');
+
+        $messageIds = Message::where('conversation_id', $conversation->id)->pluck('id');
+        foreach ($messageIds as $messageId) {
+            $this->assertFalse((bool) DB::table('user_message_read')
+                ->where('message_id', $messageId)
+                ->where('user_id', $reader->id)
+                ->value('read'));
+        }
+
+        $this->manager()->getAllMessagesFromConversation($conversation->id, $reader, true);
+
+        foreach ($messageIds as $messageId) {
+            $this->assertTrue((bool) DB::table('user_message_read')
+                ->where('message_id', $messageId)
+                ->where('user_id', $reader->id)
+                ->value('read'));
+        }
+    }
+
+    public function test_get_all_messages_from_conversation_without_read_leaves_user_message_read_rows_unread(): void
+    {
+        $reader = User::factory()->create();
+        $sender = User::factory()->create();
+        $conversation = Conversation::factory()->create();
+        $conversation->users()->attach($reader->id, ['read' => false]);
+        $conversation->users()->attach($sender->id, ['read' => true]);
+
+        $this->manager()->send($sender, $conversation->id, 'Still unread');
+
+        $messageId = Message::where('conversation_id', $conversation->id)->value('id');
+
+        $this->manager()->getAllMessagesFromConversation($conversation->id, $reader, false);
+
+        $this->assertFalse((bool) DB::table('user_message_read')
+            ->where('message_id', $messageId)
+            ->where('user_id', $reader->id)
+            ->value('read'));
     }
 
     public function test_send_system_message_creates_message_with_is_system_flag_and_no_notification_event(): void


### PR DESCRIPTION
## Summary
- Mark all `user_message_read` rows as read when loading a conversation with `read=true` (the path used when opening a chat in the app)
- Consolidate read marking in `getMessagesFromConversation` via `markMessages()` instead of per-message loops on the unread-only path
- Fixes badge/list staying unread if the user opens a thread and switches away before the 20s poll runs

## Test plan
- [x] `php artisan test` — 3463 tests passed
- [x] `php artisan test --filter="ConversationsManagerTest|ConversationApiTest::test_get_conversation_messages_with_read_true"`
- [ ] Open an unread conversation, switch to another within 5s — badge and thread should stay read after refresh
- [ ] Verify `GET /api/conversations/{id}?read=true&unread=false` marks `user_message_read` immediately

## Related
- Works with PR #388 (`mensajes-unread-fix`) for message-level badge/list consistency
- Frontend release: Carpoolear `4.0.4` version bump committed on `master`