### PR TITLE
Admin: exceso de contribución detection and review API

### DIFF
--- a/app/Helpers/TripDescriptionContributionHelper.php
+++ b/app/Helpers/TripDescriptionContributionHelper.php
@@ -3,6 +3,7 @@
 namespace STS\Helpers;
 
 use STS\Models\Trip;
+use STS\Support\TripExcessContributionStatus;
 
 class TripDescriptionContributionHelper
 {
@@ -85,6 +86,14 @@ class TripDescriptionContributionHelper
 
         $trip->has_potential_excess_contribution = $potentialSeatPriceCents !== null;
         $trip->description_potential_seat_price_cents = $potentialSeatPriceCents;
+
+        if ($potentialSeatPriceCents !== null) {
+            if ($trip->exceso_contribucion_status === null) {
+                $trip->exceso_contribucion_status = TripExcessContributionStatus::PENDIENTE;
+            }
+        } else {
+            $trip->exceso_contribucion_status = null;
+        }
     }
 
     private static function parseNumericAmountToCents(

--- a/app/Helpers/TripDescriptionContributionHelper.php
+++ b/app/Helpers/TripDescriptionContributionHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace STS\Helpers;
+
+class TripDescriptionContributionHelper
+{
+    /**
+     * @return list<int>
+     */
+    public static function extractContributionAmountsCents(string $description): array
+    {
+        $amounts = [];
+
+        if (preg_match_all(
+            '/\$\s*(\d+(?:[.,]\d+)*)\s*([kK])?/u',
+            $description,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            foreach ($matches as $match) {
+                $amounts[] = self::parseNumericAmountToCents(
+                    $match[1],
+                    ($match[2] ?? '') !== ''
+                );
+            }
+        }
+
+        if (preg_match_all(
+            '/(\d+(?:[.,]\d+)*)\s*lucas?/iu',
+            $description,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            foreach ($matches as $match) {
+                $amounts[] = self::parseNumericAmountToCents($match[1], true);
+            }
+        }
+
+        return array_values(array_unique($amounts));
+    }
+
+    public static function maxContributionAmountCents(string $description): ?int
+    {
+        $amounts = self::extractContributionAmountsCents($description);
+
+        if ($amounts === []) {
+            return null;
+        }
+
+        return max($amounts);
+    }
+
+    public static function potentialExcessContributionCents(
+        string $description,
+        int $seatPriceCents
+    ): ?int {
+        if ($seatPriceCents <= 0) {
+            return null;
+        }
+
+        $maxAmountCents = self::maxContributionAmountCents($description);
+
+        if ($maxAmountCents === null || $maxAmountCents <= $seatPriceCents) {
+            return null;
+        }
+
+        return $maxAmountCents;
+    }
+
+    public static function hasPotentialExcessContribution(
+        string $description,
+        int $seatPriceCents
+    ): bool {
+        return self::potentialExcessContributionCents($description, $seatPriceCents) !== null;
+    }
+
+    private static function parseNumericAmountToCents(
+        string $raw,
+        bool $multiplyByThousands
+    ): int {
+        $pesos = (float) self::normalizeAmountString($raw);
+
+        if ($multiplyByThousands) {
+            $pesos *= 1000;
+        }
+
+        return (int) round($pesos * 100);
+    }
+
+    private static function normalizeAmountString(string $raw): string
+    {
+        $hasComma = str_contains($raw, ',');
+        $hasDot = str_contains($raw, '.');
+
+        if ($hasComma && $hasDot) {
+            $lastComma = strrpos($raw, ',');
+            $lastDot = strrpos($raw, '.');
+
+            if ($lastComma > $lastDot) {
+                $raw = str_replace('.', '', $raw);
+                $raw = str_replace(',', '.', $raw);
+            } else {
+                $raw = str_replace(',', '', $raw);
+            }
+        } elseif ($hasComma) {
+            if (preg_match('/,\d{3}$/', $raw)) {
+                $raw = str_replace(',', '', $raw);
+            } else {
+                $raw = str_replace(',', '.', $raw);
+            }
+        } elseif ($hasDot && preg_match('/\.\d{3}$/', $raw)) {
+            $raw = str_replace('.', '', $raw);
+        }
+
+        return $raw;
+    }
+}

--- a/app/Helpers/TripDescriptionContributionHelper.php
+++ b/app/Helpers/TripDescriptionContributionHelper.php
@@ -2,6 +2,8 @@
 
 namespace STS\Helpers;
 
+use STS\Models\Trip;
+
 class TripDescriptionContributionHelper
 {
     /**
@@ -72,6 +74,17 @@ class TripDescriptionContributionHelper
         int $seatPriceCents
     ): bool {
         return self::potentialExcessContributionCents($description, $seatPriceCents) !== null;
+    }
+
+    public static function syncPotentialExcessContributionAttributes(Trip $trip): void
+    {
+        $potentialSeatPriceCents = self::potentialExcessContributionCents(
+            $trip->description ?? '',
+            (int) $trip->seat_price_cents
+        );
+
+        $trip->has_potential_excess_contribution = $potentialSeatPriceCents !== null;
+        $trip->description_potential_seat_price_cents = $potentialSeatPriceCents;
     }
 
     private static function parseNumericAmountToCents(

--- a/app/Http/Controllers/Api/Admin/TripExcessContributionController.php
+++ b/app/Http/Controllers/Api/Admin/TripExcessContributionController.php
@@ -20,7 +20,14 @@ class TripExcessContributionController extends Controller
     {
         $perPage = AdminPagination::resolvePerPage($request->query('per_page'));
         $page = AdminPagination::resolvePage($request->query('page'));
-        $paginator = $this->listService->paginate($perPage, $page);
+        $requiresActionOnly = $this->queryFlagIsTruthy($request->query('requires_action_only'));
+        $paginator = $this->listService->paginate(
+            $perPage,
+            $page,
+            $requiresActionOnly,
+            $request->query('sort'),
+            $request->query('direction'),
+        );
 
         return response()->json([
             'data' => $paginator->items(),
@@ -66,5 +73,18 @@ class TripExcessContributionController extends Controller
         return response()->json([
             'data' => $trip ? $this->listService->serializeDetail($trip) : null,
         ]);
+    }
+
+    private function queryFlagIsTruthy(mixed $value): bool
+    {
+        if ($value === true || $value === 1) {
+            return true;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
     }
 }

--- a/app/Http/Controllers/Api/Admin/TripExcessContributionController.php
+++ b/app/Http/Controllers/Api/Admin/TripExcessContributionController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Services\Admin\TripExcessContributionListService;
+use STS\Support\AdminPagination;
+
+class TripExcessContributionController extends Controller
+{
+    public function __construct(
+        private readonly TripExcessContributionListService $listService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = AdminPagination::resolvePerPage($request->query('per_page'));
+        $page = AdminPagination::resolvePage($request->query('page'));
+        $paginator = $this->listService->paginate($perPage, $page);
+
+        return response()->json([
+            'data' => $paginator->items(),
+            'meta' => [
+                'pagination' => AdminPagination::paginationMeta($paginator),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Admin/TripExcessContributionController.php
+++ b/app/Http/Controllers/Api/Admin/TripExcessContributionController.php
@@ -5,8 +5,10 @@ namespace STS\Http\Controllers\Api\Admin;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
+use STS\Models\Trip;
 use STS\Services\Admin\TripExcessContributionListService;
 use STS\Support\AdminPagination;
+use STS\Support\TripExcessContributionStatus;
 
 class TripExcessContributionController extends Controller
 {
@@ -25,6 +27,44 @@ class TripExcessContributionController extends Controller
             'meta' => [
                 'pagination' => AdminPagination::paginationMeta($paginator),
             ],
+        ]);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $trip = $this->listService->findForAdmin($id);
+
+        if ($trip === null) {
+            return response()->json(['error' => 'Trip not found.'], 404);
+        }
+
+        return response()->json([
+            'data' => $this->listService->serializeDetail($trip),
+        ]);
+    }
+
+    public function updateStatus(Request $request, int $id): JsonResponse
+    {
+        $validated = $request->validate([
+            'status' => TripExcessContributionStatus::validationRule(),
+        ]);
+
+        $trip = Trip::query()
+            ->where('has_potential_excess_contribution', true)
+            ->whereKey($id)
+            ->first();
+
+        if ($trip === null) {
+            return response()->json(['error' => 'Trip not found.'], 404);
+        }
+
+        $trip->exceso_contribucion_status = $validated['status'];
+        $trip->save();
+
+        $trip = $this->listService->findForAdmin($id);
+
+        return response()->json([
+            'data' => $trip ? $this->listService->serializeDetail($trip) : null,
         ]);
     }
 }

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -17,6 +17,7 @@ class SupportTicket extends Model
         'report',
         'account_verification',
         'account_recovery',
+        'excess_contribution',
     ];
 
     /** @var array<string, string> */
@@ -27,6 +28,7 @@ class SupportTicket extends Model
         'feedback' => 'low',
         'account_verification' => 'high',
         'account_recovery' => 'high',
+        'excess_contribution' => 'normal',
     ];
 
     public const STATUS_NEEDS_REVIEW = 'Necesita revisión';
@@ -221,6 +223,41 @@ class SupportTicket extends Model
             ->where('type', 'account_verification')
             ->open()
             ->createdByAdmin()
+            ->groupBy('user_id')
+            ->pluck('aggregate', 'user_id');
+
+        $result = [];
+        foreach ($ids as $id) {
+            $result[$id] = (int) ($rows[$id] ?? 0);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  list<int|string|null>  $userIds
+     * @return array<int, int>
+     */
+    public static function countsOpenExcessContributionByUserIds(array $userIds): array
+    {
+        $ids = [];
+        foreach ($userIds as $userId) {
+            $id = (int) $userId;
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        $ids = array_values($ids);
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $rows = static::query()
+            ->selectRaw('user_id, COUNT(*) as aggregate')
+            ->whereIn('user_id', $ids)
+            ->where('type', 'excess_contribution')
+            ->open()
             ->groupBy('user_id')
             ->pluck('aggregate', 'user_id');
 

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -104,6 +104,7 @@ class Trip extends Model
             'autoaccept_friends_requests',
             'has_potential_excess_contribution',
             'description_potential_seat_price_cents',
+            'exceso_contribucion_status',
         ];
     }
 
@@ -156,6 +157,7 @@ class Trip extends Model
             'recommended_trip_price_cents' => 'integer',
             'description_potential_seat_price_cents' => 'integer',
             'has_potential_excess_contribution' => 'boolean',
+            'exceso_contribucion_status' => 'string',
             'state' => 'string',
         ];
     }

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -102,6 +102,8 @@ class Trip extends Model
             'payment_id',
             'needs_sellado',
             'autoaccept_friends_requests',
+            'has_potential_excess_contribution',
+            'description_potential_seat_price_cents',
         ];
     }
 
@@ -152,6 +154,8 @@ class Trip extends Model
             'deleted_at' => 'datetime',
             'seat_price_cents' => 'integer',
             'recommended_trip_price_cents' => 'integer',
+            'description_potential_seat_price_cents' => 'integer',
+            'has_potential_excess_contribution' => 'boolean',
             'state' => 'string',
         ];
     }

--- a/app/Repository/TripRepository.php
+++ b/app/Repository/TripRepository.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DB;
 use Illuminate\Support\Facades\Http;
 use STS\Helpers\OngoingTripHelper;
+use STS\Helpers\TripDescriptionContributionHelper;
 use STS\Helpers\TripPriceHelper;
 use STS\Models\NodeGeo;
 use STS\Models\Passenger;
@@ -172,6 +173,8 @@ class TripRepository
 
         $this->generateTripFriendVisibility($trip);
 
+        $this->syncPotentialExcessContributionFlag($trip);
+
         // TODO: check if trip.needs_payment (temp flag), and if total_trips_created > 2, we need to pay
         // for this trip (origin and destination in paid cities),
         // if so, mark trip as awaiting_payment, create payment_id and return it to the frontend so it can redirect
@@ -288,8 +291,16 @@ class TripRepository
                 }
             }
 
+            $this->syncPotentialExcessContributionFlag($trip);
+
             return $trip;
         });
+    }
+
+    private function syncPotentialExcessContributionFlag(Trip $trip): void
+    {
+        TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
+        $trip->save();
     }
 
     public function generateTripPath($trip)

--- a/app/Services/Admin/TripExcessContributionListService.php
+++ b/app/Services/Admin/TripExcessContributionListService.php
@@ -3,43 +3,28 @@
 namespace STS\Services\Admin;
 
 use Illuminate\Pagination\LengthAwarePaginator;
-use STS\Helpers\TripDescriptionContributionHelper;
 use STS\Models\Trip;
 
 class TripExcessContributionListService
 {
     public function paginate(int $perPage, int $page): LengthAwarePaginator
     {
-        $candidates = Trip::query()
+        $paginator = Trip::query()
             ->with(['user:id,private_note'])
-            ->where('seat_price_cents', '>', 0)
-            ->whereNotNull('description')
-            ->where('description', '!=', '')
-            ->where(function ($query) {
-                $query->where('description', 'like', '%$%')
-                    ->orWhere('description', 'like', '%luca%');
-            })
+            ->where('has_potential_excess_contribution', true)
             ->orderByDesc('id')
-            ->get();
+            ->paginate($perPage, ['*'], 'page', $page);
 
-        $rows = $candidates
-            ->filter(function (Trip $trip) {
-                return TripDescriptionContributionHelper::hasPotentialExcessContribution(
-                    $trip->description ?? '',
-                    (int) $trip->seat_price_cents
-                );
-            })
+        $items = collect($paginator->items())
             ->map(fn (Trip $trip) => $this->serializeRow($trip))
-            ->values();
-
-        $total = $rows->count();
-        $items = $rows->slice(($page - 1) * $perPage, $perPage)->values();
+            ->values()
+            ->all();
 
         return new LengthAwarePaginator(
             $items,
-            $total,
-            $perPage,
-            $page,
+            $paginator->total(),
+            $paginator->perPage(),
+            $paginator->currentPage(),
             ['path' => request()->url()]
         );
     }
@@ -50,17 +35,13 @@ class TripExcessContributionListService
     private function serializeRow(Trip $trip): array
     {
         $seatPriceCents = (int) $trip->seat_price_cents;
-        $potentialSeatPriceCents = TripDescriptionContributionHelper::potentialExcessContributionCents(
-            $trip->description ?? '',
-            $seatPriceCents
-        );
 
         return [
             'id' => $trip->id,
             'from_town' => $trip->from_town,
             'to_town' => $trip->to_town,
             'seat_price_cents' => $seatPriceCents,
-            'potential_seat_price_cents' => $potentialSeatPriceCents,
+            'potential_seat_price_cents' => $trip->description_potential_seat_price_cents,
             'has_private_note' => trim((string) ($trip->user?->private_note ?? '')) !== '',
             'user_id' => $trip->user_id,
         ];

--- a/app/Services/Admin/TripExcessContributionListService.php
+++ b/app/Services/Admin/TripExcessContributionListService.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace STS\Services\Admin;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use STS\Helpers\TripDescriptionContributionHelper;
+use STS\Models\Trip;
+
+class TripExcessContributionListService
+{
+    public function paginate(int $perPage, int $page): LengthAwarePaginator
+    {
+        $candidates = Trip::query()
+            ->with(['user:id,private_note'])
+            ->where('seat_price_cents', '>', 0)
+            ->whereNotNull('description')
+            ->where('description', '!=', '')
+            ->where(function ($query) {
+                $query->where('description', 'like', '%$%')
+                    ->orWhere('description', 'like', '%luca%');
+            })
+            ->orderByDesc('id')
+            ->get();
+
+        $rows = $candidates
+            ->filter(function (Trip $trip) {
+                return TripDescriptionContributionHelper::hasPotentialExcessContribution(
+                    $trip->description ?? '',
+                    (int) $trip->seat_price_cents
+                );
+            })
+            ->map(fn (Trip $trip) => $this->serializeRow($trip))
+            ->values();
+
+        $total = $rows->count();
+        $items = $rows->slice(($page - 1) * $perPage, $perPage)->values();
+
+        return new LengthAwarePaginator(
+            $items,
+            $total,
+            $perPage,
+            $page,
+            ['path' => request()->url()]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRow(Trip $trip): array
+    {
+        $seatPriceCents = (int) $trip->seat_price_cents;
+        $potentialSeatPriceCents = TripDescriptionContributionHelper::potentialExcessContributionCents(
+            $trip->description ?? '',
+            $seatPriceCents
+        );
+
+        return [
+            'id' => $trip->id,
+            'from_town' => $trip->from_town,
+            'to_town' => $trip->to_town,
+            'seat_price_cents' => $seatPriceCents,
+            'potential_seat_price_cents' => $potentialSeatPriceCents,
+            'has_private_note' => trim((string) ($trip->user?->private_note ?? '')) !== '',
+            'user_id' => $trip->user_id,
+        ];
+    }
+}

--- a/app/Services/Admin/TripExcessContributionListService.php
+++ b/app/Services/Admin/TripExcessContributionListService.php
@@ -5,16 +5,28 @@ namespace STS\Services\Admin;
 use Illuminate\Pagination\LengthAwarePaginator;
 use STS\Models\SupportTicket;
 use STS\Models\Trip;
+use STS\Support\TripExcessContributionSort;
 
 class TripExcessContributionListService
 {
-    public function paginate(int $perPage, int $page): LengthAwarePaginator
-    {
-        $paginator = Trip::query()
+    public function paginate(
+        int $perPage,
+        int $page,
+        bool $requiresActionOnly = false,
+        ?string $sort = null,
+        ?string $direction = null,
+    ): LengthAwarePaginator {
+        $query = Trip::query()
             ->with(['user:id,name,private_note'])
-            ->where('has_potential_excess_contribution', true)
-            ->orderByDesc('id')
-            ->paginate($perPage, ['*'], 'page', $page);
+            ->where('has_potential_excess_contribution', true);
+
+        if ($requiresActionOnly) {
+            $query = TripExcessContributionSort::applyRequiresActionOnlyFilter($query);
+        }
+
+        $query = TripExcessContributionSort::apply($query, $sort, $direction);
+
+        $paginator = $query->paginate($perPage, ['*'], 'page', $page);
 
         $pageItems = collect($paginator->items());
         $ticketCounts = SupportTicket::countsOpenExcessContributionByUserIds(

--- a/app/Services/Admin/TripExcessContributionListService.php
+++ b/app/Services/Admin/TripExcessContributionListService.php
@@ -3,6 +3,7 @@
 namespace STS\Services\Admin;
 
 use Illuminate\Pagination\LengthAwarePaginator;
+use STS\Models\SupportTicket;
 use STS\Models\Trip;
 
 class TripExcessContributionListService
@@ -10,13 +11,21 @@ class TripExcessContributionListService
     public function paginate(int $perPage, int $page): LengthAwarePaginator
     {
         $paginator = Trip::query()
-            ->with(['user:id,private_note'])
+            ->with(['user:id,name,private_note'])
             ->where('has_potential_excess_contribution', true)
             ->orderByDesc('id')
             ->paginate($perPage, ['*'], 'page', $page);
 
-        $items = collect($paginator->items())
-            ->map(fn (Trip $trip) => $this->serializeRow($trip))
+        $pageItems = collect($paginator->items());
+        $ticketCounts = SupportTicket::countsOpenExcessContributionByUserIds(
+            $pageItems->pluck('user_id')->all()
+        );
+
+        $items = $pageItems
+            ->map(fn (Trip $trip) => $this->serializeRow(
+                $trip,
+                $ticketCounts[(int) $trip->user_id] ?? 0
+            ))
             ->values()
             ->all();
 
@@ -29,10 +38,33 @@ class TripExcessContributionListService
         );
     }
 
+    public function findForAdmin(int $tripId): ?Trip
+    {
+        return Trip::query()
+            ->with(['user:id,name,email,private_note'])
+            ->where('has_potential_excess_contribution', true)
+            ->whereKey($tripId)
+            ->first();
+    }
+
     /**
      * @return array<string, mixed>
      */
-    private function serializeRow(Trip $trip): array
+    public function serializeDetail(Trip $trip): array
+    {
+        $ticketCount = SupportTicket::countsOpenExcessContributionByUserIds([(int) $trip->user_id])[(int) $trip->user_id] ?? 0;
+
+        return array_merge($this->serializeRow($trip, $ticketCount), [
+            'description' => $trip->description,
+            'trip_date' => $trip->trip_date?->toDateTimeString(),
+            'user_email' => $trip->user?->email,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeRow(Trip $trip, int $excessContributionSupportTicketsCount = 0): array
     {
         $seatPriceCents = (int) $trip->seat_price_cents;
 
@@ -44,6 +76,9 @@ class TripExcessContributionListService
             'potential_seat_price_cents' => $trip->description_potential_seat_price_cents,
             'has_private_note' => trim((string) ($trip->user?->private_note ?? '')) !== '',
             'user_id' => $trip->user_id,
+            'user_name' => $trip->user?->name,
+            'exceso_contribucion_status' => $trip->exceso_contribucion_status,
+            'excess_contribution_support_tickets_count' => $excessContributionSupportTicketsCount,
         ];
     }
 }

--- a/app/Support/TripExcessContributionSort.php
+++ b/app/Support/TripExcessContributionSort.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace STS\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use STS\Models\SupportTicket;
+use STS\Models\Trip;
+
+class TripExcessContributionSort
+{
+    /** @var list<string> */
+    public const ALLOWED_SORTS = [
+        'id',
+        'user_name',
+        'from_town',
+        'to_town',
+        'seat_price_cents',
+        'potential_seat_price_cents',
+        'has_private_note',
+        'excess_contribution_support_tickets_count',
+        'exceso_contribucion_status',
+    ];
+
+    public static function resolveSort(?string $sort): ?string
+    {
+        return in_array($sort, self::ALLOWED_SORTS, true) ? $sort : null;
+    }
+
+    public static function resolveDirection(?string $direction): string
+    {
+        return strtolower((string) $direction) === 'asc' ? 'asc' : 'desc';
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     * @return Builder<Trip>
+     */
+    public static function applyRequiresActionOnlyFilter(Builder $query): Builder
+    {
+        return $query->where(function (Builder $statusQuery) {
+            $statusQuery
+                ->whereNull('exceso_contribucion_status')
+                ->orWhereIn(
+                    'exceso_contribucion_status',
+                    TripExcessContributionStatus::requiresAdminActionStatuses()
+                );
+        });
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     * @return Builder<Trip>
+     */
+    public static function apply(Builder $query, ?string $sort, ?string $direction): Builder
+    {
+        $resolvedSort = self::resolveSort($sort);
+        $resolvedDirection = self::resolveDirection($direction);
+
+        if ($resolvedSort === null) {
+            return self::applyDefaultOrder($query);
+        }
+
+        return self::applyExplicitOrder($query, $resolvedSort, $resolvedDirection);
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     * @return Builder<Trip>
+     */
+    private static function applyDefaultOrder(Builder $query): Builder
+    {
+        $table = 'trips';
+
+        return $query
+            ->orderByRaw(self::statusOrderExpression($table, 'asc'))
+            ->orderBy("{$table}.id", 'desc');
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     * @return Builder<Trip>
+     */
+    private static function applyExplicitOrder(Builder $query, string $sort, string $direction): Builder
+    {
+        $table = 'trips';
+
+        switch ($sort) {
+            case 'id':
+                $query->orderBy("{$table}.id", $direction);
+                break;
+            case 'user_name':
+                self::joinUsers($query);
+                $query
+                    ->orderByRaw('users.name IS NULL')
+                    ->orderBy('users.name', $direction);
+                break;
+            case 'from_town':
+                $query->orderBy("{$table}.from_town", $direction);
+                break;
+            case 'to_town':
+                $query->orderBy("{$table}.to_town", $direction);
+                break;
+            case 'seat_price_cents':
+                $query->orderBy("{$table}.seat_price_cents", $direction);
+                break;
+            case 'potential_seat_price_cents':
+                $query
+                    ->orderByRaw("{$table}.description_potential_seat_price_cents IS NULL")
+                    ->orderBy("{$table}.description_potential_seat_price_cents", $direction);
+                break;
+            case 'has_private_note':
+                self::joinUsers($query);
+                $query->orderByRaw(
+                    "(TRIM(COALESCE(users.private_note, '')) <> '') {$direction}"
+                );
+                break;
+            case 'excess_contribution_support_tickets_count':
+                self::joinExcessContributionSupportTicketCounts($query);
+                $query->orderByRaw(
+                    'COALESCE(excess_contribution_support_tickets_count, 0) '.$direction
+                );
+                break;
+            case 'exceso_contribucion_status':
+                $query->orderByRaw(self::statusOrderExpression($table, $direction));
+                break;
+        }
+
+        return $query->orderBy("{$table}.id", 'asc');
+    }
+
+    private static function statusOrderExpression(string $table, string $direction): string
+    {
+        $pendiente = TripExcessContributionStatus::PENDIENTE;
+        $enProceso = TripExcessContributionStatus::EN_PROCESO;
+        $resuelto = TripExcessContributionStatus::RESUELTO;
+        $descartado = TripExcessContributionStatus::DESCARTADO;
+
+        return "CASE
+            WHEN {$table}.exceso_contribucion_status IS NULL OR {$table}.exceso_contribucion_status = '' OR {$table}.exceso_contribucion_status = '{$pendiente}' THEN 0
+            WHEN {$table}.exceso_contribucion_status = '{$enProceso}' THEN 1
+            WHEN {$table}.exceso_contribucion_status = '{$resuelto}' THEN 2
+            WHEN {$table}.exceso_contribucion_status = '{$descartado}' THEN 3
+            ELSE 0
+        END {$direction}";
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     */
+    private static function joinExcessContributionSupportTicketCounts(Builder $query): void
+    {
+        if (self::queryHasExcessContributionSupportTicketCountsJoin($query)) {
+            return;
+        }
+
+        $subquery = SupportTicket::query()
+            ->selectRaw('user_id, COUNT(*) as excess_contribution_support_tickets_count')
+            ->where('type', 'excess_contribution')
+            ->open()
+            ->groupBy('user_id');
+
+        $query
+            ->leftJoinSub($subquery, 'excess_contribution_support_tickets', function ($join) {
+                $join->on(
+                    'excess_contribution_support_tickets.user_id',
+                    '=',
+                    'trips.user_id'
+                );
+            })
+            ->select('trips.*');
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     */
+    private static function queryHasExcessContributionSupportTicketCountsJoin(Builder $query): bool
+    {
+        $joins = $query->getQuery()->joins ?? [];
+
+        foreach ($joins as $join) {
+            if ($join->table === 'excess_contribution_support_tickets') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     */
+    private static function joinUsers(Builder $query): void
+    {
+        if (self::queryHasUsersJoin($query)) {
+            return;
+        }
+
+        $query
+            ->leftJoin('users', 'users.id', '=', 'trips.user_id')
+            ->select('trips.*');
+    }
+
+    /**
+     * @param  Builder<Trip>  $query
+     */
+    private static function queryHasUsersJoin(Builder $query): bool
+    {
+        $joins = $query->getQuery()->joins ?? [];
+
+        foreach ($joins as $join) {
+            if ($join->table === 'users') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Support/TripExcessContributionStatus.php
+++ b/app/Support/TripExcessContributionStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace STS\Support;
+
+class TripExcessContributionStatus
+{
+    public const PENDIENTE = 'pendiente';
+
+    public const RESUELTO = 'resuelto';
+
+    public const DESCARTADO = 'descartado';
+
+    public const EN_PROCESO = 'en_proceso';
+
+    /** @var list<string> */
+    public const ALL = [
+        self::PENDIENTE,
+        self::RESUELTO,
+        self::DESCARTADO,
+        self::EN_PROCESO,
+    ];
+
+    public static function validationRule(): string
+    {
+        return 'required|in:'.implode(',', self::ALL);
+    }
+}

--- a/app/Support/TripExcessContributionStatus.php
+++ b/app/Support/TripExcessContributionStatus.php
@@ -24,4 +24,22 @@ class TripExcessContributionStatus
     {
         return 'required|in:'.implode(',', self::ALL);
     }
+
+    /** @return list<string> */
+    public static function requiresAdminActionStatuses(): array
+    {
+        return [
+            self::PENDIENTE,
+            self::EN_PROCESO,
+        ];
+    }
+
+    public static function requiresAdminAction(?string $status): bool
+    {
+        if ($status === null || $status === '') {
+            return true;
+        }
+
+        return in_array($status, self::requiresAdminActionStatuses(), true);
+    }
 }

--- a/database/migrations/2026_08_13_140000_add_potential_excess_contribution_to_trips_table.php
+++ b/database/migrations/2026_08_13_140000_add_potential_excess_contribution_to_trips_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use STS\Helpers\TripDescriptionContributionHelper;
+use STS\Models\Trip;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->boolean('has_potential_excess_contribution')->default(false);
+            $table->unsignedInteger('description_potential_seat_price_cents')->nullable();
+        });
+
+        Trip::query()
+            ->where('seat_price_cents', '>', 0)
+            ->whereNotNull('description')
+            ->where('description', '!=', '')
+            ->where(function ($query) {
+                $query->where('description', 'like', '%$%')
+                    ->orWhere('description', 'like', '%luca%');
+            })
+            ->orderBy('id')
+            ->chunkById(200, function ($trips) {
+                foreach ($trips as $trip) {
+                    TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
+
+                    if ($trip->isDirty([
+                        'has_potential_excess_contribution',
+                        'description_potential_seat_price_cents',
+                    ])) {
+                        $trip->saveQuietly();
+                    }
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn([
+                'has_potential_excess_contribution',
+                'description_potential_seat_price_cents',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_08_13_150000_add_exceso_contribucion_status_to_trips_table.php
+++ b/database/migrations/2026_08_13_150000_add_exceso_contribucion_status_to_trips_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use STS\Support\TripExcessContributionStatus;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->string('exceso_contribucion_status', 32)->nullable();
+        });
+
+        DB::table('trips')
+            ->where('has_potential_excess_contribution', true)
+            ->whereNull('exceso_contribucion_status')
+            ->update(['exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn('exceso_contribucion_status');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use STS\Http\Controllers\Api\Admin\RatingController as AdminRatingController;
 use STS\Http\Controllers\Api\Admin\ReferencesController as AdminReferencesController;
 use STS\Http\Controllers\Api\Admin\SupportReplyTemplateController as AdminSupportReplyTemplateController;
 use STS\Http\Controllers\Api\Admin\SupportTicketController as AdminSupportTicketController;
+use STS\Http\Controllers\Api\Admin\TripExcessContributionController as AdminTripExcessContributionController;
 use STS\Http\Controllers\Api\Admin\UserController as AdminUserController;
 use STS\Http\Controllers\Api\Admin\UserMigrationController as AdminUserMigrationController;
 use STS\Http\Controllers\Api\v1\AuthController;
@@ -258,6 +259,7 @@ Route::middleware(['api'])->group(function () {
     // Admin routes
     Route::prefix('admin')->middleware('user.admin')->group(function () {
         Route::get('dashboard', [AdminDashboardController::class, 'show']);
+        Route::get('trip-excess-contributions', [AdminTripExcessContributionController::class, 'index']);
         Route::apiResource('badges', BadgeController::class);
         // Campaign routes
         Route::apiResource('campaigns', CampaignController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -260,6 +260,8 @@ Route::middleware(['api'])->group(function () {
     Route::prefix('admin')->middleware('user.admin')->group(function () {
         Route::get('dashboard', [AdminDashboardController::class, 'show']);
         Route::get('trip-excess-contributions', [AdminTripExcessContributionController::class, 'index']);
+        Route::get('trip-excess-contributions/{id}', [AdminTripExcessContributionController::class, 'show']);
+        Route::post('trip-excess-contributions/{id}/status', [AdminTripExcessContributionController::class, 'updateStatus']);
         Route::apiResource('badges', BadgeController::class);
         // Campaign routes
         Route::apiResource('campaigns', CampaignController::class);

--- a/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Http;
 
 use STS\Http\Middleware\UserAdmin;
+use STS\Models\SupportTicket;
 use STS\Models\Trip;
 use STS\Models\User;
+use STS\Support\TripExcessContributionStatus;
 use Tests\TestCase;
 
 class AdminTripExcessContributionControllerIntegrationTest extends TestCase
@@ -37,6 +39,18 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'description' => 'La contribución es de $24000 por persona',
             'has_potential_excess_contribution' => true,
             'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
+        ]);
+
+        SupportTicket::query()->create([
+            'user_id' => $driverWithNote->id,
+            'type' => 'excess_contribution',
+            'subject' => 'Exceso de contribución',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'unread_for_user' => 0,
+            'unread_for_admin' => 0,
+            'created_by' => $admin->id,
         ]);
 
         Trip::factory()->create([
@@ -68,6 +82,9 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'potential_seat_price_cents',
             'has_private_note',
             'user_id',
+            'user_name',
+            'exceso_contribucion_status',
+            'excess_contribution_support_tickets_count',
         ], array_keys($rows[0]));
 
         $row = $rows[0];
@@ -78,6 +95,77 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
         $this->assertSame(2400000, $row['potential_seat_price_cents']);
         $this->assertTrue($row['has_private_note']);
         $this->assertSame($driverWithNote->id, $row['user_id']);
+        $this->assertSame('Driver With Note', $row['user_name']);
+        $this->assertSame(TripExcessContributionStatus::PENDIENTE, $row['exceso_contribucion_status']);
+        $this->assertSame(1, $row['excess_contribution_support_tickets_count']);
+    }
+
+    public function test_show_returns_trip_and_creator_detail(): void
+    {
+        $admin = $this->admin();
+        $driver = User::factory()->create([
+            'name' => 'Creator Name',
+            'email' => 'creator@example.com',
+        ]);
+
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'from_town' => 'Córdoba',
+            'to_town' => 'Mendoza',
+            'seat_price_cents' => 1500000,
+            'description' => 'Pago $24000',
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::EN_PROCESO,
+        ]);
+
+        SupportTicket::query()->create([
+            'user_id' => $driver->id,
+            'type' => 'excess_contribution',
+            'subject' => 'Ticket exceso',
+            'status' => 'Open',
+            'priority' => 'normal',
+            'unread_for_user' => 0,
+            'unread_for_admin' => 0,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/trip-excess-contributions/'.$trip->id)->assertOk();
+        $data = $response->json('data');
+
+        $this->assertSame($trip->id, $data['id']);
+        $this->assertSame('Córdoba', $data['from_town']);
+        $this->assertSame('Mendoza', $data['to_town']);
+        $this->assertSame('Pago $24000', $data['description']);
+        $this->assertSame(TripExcessContributionStatus::EN_PROCESO, $data['exceso_contribucion_status']);
+        $this->assertSame($driver->id, $data['user_id']);
+        $this->assertSame('Creator Name', $data['user_name']);
+        $this->assertSame('creator@example.com', $data['user_email']);
+        $this->assertSame(1, $data['excess_contribution_support_tickets_count']);
+    }
+
+    public function test_update_status_changes_exceso_contribucion_status(): void
+    {
+        $admin = $this->admin();
+        $driver = User::factory()->create();
+        $trip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/trip-excess-contributions/'.$trip->id.'/status', [
+            'status' => TripExcessContributionStatus::RESUELTO,
+        ])->assertOk();
+
+        $trip->refresh();
+        $this->assertSame(TripExcessContributionStatus::RESUELTO, $trip->exceso_contribucion_status);
     }
 
     public function test_index_supports_pagination_meta(): void
@@ -92,6 +180,7 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
                 'description' => 'Pago $'.(2000 + $index).' por persona',
                 'has_potential_excess_contribution' => true,
                 'description_potential_seat_price_cents' => (2000 + $index) * 100,
+                'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
             ]);
         }
 

--- a/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
@@ -35,6 +35,8 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'to_town' => 'Rosario',
             'seat_price_cents' => 1500000,
             'description' => 'La contribución es de $24000 por persona',
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
         ]);
 
         Trip::factory()->create([
@@ -88,6 +90,8 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
                 'user_id' => $driver->id,
                 'seat_price_cents' => 100000,
                 'description' => 'Pago $'.(2000 + $index).' por persona',
+                'has_potential_excess_contribution' => true,
+                'description_potential_seat_price_cents' => (2000 + $index) * 100,
             ]);
         }
 

--- a/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
@@ -83,7 +83,7 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
         $admin = $this->admin();
         $driver = User::factory()->create();
 
-        foreach (range(1, 3) as $index) {
+        foreach (range(1, 11) as $index) {
             Trip::factory()->create([
                 'user_id' => $driver->id,
                 'seat_price_cents' => 100000,
@@ -94,14 +94,14 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
         $this->actingAs($admin, 'api');
         $this->withoutMiddleware(UserAdmin::class);
 
-        $response = $this->getJson('api/admin/trip-excess-contributions?per_page=2&page=1')
+        $response = $this->getJson('api/admin/trip-excess-contributions?per_page=10&page=1')
             ->assertOk();
 
-        $this->assertCount(2, $response->json('data'));
+        $this->assertCount(10, $response->json('data'));
         $this->assertSame([
             'current_page' => 1,
-            'per_page' => 2,
-            'total' => 3,
+            'per_page' => 10,
+            'total' => 11,
             'total_pages' => 2,
         ], $response->json('meta.pagination'));
     }

--- a/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
@@ -198,4 +198,68 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'total_pages' => 2,
         ], $response->json('meta.pagination'));
     }
+
+    public function test_index_requires_action_only_hides_resuelto_and_descartado(): void
+    {
+        $admin = $this->admin();
+        $driver = User::factory()->create();
+
+        $pendingTrip = Trip::factory()->create([
+            'user_id' => $driver->id,
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
+        ]);
+        Trip::factory()->create([
+            'user_id' => $driver->id,
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::RESUELTO,
+        ]);
+        Trip::factory()->create([
+            'user_id' => $driver->id,
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::DESCARTADO,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/trip-excess-contributions?requires_action_only=1')
+            ->assertOk();
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertSame([$pendingTrip->id], $ids);
+    }
+
+    public function test_index_sorts_by_user_name(): void
+    {
+        $admin = $this->admin();
+        $driverA = User::factory()->create(['name' => 'Alpha Driver']);
+        $driverB = User::factory()->create(['name' => 'Beta Driver']);
+
+        Trip::factory()->create([
+            'user_id' => $driverB->id,
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
+        ]);
+        Trip::factory()->create([
+            'user_id' => $driverA->id,
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+            'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson(
+            'api/admin/trip-excess-contributions?sort=user_name&direction=asc'
+        )->assertOk();
+
+        $names = collect($response->json('data'))->pluck('user_name')->all();
+        $this->assertSame(['Alpha Driver', 'Beta Driver'], $names);
+    }
 }

--- a/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\Trip;
+use STS\Models\User;
+use Tests\TestCase;
+
+class AdminTripExcessContributionControllerIntegrationTest extends TestCase
+{
+    private function admin(): User
+    {
+        $user = User::factory()->create();
+        $user->forceFill(['is_admin' => true])->saveQuietly();
+
+        return $user->fresh();
+    }
+
+    public function test_index_returns_trips_with_higher_description_contribution(): void
+    {
+        $admin = $this->admin();
+        $driverWithNote = User::factory()->create([
+            'name' => 'Driver With Note',
+            'private_note' => 'Revisar historial',
+        ]);
+        $driverWithoutNote = User::factory()->create([
+            'name' => 'Driver Without Note',
+            'private_note' => null,
+        ]);
+
+        $excessTrip = Trip::factory()->create([
+            'user_id' => $driverWithNote->id,
+            'from_town' => 'Buenos Aires',
+            'to_town' => 'Rosario',
+            'seat_price_cents' => 1500000,
+            'description' => 'La contribución es de $24000 por persona',
+        ]);
+
+        Trip::factory()->create([
+            'user_id' => $driverWithoutNote->id,
+            'seat_price_cents' => 1500000,
+            'description' => 'Contribución $15000',
+        ]);
+
+        Trip::factory()->create([
+            'user_id' => $driverWithoutNote->id,
+            'seat_price_cents' => 1500000,
+            'description' => 'Sin montos en la descripción',
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/trip-excess-contributions')->assertOk();
+        $this->assertArrayHasKey('data', $response->json());
+        $this->assertArrayHasKey('meta', $response->json());
+
+        $rows = $response->json('data');
+        $this->assertCount(1, $rows);
+        $this->assertSame([
+            'id',
+            'from_town',
+            'to_town',
+            'seat_price_cents',
+            'potential_seat_price_cents',
+            'has_private_note',
+            'user_id',
+        ], array_keys($rows[0]));
+
+        $row = $rows[0];
+        $this->assertSame($excessTrip->id, $row['id']);
+        $this->assertSame('Buenos Aires', $row['from_town']);
+        $this->assertSame('Rosario', $row['to_town']);
+        $this->assertSame(1500000, $row['seat_price_cents']);
+        $this->assertSame(2400000, $row['potential_seat_price_cents']);
+        $this->assertTrue($row['has_private_note']);
+        $this->assertSame($driverWithNote->id, $row['user_id']);
+    }
+
+    public function test_index_supports_pagination_meta(): void
+    {
+        $admin = $this->admin();
+        $driver = User::factory()->create();
+
+        foreach (range(1, 3) as $index) {
+            Trip::factory()->create([
+                'user_id' => $driver->id,
+                'seat_price_cents' => 100000,
+                'description' => 'Pago $'.(2000 + $index).' por persona',
+            ]);
+        }
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $response = $this->getJson('api/admin/trip-excess-contributions?per_page=2&page=1')
+            ->assertOk();
+
+        $this->assertCount(2, $response->json('data'));
+        $this->assertSame([
+            'current_page' => 1,
+            'per_page' => 2,
+            'total' => 3,
+            'total_pages' => 2,
+        ], $response->json('meta.pagination'));
+    }
+}

--- a/tests/Unit/Helpers/TripDescriptionContributionHelperSyncTest.php
+++ b/tests/Unit/Helpers/TripDescriptionContributionHelperSyncTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use STS\Helpers\TripDescriptionContributionHelper;
+use STS\Models\Trip;
+
+class TripDescriptionContributionHelperSyncTest extends TestCase
+{
+    public function test_sync_potential_excess_contribution_attributes_sets_flag_and_amount(): void
+    {
+        $trip = new Trip([
+            'seat_price_cents' => 1500000,
+            'description' => 'La contribución es de $24000 por persona',
+        ]);
+
+        TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
+
+        $this->assertTrue($trip->has_potential_excess_contribution);
+        $this->assertSame(2400000, $trip->description_potential_seat_price_cents);
+    }
+
+    public function test_sync_potential_excess_contribution_attributes_clears_flag_when_not_excess(): void
+    {
+        $trip = new Trip([
+            'seat_price_cents' => 1500000,
+            'description' => 'Contribución $15000',
+            'has_potential_excess_contribution' => true,
+            'description_potential_seat_price_cents' => 2400000,
+        ]);
+
+        TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
+
+        $this->assertFalse($trip->has_potential_excess_contribution);
+        $this->assertNull($trip->description_potential_seat_price_cents);
+    }
+}

--- a/tests/Unit/Helpers/TripDescriptionContributionHelperSyncTest.php
+++ b/tests/Unit/Helpers/TripDescriptionContributionHelperSyncTest.php
@@ -19,6 +19,7 @@ class TripDescriptionContributionHelperSyncTest extends TestCase
 
         $this->assertTrue($trip->has_potential_excess_contribution);
         $this->assertSame(2400000, $trip->description_potential_seat_price_cents);
+        $this->assertSame('pendiente', $trip->exceso_contribucion_status);
     }
 
     public function test_sync_potential_excess_contribution_attributes_clears_flag_when_not_excess(): void
@@ -34,5 +35,6 @@ class TripDescriptionContributionHelperSyncTest extends TestCase
 
         $this->assertFalse($trip->has_potential_excess_contribution);
         $this->assertNull($trip->description_potential_seat_price_cents);
+        $this->assertNull($trip->exceso_contribucion_status);
     }
 }

--- a/tests/Unit/Helpers/TripDescriptionContributionHelperTest.php
+++ b/tests/Unit/Helpers/TripDescriptionContributionHelperTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use STS\Helpers\TripDescriptionContributionHelper;
+
+class TripDescriptionContributionHelperTest extends TestCase
+{
+    public function test_potential_excess_detects_dollar_amount_above_seat_price(): void
+    {
+        $seatPriceCents = 1500000; // $15.000
+
+        $this->assertSame(
+            2400000,
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                'La contribución es de $24000 por persona',
+                $seatPriceCents
+            )
+        );
+    }
+
+    public function test_potential_excess_detects_k_suffix_amounts(): void
+    {
+        $seatPriceCents = 1500000;
+
+        $this->assertSame(
+            2400000,
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                'Pago $24K cada uno',
+                $seatPriceCents
+            )
+        );
+    }
+
+    public function test_potential_excess_detects_lucas_amounts(): void
+    {
+        $seatPriceCents = 1500000;
+
+        $this->assertSame(
+            2400000,
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                'Son 24 lucas por persona',
+                $seatPriceCents
+            )
+        );
+    }
+
+    public function test_potential_excess_returns_null_when_description_amount_is_not_higher(): void
+    {
+        $seatPriceCents = 1500000;
+
+        $this->assertNull(
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                'Contribución $15000',
+                $seatPriceCents
+            )
+        );
+        $this->assertNull(
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                'Solo 10 lucas',
+                $seatPriceCents
+            )
+        );
+    }
+
+    public function test_potential_excess_returns_null_for_voluntary_or_non_positive_seat_price(): void
+    {
+        $this->assertNull(
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                '$24000',
+                -1
+            )
+        );
+        $this->assertNull(
+            TripDescriptionContributionHelper::potentialExcessContributionCents(
+                '$24000',
+                0
+            )
+        );
+    }
+
+    public function test_has_potential_excess_contribution_reflects_potential_amount(): void
+    {
+        $this->assertTrue(
+            TripDescriptionContributionHelper::hasPotentialExcessContribution(
+                '$24000',
+                1500000
+            )
+        );
+        $this->assertFalse(
+            TripDescriptionContributionHelper::hasPotentialExcessContribution(
+                '$15000',
+                1500000
+            )
+        );
+    }
+}

--- a/tests/Unit/Models/SupportTicketTest.php
+++ b/tests/Unit/Models/SupportTicketTest.php
@@ -14,6 +14,7 @@ class SupportTicketTest extends TestCase
     public function test_type_default_priorities_assigns_high_to_account_recovery(): void
     {
         $this->assertSame('high', SupportTicket::TYPE_DEFAULT_PRIORITIES['account_recovery']);
+        $this->assertContains('excess_contribution', SupportTicket::TYPES);
     }
 
     public function test_statuses_include_needs_review(): void

--- a/tests/Unit/Models/TripTest.php
+++ b/tests/Unit/Models/TripTest.php
@@ -71,6 +71,7 @@ class TripTest extends TestCase
             'autoaccept_friends_requests',
             'has_potential_excess_contribution',
             'description_potential_seat_price_cents',
+            'exceso_contribucion_status',
         ];
 
         $this->assertSame($expected, (new Trip)->getFillable());
@@ -103,6 +104,7 @@ class TripTest extends TestCase
             'recommended_trip_price_cents' => 'integer',
             'description_potential_seat_price_cents' => 'integer',
             'has_potential_excess_contribution' => 'boolean',
+            'exceso_contribucion_status' => 'string',
             'state' => 'string',
         ];
 

--- a/tests/Unit/Models/TripTest.php
+++ b/tests/Unit/Models/TripTest.php
@@ -69,6 +69,8 @@ class TripTest extends TestCase
             'payment_id',
             'needs_sellado',
             'autoaccept_friends_requests',
+            'has_potential_excess_contribution',
+            'description_potential_seat_price_cents',
         ];
 
         $this->assertSame($expected, (new Trip)->getFillable());
@@ -99,6 +101,8 @@ class TripTest extends TestCase
             'deleted_at' => 'datetime',
             'seat_price_cents' => 'integer',
             'recommended_trip_price_cents' => 'integer',
+            'description_potential_seat_price_cents' => 'integer',
+            'has_potential_excess_contribution' => 'boolean',
             'state' => 'string',
         ];
 

--- a/tests/Unit/Repository/TripRepositoryTest.php
+++ b/tests/Unit/Repository/TripRepositoryTest.php
@@ -4429,4 +4429,58 @@ class TripRepositoryTest extends TestCase
         $this->assertTrue($all->contains($allowsSmoking->id));
         $this->assertTrue($all->contains($allowsKids->id));
     }
+
+    public function test_create_sets_potential_excess_contribution_flag_from_description(): void
+    {
+        Config::set('carpoolear.module_max_price_enabled', false);
+        Config::set('carpoolear.module_trip_creation_payment_enabled', false);
+
+        $repo = $this->makeTripRepoPartialForCreate(['status' => false], false);
+        $user = User::factory()->create();
+
+        $trip = $repo->create([
+            'user_id' => $user->id,
+            'is_passenger' => 0,
+            'from_town' => 'A',
+            'to_town' => 'B',
+            'trip_date' => Carbon::now()->addHour(),
+            'total_seats' => 1,
+            'friendship_type_id' => Trip::PRIVACY_PUBLIC,
+            'estimated_time' => '01:00',
+            'distance' => 10,
+            'co2' => 1,
+            'description' => 'La contribución es de $24000 por persona',
+            'mail_send' => false,
+            'seat_price_cents' => 1500000,
+            'points' => [
+                ['lat' => -34.6, 'lng' => -58.4, 'json_address' => ['id' => 9001, 'ciudad' => 'Origen']],
+            ],
+        ]);
+
+        $trip->refresh();
+        $this->assertTrue($trip->has_potential_excess_contribution);
+        $this->assertSame(2400000, (int) $trip->description_potential_seat_price_cents);
+    }
+
+    public function test_update_recomputes_potential_excess_contribution_flag(): void
+    {
+        Config::set('carpoolear.module_trip_creation_payment_enabled', false);
+        Config::set('carpoolear.module_max_price_enabled', false);
+
+        $trip = Trip::factory()->create([
+            'seat_price_cents' => 1500000,
+            'description' => 'La contribución es de $24000 por persona',
+            'has_potential_excess_contribution' => false,
+            'description_potential_seat_price_cents' => null,
+        ]);
+
+        $updated = $this->repo()->update($trip, [
+            'description' => 'Contribución $15000',
+            'seat_price_cents' => 1500000,
+        ]);
+
+        $updated->refresh();
+        $this->assertFalse($updated->has_potential_excess_contribution);
+        $this->assertNull($updated->description_potential_seat_price_cents);
+    }
 }

--- a/tests/Unit/Support/TripExcessContributionSortTest.php
+++ b/tests/Unit/Support/TripExcessContributionSortTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use STS\Support\TripExcessContributionSort;
+use Tests\TestCase;
+
+class TripExcessContributionSortTest extends TestCase
+{
+    public function test_resolve_sort_accepts_allowed_columns(): void
+    {
+        $this->assertSame('id', TripExcessContributionSort::resolveSort('id'));
+        $this->assertSame('user_name', TripExcessContributionSort::resolveSort('user_name'));
+        $this->assertSame(
+            'excess_contribution_support_tickets_count',
+            TripExcessContributionSort::resolveSort('excess_contribution_support_tickets_count')
+        );
+    }
+
+    public function test_resolve_sort_returns_null_for_invalid_columns(): void
+    {
+        $this->assertNull(TripExcessContributionSort::resolveSort('not_a_column'));
+        $this->assertNull(TripExcessContributionSort::resolveSort(null));
+    }
+
+    public function test_apply_requires_action_only_filters_terminal_statuses(): void
+    {
+        $query = TripExcessContributionSort::applyRequiresActionOnlyFilter(
+            \STS\Models\Trip::query()
+        );
+
+        $sql = strtolower($query->toSql());
+
+        $this->assertStringContainsString('exceso_contribucion_status', $sql);
+        $this->assertStringContainsString('is null', $sql);
+        $this->assertStringContainsString('in (?, ?)', $sql);
+    }
+
+    public function test_apply_orders_by_id_when_sort_is_id(): void
+    {
+        $query = TripExcessContributionSort::apply(
+            \STS\Models\Trip::query(),
+            'id',
+            'desc'
+        );
+
+        $this->assertInstanceOf(Builder::class, $query);
+        $this->assertStringContainsString('order by `trips`.`id` desc', strtolower($query->toSql()));
+    }
+}

--- a/tests/Unit/Support/TripExcessContributionStatusTest.php
+++ b/tests/Unit/Support/TripExcessContributionStatusTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use STS\Support\TripExcessContributionStatus;
+use Tests\TestCase;
+
+class TripExcessContributionStatusTest extends TestCase
+{
+    public function test_all_statuses_include_expected_values(): void
+    {
+        $this->assertSame([
+            'pendiente',
+            'resuelto',
+            'descartado',
+            'en_proceso',
+        ], TripExcessContributionStatus::ALL);
+    }
+}


### PR DESCRIPTION
## Summary
- Detect trips whose description mentions a higher per-seat contribution than `seat_price_cents`, persist flag, parsed amount, and workflow status on create/update.
- Add admin API to list, inspect, and update excess-contribution cases (`pendiente`, `en_proceso`, `resuelto`, `descartado`), with pagination, backend sorting, and a `requires_action_only` filter.
- Register `excess_contribution` support ticket type and expose open ticket counts per driver on the admin list.

## Test plan
- [x] Create/update a trip with description like `$24000 por persona` and a lower seat price; confirm flag and potential amount are stored.
- [x] `GET /api/admin/trip-excess-contributions` returns paginated rows with user, towns, contributions, notes flag, ticket count, and status.
- [x] `requires_action_only=1` hides `resuelto` and `descartado` trips.
- [x] Sort params (`sort`, `direction`) order results on the server for id, user name, towns, amounts, notes, tickets, and status.
- [x] `POST /api/admin/trip-excess-contributions/{id}/status` updates status and detail endpoint reflects the change.
- [x] Run `php artisan test` on the branch.