### PR TITLE
fix: use STS\Helpers namespace for DocumentIdHelper autoloading

### DIFF
--- a/app/Helpers/DocumentIdHelper.php
+++ b/app/Helpers/DocumentIdHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Helpers;
+namespace STS\Helpers;
 
 class DocumentIdHelper
 {

--- a/app/Http/Controllers/Api/Admin/UserController.php
+++ b/app/Http/Controllers/Api/Admin/UserController.php
@@ -2,10 +2,10 @@
 
 namespace STS\Http\Controllers\Api\Admin;
 
-use App\Helpers\DocumentIdHelper;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
+use STS\Helpers\DocumentIdHelper;
 use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
 use STS\Models\AdminActionLog;

--- a/app/Services/Logic/UsersManager.php
+++ b/app/Services/Logic/UsersManager.php
@@ -2,13 +2,13 @@
 
 namespace STS\Services\Logic;
 
-use App\Helpers\DocumentIdHelper;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use STS\Events\User\Create as CreateEvent;
 use STS\Events\User\Update as UpdateEvent;
+use STS\Helpers\DocumentIdHelper;
 use STS\Models\BannedUser;
 use STS\Models\Car;
 use STS\Models\Passenger;

--- a/tests/Unit/Helpers/DocumentIdHelperTest.php
+++ b/tests/Unit/Helpers/DocumentIdHelperTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
-use App\Helpers\DocumentIdHelper;
+use STS\Helpers\DocumentIdHelper;
 use Tests\TestCase;
 
 class DocumentIdHelperTest extends TestCase


### PR DESCRIPTION
## Summary
- Fixes production `Class "App\Helpers\DocumentIdHelper" not found` error when updating users via admin API
- Moves `DocumentIdHelper` from `App\Helpers` to `STS\Helpers`, matching the project's Composer PSR-4 autoload mapping and other helpers in `app/Helpers/`
- Updates imports in `UsersManager`, admin `UserController`, and unit tests

## Test plan
- [x] `php artisan test tests/Unit/Helpers/DocumentIdHelperTest.php` (6 tests passing)
- [ ] Deploy and verify admin user update with document number works in production