### PR TITLE
Add average contribution and excess percentage to excess contribution admin

### DIFF
--- a/app/Helpers/TripDescriptionContributionHelper.php
+++ b/app/Helpers/TripDescriptionContributionHelper.php
@@ -77,6 +77,35 @@ class TripDescriptionContributionHelper
         return self::potentialExcessContributionCents($description, $seatPriceCents) !== null;
     }
 
+    public static function averageContributionCents(Trip $trip): ?int
+    {
+        if (! $trip->recommended_trip_price_cents) {
+            return null;
+        }
+
+        return TripPriceHelper::seatPriceCentsFromTripPriceCents(
+            (int) $trip->recommended_trip_price_cents,
+            $trip->rear_max_two_passengers
+        );
+    }
+
+    public static function excessContributionPercentage(
+        ?int $askedSeatPriceCents,
+        ?int $averageContributionCents
+    ): ?int {
+        if (
+            $askedSeatPriceCents === null
+            || $averageContributionCents === null
+            || $averageContributionCents <= 0
+        ) {
+            return null;
+        }
+
+        return (int) round(
+            ($askedSeatPriceCents - $averageContributionCents) / $averageContributionCents * 100
+        );
+    }
+
     public static function syncPotentialExcessContributionAttributes(Trip $trip): void
     {
         $potentialSeatPriceCents = self::potentialExcessContributionCents(
@@ -86,6 +115,11 @@ class TripDescriptionContributionHelper
 
         $trip->has_potential_excess_contribution = $potentialSeatPriceCents !== null;
         $trip->description_potential_seat_price_cents = $potentialSeatPriceCents;
+        $trip->average_contribution_cents = self::averageContributionCents($trip);
+        $trip->excess_contribution_percentage = self::excessContributionPercentage(
+            $potentialSeatPriceCents,
+            $trip->average_contribution_cents
+        );
 
         if ($potentialSeatPriceCents !== null) {
             if ($trip->exceso_contribucion_status === null) {
@@ -93,6 +127,8 @@ class TripDescriptionContributionHelper
             }
         } else {
             $trip->exceso_contribucion_status = null;
+            $trip->average_contribution_cents = null;
+            $trip->excess_contribution_percentage = null;
         }
     }
 

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -104,6 +104,8 @@ class Trip extends Model
             'autoaccept_friends_requests',
             'has_potential_excess_contribution',
             'description_potential_seat_price_cents',
+            'average_contribution_cents',
+            'excess_contribution_percentage',
             'exceso_contribucion_status',
         ];
     }
@@ -156,6 +158,8 @@ class Trip extends Model
             'seat_price_cents' => 'integer',
             'recommended_trip_price_cents' => 'integer',
             'description_potential_seat_price_cents' => 'integer',
+            'average_contribution_cents' => 'integer',
+            'excess_contribution_percentage' => 'integer',
             'has_potential_excess_contribution' => 'boolean',
             'exceso_contribucion_status' => 'string',
             'state' => 'string',

--- a/app/Services/Admin/TripExcessContributionListService.php
+++ b/app/Services/Admin/TripExcessContributionListService.php
@@ -86,6 +86,8 @@ class TripExcessContributionListService
             'to_town' => $trip->to_town,
             'seat_price_cents' => $seatPriceCents,
             'potential_seat_price_cents' => $trip->description_potential_seat_price_cents,
+            'average_contribution_cents' => $trip->average_contribution_cents,
+            'excess_contribution_percentage' => $trip->excess_contribution_percentage,
             'has_private_note' => trim((string) ($trip->user?->private_note ?? '')) !== '',
             'user_id' => $trip->user_id,
             'user_name' => $trip->user?->name,

--- a/app/Support/TripExcessContributionSort.php
+++ b/app/Support/TripExcessContributionSort.php
@@ -16,6 +16,8 @@ class TripExcessContributionSort
         'to_town',
         'seat_price_cents',
         'potential_seat_price_cents',
+        'average_contribution_cents',
+        'excess_contribution_percentage',
         'has_private_note',
         'excess_contribution_support_tickets_count',
         'exceso_contribucion_status',
@@ -107,6 +109,16 @@ class TripExcessContributionSort
                 $query
                     ->orderByRaw("{$table}.description_potential_seat_price_cents IS NULL")
                     ->orderBy("{$table}.description_potential_seat_price_cents", $direction);
+                break;
+            case 'average_contribution_cents':
+                $query
+                    ->orderByRaw("{$table}.average_contribution_cents IS NULL")
+                    ->orderBy("{$table}.average_contribution_cents", $direction);
+                break;
+            case 'excess_contribution_percentage':
+                $query
+                    ->orderByRaw("{$table}.excess_contribution_percentage IS NULL")
+                    ->orderBy("{$table}.excess_contribution_percentage", $direction);
                 break;
             case 'has_private_note':
                 self::joinUsers($query);

--- a/database/migrations/2026_08_20_180000_add_average_contribution_fields_to_trips_table.php
+++ b/database/migrations/2026_08_20_180000_add_average_contribution_fields_to_trips_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use STS\Helpers\TripDescriptionContributionHelper;
+use STS\Models\Trip;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->unsignedInteger('average_contribution_cents')->nullable();
+            $table->unsignedSmallInteger('excess_contribution_percentage')->nullable();
+        });
+
+        Trip::query()
+            ->where('has_potential_excess_contribution', true)
+            ->orderBy('id')
+            ->chunkById(200, function ($trips) {
+                foreach ($trips as $trip) {
+                    TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
+
+                    if ($trip->isDirty([
+                        'average_contribution_cents',
+                        'excess_contribution_percentage',
+                    ])) {
+                        $trip->saveQuietly();
+                    }
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn([
+                'average_contribution_cents',
+                'excess_contribution_percentage',
+            ]);
+        });
+    }
+};

--- a/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminTripExcessContributionControllerIntegrationTest.php
@@ -37,8 +37,12 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'to_town' => 'Rosario',
             'seat_price_cents' => 1500000,
             'description' => 'La contribución es de $24000 por persona',
+            'recommended_trip_price_cents' => 5000000,
+            'rear_max_two_passengers' => false,
             'has_potential_excess_contribution' => true,
             'description_potential_seat_price_cents' => 2400000,
+            'average_contribution_cents' => 1000000,
+            'excess_contribution_percentage' => 140,
             'exceso_contribucion_status' => TripExcessContributionStatus::PENDIENTE,
         ]);
 
@@ -80,6 +84,8 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'to_town',
             'seat_price_cents',
             'potential_seat_price_cents',
+            'average_contribution_cents',
+            'excess_contribution_percentage',
             'has_private_note',
             'user_id',
             'user_name',
@@ -93,6 +99,8 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
         $this->assertSame('Rosario', $row['to_town']);
         $this->assertSame(1500000, $row['seat_price_cents']);
         $this->assertSame(2400000, $row['potential_seat_price_cents']);
+        $this->assertSame(1000000, $row['average_contribution_cents']);
+        $this->assertSame(140, $row['excess_contribution_percentage']);
         $this->assertTrue($row['has_private_note']);
         $this->assertSame($driverWithNote->id, $row['user_id']);
         $this->assertSame('Driver With Note', $row['user_name']);
@@ -114,8 +122,12 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
             'to_town' => 'Mendoza',
             'seat_price_cents' => 1500000,
             'description' => 'Pago $24000',
+            'recommended_trip_price_cents' => 5000000,
+            'rear_max_two_passengers' => false,
             'has_potential_excess_contribution' => true,
             'description_potential_seat_price_cents' => 2400000,
+            'average_contribution_cents' => 1000000,
+            'excess_contribution_percentage' => 140,
             'exceso_contribucion_status' => TripExcessContributionStatus::EN_PROCESO,
         ]);
 
@@ -139,6 +151,8 @@ class AdminTripExcessContributionControllerIntegrationTest extends TestCase
         $this->assertSame('Córdoba', $data['from_town']);
         $this->assertSame('Mendoza', $data['to_town']);
         $this->assertSame('Pago $24000', $data['description']);
+        $this->assertSame(1000000, $data['average_contribution_cents']);
+        $this->assertSame(140, $data['excess_contribution_percentage']);
         $this->assertSame(TripExcessContributionStatus::EN_PROCESO, $data['exceso_contribucion_status']);
         $this->assertSame($driver->id, $data['user_id']);
         $this->assertSame('Creator Name', $data['user_name']);

--- a/tests/Unit/Helpers/TripDescriptionContributionHelperSyncTest.php
+++ b/tests/Unit/Helpers/TripDescriptionContributionHelperSyncTest.php
@@ -13,6 +13,8 @@ class TripDescriptionContributionHelperSyncTest extends TestCase
         $trip = new Trip([
             'seat_price_cents' => 1500000,
             'description' => 'La contribución es de $24000 por persona',
+            'recommended_trip_price_cents' => 5000000,
+            'rear_max_two_passengers' => false,
         ]);
 
         TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
@@ -20,6 +22,8 @@ class TripDescriptionContributionHelperSyncTest extends TestCase
         $this->assertTrue($trip->has_potential_excess_contribution);
         $this->assertSame(2400000, $trip->description_potential_seat_price_cents);
         $this->assertSame('pendiente', $trip->exceso_contribucion_status);
+        $this->assertSame(1000000, $trip->average_contribution_cents);
+        $this->assertSame(140, $trip->excess_contribution_percentage);
     }
 
     public function test_sync_potential_excess_contribution_attributes_clears_flag_when_not_excess(): void
@@ -36,5 +40,21 @@ class TripDescriptionContributionHelperSyncTest extends TestCase
         $this->assertFalse($trip->has_potential_excess_contribution);
         $this->assertNull($trip->description_potential_seat_price_cents);
         $this->assertNull($trip->exceso_contribucion_status);
+        $this->assertNull($trip->average_contribution_cents);
+        $this->assertNull($trip->excess_contribution_percentage);
+    }
+
+    public function test_sync_potential_excess_contribution_attributes_leaves_percentage_null_without_average(): void
+    {
+        $trip = new Trip([
+            'seat_price_cents' => 1500000,
+            'description' => 'La contribución es de $24000 por persona',
+        ]);
+
+        TripDescriptionContributionHelper::syncPotentialExcessContributionAttributes($trip);
+
+        $this->assertTrue($trip->has_potential_excess_contribution);
+        $this->assertNull($trip->average_contribution_cents);
+        $this->assertNull($trip->excess_contribution_percentage);
     }
 }

--- a/tests/Unit/Helpers/TripDescriptionContributionHelperTest.php
+++ b/tests/Unit/Helpers/TripDescriptionContributionHelperTest.php
@@ -95,4 +95,62 @@ class TripDescriptionContributionHelperTest extends TestCase
             )
         );
     }
+
+    public function test_average_contribution_cents_uses_recommended_trip_price_per_seat(): void
+    {
+        $trip = new \STS\Models\Trip([
+            'recommended_trip_price_cents' => 5000000,
+            'rear_max_two_passengers' => false,
+        ]);
+
+        $this->assertSame(
+            1000000,
+            TripDescriptionContributionHelper::averageContributionCents($trip)
+        );
+    }
+
+    public function test_average_contribution_cents_returns_null_without_recommended_price(): void
+    {
+        $trip = new \STS\Models\Trip([
+            'recommended_trip_price_cents' => null,
+        ]);
+
+        $this->assertNull(
+            TripDescriptionContributionHelper::averageContributionCents($trip)
+        );
+    }
+
+    public function test_excess_contribution_percentage_measures_asked_amount_over_average(): void
+    {
+        $this->assertSame(
+            100,
+            TripDescriptionContributionHelper::excessContributionPercentage(
+                2000000,
+                1000000
+            )
+        );
+        $this->assertSame(
+            140,
+            TripDescriptionContributionHelper::excessContributionPercentage(
+                2400000,
+                1000000
+            )
+        );
+    }
+
+    public function test_excess_contribution_percentage_returns_null_without_valid_average(): void
+    {
+        $this->assertNull(
+            TripDescriptionContributionHelper::excessContributionPercentage(
+                2000000,
+                null
+            )
+        );
+        $this->assertNull(
+            TripDescriptionContributionHelper::excessContributionPercentage(
+                2000000,
+                0
+            )
+        );
+    }
 }

--- a/tests/Unit/Models/TripTest.php
+++ b/tests/Unit/Models/TripTest.php
@@ -71,6 +71,8 @@ class TripTest extends TestCase
             'autoaccept_friends_requests',
             'has_potential_excess_contribution',
             'description_potential_seat_price_cents',
+            'average_contribution_cents',
+            'excess_contribution_percentage',
             'exceso_contribucion_status',
         ];
 
@@ -103,6 +105,8 @@ class TripTest extends TestCase
             'seat_price_cents' => 'integer',
             'recommended_trip_price_cents' => 'integer',
             'description_potential_seat_price_cents' => 'integer',
+            'average_contribution_cents' => 'integer',
+            'excess_contribution_percentage' => 'integer',
             'has_potential_excess_contribution' => 'boolean',
             'exceso_contribucion_status' => 'string',
             'state' => 'string',


### PR DESCRIPTION
## Summary
- Persist `average_contribution_cents` and `excess_contribution_percentage` on trips when syncing potential excess contribution attributes.
- Average contribution is derived from `recommended_trip_price_cents` (same per-seat calculation used in trip creation/detail).
- Excess percentage is computed as `(asked - average) / average * 100`, where asked is the description potential seat price.
- Expose both fields in the admin excess contribution list/detail API and allow sorting by them.
- Backfill existing flagged trips via migration.

## Test plan
- [x] `php artisan test` (3509 passed)
- [ ] Verify admin list/detail show stored values for new trips with recommended price
- [ ] Verify old trips without stored values return null (frontend shows N/D)

Companion frontend PR: STS-Rosario/carpoolear