### PR TITLE
Sort manual verification list by support tickets

### DIFF
--- a/app/Support/ManualIdentityValidationSort.php
+++ b/app/Support/ManualIdentityValidationSort.php
@@ -4,6 +4,7 @@ namespace STS\Support;
 
 use Illuminate\Database\Eloquent\Builder;
 use STS\Models\ManualIdentityValidation;
+use STS\Models\SupportTicket;
 
 class ManualIdentityValidationSort
 {
@@ -16,6 +17,7 @@ class ManualIdentityValidationSort
         'waiting_time',
         'paid',
         'review_status',
+        'open_account_verification_tickets_count',
     ];
 
     public static function resolveSort(?string $sort): ?string
@@ -98,18 +100,87 @@ class ManualIdentityValidationSort
                 break;
             case 'review_status':
                 $query->orderByRaw(
-                    "CASE
-                        WHEN {$table}.paid = 0 THEN 0
-                        WHEN {$table}.review_status IS NULL OR {$table}.review_status = '' THEN 1
-                        WHEN {$table}.review_status IN ('approved', 'approve') THEN 2
-                        WHEN {$table}.review_status IN ('rejected', 'reject') THEN 3
-                        ELSE 1
-                    END {$direction}"
+                    self::reviewStatusOrderExpression($table, $direction)
                 );
+                break;
+            case 'open_account_verification_tickets_count':
+                self::joinOpenAccountVerificationTicketCounts($query);
+                $query
+                    ->orderByRaw(
+                        'COALESCE(open_account_verification_tickets_count, 0) '.$direction
+                    )
+                    ->orderByRaw(
+                        self::workflowStateOrderExpression($table, $direction)
+                    );
                 break;
         }
 
         return $query->orderBy("{$table}.id", 'asc');
+    }
+
+    private static function reviewStatusOrderExpression(string $table, string $direction): string
+    {
+        return "CASE
+            WHEN {$table}.paid = 0 THEN 0
+            WHEN {$table}.review_status IS NULL OR {$table}.review_status = '' THEN 1
+            WHEN {$table}.review_status IN ('approved', 'approve') THEN 2
+            WHEN {$table}.review_status IN ('rejected', 'reject') THEN 3
+            ELSE 1
+        END {$direction}";
+    }
+
+    private static function workflowStateOrderExpression(string $table, string $direction): string
+    {
+        return "CASE
+            WHEN {$table}.paid = 0 THEN 0
+            WHEN {$table}.submitted_at IS NULL THEN 1
+            WHEN {$table}.review_status IN ('approved', 'approve') THEN 3
+            WHEN {$table}.review_status IN ('rejected', 'reject') THEN 4
+            ELSE 2
+        END {$direction}";
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     */
+    private static function joinOpenAccountVerificationTicketCounts(Builder $query): void
+    {
+        if (self::queryHasOpenAccountVerificationTicketCountsJoin($query)) {
+            return;
+        }
+
+        $subquery = SupportTicket::query()
+            ->selectRaw('user_id, COUNT(*) as open_account_verification_tickets_count')
+            ->where('type', 'account_verification')
+            ->open()
+            ->createdByAdmin()
+            ->groupBy('user_id');
+
+        $query
+            ->leftJoinSub($subquery, 'open_account_verification_tickets', function ($join) {
+                $join->on(
+                    'open_account_verification_tickets.user_id',
+                    '=',
+                    'manual_identity_validations.user_id'
+                );
+            })
+            ->select('manual_identity_validations.*');
+    }
+
+    /**
+     * @param  Builder<ManualIdentityValidation>  $query
+     */
+    private static function queryHasOpenAccountVerificationTicketCountsJoin(Builder $query): bool
+    {
+        $joins = $query->getQuery()->joins ?? [];
+
+        foreach ($joins as $join) {
+            if ($join->table === 'open_account_verification_tickets') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -183,6 +183,122 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->assertContains($approvedUser->id, $resolvedIds);
     }
 
+    public function test_index_sorts_by_open_account_verification_tickets_count_desc(): void
+    {
+        $admin = $this->admin();
+        $userNone = User::factory()->create(['name' => 'No Tickets']);
+        $userOne = User::factory()->create(['name' => 'One Ticket']);
+        $userTwo = User::factory()->create(['name' => 'Two Tickets']);
+
+        $rowNone = ManualIdentityValidation::create([
+            'user_id' => $userNone->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $rowOne = ManualIdentityValidation::create([
+            'user_id' => $userOne->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $rowTwo = ManualIdentityValidation::create([
+            'user_id' => $userTwo->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        SupportTicket::create([
+            'user_id' => $userOne->id,
+            'type' => 'account_verification',
+            'subject' => 'One open ticket',
+            'status' => 'Open',
+            'priority' => 'high',
+            'created_by' => $admin->id,
+        ]);
+        SupportTicket::create([
+            'user_id' => $userTwo->id,
+            'type' => 'account_verification',
+            'subject' => 'Two open tickets A',
+            'status' => 'Open',
+            'priority' => 'high',
+            'created_by' => $admin->id,
+        ]);
+        SupportTicket::create([
+            'user_id' => $userTwo->id,
+            'type' => 'account_verification',
+            'subject' => 'Two open tickets B',
+            'status' => 'Esperando respuesta',
+            'priority' => 'high',
+            'created_by' => $admin->id,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $ids = collect(
+            $this->getJson(
+                'api/admin/manual-identity-validations?sort=open_account_verification_tickets_count&direction=desc&show_resolved=1'
+            )->assertOk()->json('data')
+        )->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertSame([$rowTwo->id, $rowOne->id, $rowNone->id], array_slice($ids, 0, 3));
+    }
+
+    public function test_index_sorts_by_open_account_verification_tickets_count_then_workflow_state(): void
+    {
+        $admin = $this->admin();
+        $unpaidUser = User::factory()->create(['name' => 'Unpaid']);
+        $awaitingPhotosUser = User::factory()->create(['name' => 'Awaiting Photos']);
+        $pendingReviewUser = User::factory()->create(['name' => 'Pending Review']);
+
+        $unpaidRow = ManualIdentityValidation::create([
+            'user_id' => $unpaidUser->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $awaitingPhotosRow = ManualIdentityValidation::create([
+            'user_id' => $awaitingPhotosUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => null,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS,
+        ]);
+        $pendingReviewRow = ManualIdentityValidation::create([
+            'user_id' => $pendingReviewUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        foreach ([$unpaidUser, $awaitingPhotosUser, $pendingReviewUser] as $user) {
+            SupportTicket::create([
+                'user_id' => $user->id,
+                'type' => 'account_verification',
+                'subject' => 'Shared ticket count',
+                'status' => 'Open',
+                'priority' => 'high',
+                'created_by' => $admin->id,
+            ]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $ids = collect(
+            $this->getJson(
+                'api/admin/manual-identity-validations?sort=open_account_verification_tickets_count&direction=asc&show_resolved=1'
+            )->assertOk()->json('data')
+        )->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertSame(
+            [$unpaidRow->id, $awaitingPhotosRow->id, $pendingReviewRow->id],
+            array_slice($ids, 0, 3)
+        );
+    }
+
     public function test_index_sorts_by_id_across_pages_not_only_within_page(): void
     {
         $admin = $this->admin();

--- a/tests/Unit/Support/ManualIdentityValidationSortTest.php
+++ b/tests/Unit/Support/ManualIdentityValidationSortTest.php
@@ -13,6 +13,10 @@ class ManualIdentityValidationSortTest extends TestCase
         $this->assertSame('id', ManualIdentityValidationSort::resolveSort('id'));
         $this->assertSame('user_name', ManualIdentityValidationSort::resolveSort('user_name'));
         $this->assertSame('waiting_time', ManualIdentityValidationSort::resolveSort('waiting_time'));
+        $this->assertSame(
+            'open_account_verification_tickets_count',
+            ManualIdentityValidationSort::resolveSort('open_account_verification_tickets_count')
+        );
     }
 
     public function test_resolve_sort_returns_null_for_invalid_columns(): void
@@ -49,5 +53,20 @@ class ManualIdentityValidationSortTest extends TestCase
         );
 
         $this->assertStringContainsString('order by `manual_identity_validations`.`id` desc', strtolower($query->toSql()));
+    }
+
+    public function test_apply_orders_by_open_account_verification_ticket_count_and_workflow_state(): void
+    {
+        $query = ManualIdentityValidationSort::apply(
+            \STS\Models\ManualIdentityValidation::query(),
+            'open_account_verification_tickets_count',
+            'desc'
+        );
+
+        $sql = strtolower($query->toSql());
+
+        $this->assertStringContainsString('open_account_verification_tickets_count', $sql);
+        $this->assertStringContainsString('when manual_identity_validations.paid = 0 then 0', $sql);
+        $this->assertStringContainsString('coalesce(open_account_verification_tickets_count, 0) desc', $sql);
     }
 }


### PR DESCRIPTION
## Summary
- Support `sort=open_account_verification_tickets_count` on the admin manual identity validations index
- Join open, admin-created account verification tickets per user and order by ticket count
- Use manual validation workflow state as secondary sort (unpaid → awaiting photos → pending review → approved → rejected)

## Test plan
- [x] `php artisan test --filter=ManualIdentityValidationSortTest`
- [x] `php artisan test --filter=test_index_sorts_by_open_account_verification`
- [x] Full backend suite (`composer test`)
- [ ] With frontend PR deployed, verify admin manual verifications list sorts correctly by tickets column across pages

**Pairs with:** STS-Rosario/carpoolear frontend PR for the admin table sort UI.