### PR TITLE
Mercado Pago platform donations with webhooks and admin tools

### DIFF
--- a/app/Console/Commands/ReconcilePlatformDonations.php
+++ b/app/Console/Commands/ReconcilePlatformDonations.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use STS\Models\DonationPayment;
+use STS\Models\DonationSubscriptionCharge;
+use STS\Services\MercadoPagoService;
+use STS\Services\PlatformDonationService;
+
+class ReconcilePlatformDonations extends Command
+{
+    protected $signature = 'donations:reconcile {--days=2}';
+
+    protected $description = 'Reconcile recent Mercado Pago platform donation payments';
+
+    public function handle(MercadoPagoService $mercadoPagoService, PlatformDonationService $platformDonationService): int
+    {
+        $since = Carbon::now()->subDays((int) $this->option('days'));
+
+        $pendingPayments = DonationPayment::query()
+            ->where('status', 'pending')
+            ->where('created_at', '>=', $since)
+            ->whereNotNull('mp_preference_id')
+            ->get();
+
+        $reconciled = 0;
+        foreach ($pendingPayments as $payment) {
+            if (empty($payment->mp_payment_id)) {
+                continue;
+            }
+
+            $mpPayment = $mercadoPagoService->getPayment($payment->mp_payment_id);
+            if ($mpPayment) {
+                $platformDonationService->handlePlatformPayment($mpPayment);
+                $reconciled++;
+            }
+        }
+
+        $pendingCharges = DonationSubscriptionCharge::query()
+            ->where('status', 'pending')
+            ->where('created_at', '>=', $since)
+            ->get();
+
+        foreach ($pendingCharges as $charge) {
+            $mpPayment = $mercadoPagoService->getPayment($charge->mp_payment_id);
+            if ($mpPayment) {
+                $platformDonationService->handleSubscriptionAuthorizedPayment($mpPayment);
+                $reconciled++;
+            }
+        }
+
+        $this->info("Reconciled {$reconciled} platform donation record(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/SyncDonationSubscriptionAmounts.php
+++ b/app/Console/Commands/SyncDonationSubscriptionAmounts.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use STS\Models\DonationAmountAdjustment;
+use STS\Services\PlatformDonationService;
+
+class SyncDonationSubscriptionAmounts extends Command
+{
+    protected $signature = 'donations:sync-subscription-amounts {--adjustment-id=}';
+
+    protected $description = 'Retry syncing donation subscription amounts after inflation updates';
+
+    public function handle(PlatformDonationService $platformDonationService): int
+    {
+        $adjustmentId = $this->option('adjustment-id');
+
+        $query = DonationAmountAdjustment::query()
+            ->whereNull('applied_at')
+            ->orWhere('subscriptions_failed', '>', 0);
+
+        if ($adjustmentId) {
+            $query = DonationAmountAdjustment::query()->where('id', $adjustmentId);
+        }
+
+        $count = 0;
+        foreach ($query->get() as $adjustment) {
+            $platformDonationService->syncSubscriptionAmountsForAdjustment($adjustment);
+            $count++;
+        }
+
+        $this->info("Processed {$count} donation amount adjustment(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/DonationPaymentController.php
+++ b/app/Http/Controllers/Api/Admin/DonationPaymentController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\DonationPayment;
+
+class DonationPaymentController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = DonationPayment::query()->with(['user', 'tier'])->latest();
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->string('status'));
+        }
+
+        if ($request->filled('user_id')) {
+            $query->where('user_id', $request->integer('user_id'));
+        }
+
+        return response()->json($query->paginate($request->integer('per_page', 25)));
+    }
+}

--- a/app/Http/Controllers/Api/Admin/DonationSubscriptionController.php
+++ b/app/Http/Controllers/Api/Admin/DonationSubscriptionController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\DonationSubscription;
+
+class DonationSubscriptionController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = DonationSubscription::query()->with(['user', 'tier'])->latest();
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->string('status'));
+        }
+
+        if ($request->filled('user_id')) {
+            $query->where('user_id', $request->integer('user_id'));
+        }
+
+        return response()->json($query->paginate($request->integer('per_page', 25)));
+    }
+}

--- a/app/Http/Controllers/Api/Admin/DonationSummaryController.php
+++ b/app/Http/Controllers/Api/Admin/DonationSummaryController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use STS\Http\Controllers\Controller;
+use STS\Services\PlatformDonationService;
+
+class DonationSummaryController extends Controller
+{
+    public function __construct(private PlatformDonationService $platformDonationService) {}
+
+    public function show(): JsonResponse
+    {
+        return response()->json($this->platformDonationService->summary());
+    }
+}

--- a/app/Http/Controllers/Api/Admin/DonationTierController.php
+++ b/app/Http/Controllers/Api/Admin/DonationTierController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace STS\Http\Controllers\Api\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\DonationTier;
+use STS\Services\PlatformDonationService;
+
+class DonationTierController extends Controller
+{
+    public function __construct(private PlatformDonationService $platformDonationService) {}
+
+    public function index(): JsonResponse
+    {
+        $tiers = DonationTier::query()->orderBy('sort_order')->get()
+            ->map(fn (DonationTier $tier) => $this->platformDonationService->formatTier($tier));
+
+        return response()->json($tiers);
+    }
+
+    public function update(Request $request, DonationTier $donationTier): JsonResponse
+    {
+        $validated = $request->validate([
+            'amount_cents' => 'sometimes|integer|min:100',
+            'is_active' => 'sometimes|boolean',
+            'sort_order' => 'sometimes|integer|min:0',
+            'icon' => 'sometimes|string|max:64',
+            'label_key' => 'sometimes|string|max:128',
+        ]);
+
+        $donationTier->update($validated);
+
+        return response()->json($this->platformDonationService->formatTier($donationTier->fresh()));
+    }
+
+    public function applyInflation(Request $request, DonationTier $donationTier): JsonResponse
+    {
+        $validated = $request->validate([
+            'new_amount_cents' => 'required|integer|min:100',
+        ]);
+
+        $adjustment = $this->platformDonationService->applyInflation(
+            $donationTier,
+            $validated['new_amount_cents'],
+            $request->user()->id
+        );
+
+        return response()->json($adjustment->load('tier'), 202);
+    }
+}

--- a/app/Http/Controllers/Api/v1/DonationTierController.php
+++ b/app/Http/Controllers/Api/v1/DonationTierController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\JsonResponse;
+use STS\Http\Controllers\Controller;
+use STS\Services\PlatformDonationService;
+
+class DonationTierController extends Controller
+{
+    public function __construct(private PlatformDonationService $platformDonationService) {}
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->platformDonationService->listActiveTiers());
+    }
+}

--- a/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
@@ -16,6 +16,8 @@ use STS\Models\Trip;
 use STS\Services\FriendTripAlertService;
 use STS\Services\Logic\ConversationsManager;
 use STS\Services\Logic\TripsManager;
+use STS\Services\MercadoPagoService;
+use STS\Services\PlatformDonationService;
 
 class MercadoPagoWebhookController extends Controller
 {
@@ -25,10 +27,20 @@ class MercadoPagoWebhookController extends Controller
 
     protected $paymentClient;
 
-    public function __construct(TripsManager $tripLogic, ConversationsManager $conversationManager)
-    {
+    protected $mercadoPagoService;
+
+    protected $platformDonationService;
+
+    public function __construct(
+        TripsManager $tripLogic,
+        ConversationsManager $conversationManager,
+        MercadoPagoService $mercadoPagoService,
+        PlatformDonationService $platformDonationService
+    ) {
         $this->tripLogic = $tripLogic;
         $this->conversationManager = $conversationManager;
+        $this->mercadoPagoService = $mercadoPagoService;
+        $this->platformDonationService = $platformDonationService;
 
         // Initialize Mercado Pago SDK
         MercadoPagoConfig::setAccessToken(config('services.mercadopago.access_token'));
@@ -67,8 +79,38 @@ class MercadoPagoWebhookController extends Controller
             }
         }
 
-        // Only process payment.created (Payments API / Checkout Pro)
-        if ($request->input('action') !== 'payment.created') {
+        $webhookType = $request->query('type') ?? $request->input('type');
+        $action = $request->input('action');
+
+        if ($webhookType === 'subscription_preapproval' || $action === 'subscription_preapproval') {
+            try {
+                return $this->handleSubscriptionPreapprovalWebhook($request);
+            } catch (\Throwable $e) {
+                Log::error('MercadoPago subscription_preapproval webhook failed', [
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+
+                return response()->json(['error' => 'Internal error'], 500);
+            }
+        }
+
+        if ($webhookType === 'subscription_authorized_payment' || $action === 'subscription_authorized_payment') {
+            try {
+                return $this->handleSubscriptionAuthorizedPaymentWebhook($request);
+            } catch (\Throwable $e) {
+                Log::error('MercadoPago subscription_authorized_payment webhook failed', [
+                    'message' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
+
+                return response()->json(['error' => 'Internal error'], 500);
+            }
+        }
+
+        if (! in_array($action, ['payment.created', 'payment.updated'], true)) {
             return response()->json(['status' => 'success']);
         }
 
@@ -108,9 +150,19 @@ class MercadoPagoWebhookController extends Controller
         }
 
         if (stripos($decodedReference, 'sellado') !== false) {
+            if ($action !== 'payment.created') {
+                return response()->json(['status' => 'success']);
+            }
+
             return $this->handleTripPayment($mpPayment);
         } elseif (stripos($decodedReference, 'campaña') !== false) {
+            if ($action !== 'payment.created') {
+                return response()->json(['status' => 'success']);
+            }
+
             return $this->handleCampaignDonation($mpPayment);
+        } elseif (stripos($decodedReference, 'plataforma') !== false) {
+            return $this->handlePlatformDonationPayment($mpPayment);
         }
 
         Log::error('Unknown payment type in external reference', ['external_reference' => $externalReference, 'decoded_reference' => $decodedReference]);
@@ -309,6 +361,7 @@ class MercadoPagoWebhookController extends Controller
                 'id' => $payment->id,
                 'status' => $payment->status,
                 'status_detail' => $payment->status_detail,
+                'transaction_amount' => $payment->transaction_amount,
                 'amount' => $payment->transaction_amount,
                 'currency_id' => $payment->currency_id,
                 'payment_method_id' => $payment->payment_method_id,
@@ -724,5 +777,67 @@ class MercadoPagoWebhookController extends Controller
         ];
 
         return $statusMap[$mpStatus] ?? 'pending';
+    }
+
+    protected function handlePlatformDonationPayment(array $mpPayment)
+    {
+        try {
+            $this->platformDonationService->handlePlatformPayment($mpPayment);
+        } catch (\Throwable $e) {
+            Log::error('Failed to handle platform donation payment', [
+                'payment_id' => $mpPayment['id'] ?? null,
+                'message' => $e->getMessage(),
+            ]);
+
+            return response()->json(['error' => 'Failed to process platform donation'], 500);
+        }
+
+        return response()->json(['status' => 'success']);
+    }
+
+    protected function handleSubscriptionPreapprovalWebhook(Request $request)
+    {
+        if (! $this->verifyMercadoPagoRequest($request)) {
+            Log::error('Invalid MercadoPago subscription_preapproval webhook request');
+
+            return response()->json(['error' => 'Invalid request'], 400);
+        }
+
+        $preapprovalId = $request->query('data_id') ?? $request->input('data_id') ?? $request->input('data.id');
+        if (! $preapprovalId) {
+            return response()->json(['error' => 'No preapproval ID'], 400);
+        }
+
+        $preapproval = $this->mercadoPagoService->getPreapproval((string) $preapprovalId);
+        if (! $preapproval) {
+            return response()->json(['error' => 'Could not fetch preapproval'], 500);
+        }
+
+        $this->platformDonationService->handleSubscriptionPreapproval($preapproval);
+
+        return response()->json(['status' => 'success']);
+    }
+
+    protected function handleSubscriptionAuthorizedPaymentWebhook(Request $request)
+    {
+        if (! $this->verifyMercadoPagoRequest($request)) {
+            Log::error('Invalid MercadoPago subscription_authorized_payment webhook request');
+
+            return response()->json(['error' => 'Invalid request'], 400);
+        }
+
+        $paymentId = $request->query('data_id') ?? $request->input('data_id') ?? $request->input('data.id');
+        if (! $paymentId) {
+            return response()->json(['error' => 'No payment ID'], 400);
+        }
+
+        $mpPayment = $this->getMercadoPagoPayment($paymentId);
+        if (! $mpPayment) {
+            return response()->json(['error' => 'Could not fetch payment'], 500);
+        }
+
+        $this->platformDonationService->handleSubscriptionAuthorizedPayment($mpPayment);
+
+        return response()->json(['status' => 'success']);
     }
 }

--- a/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
+++ b/app/Http/Controllers/Api/v1/MercadoPagoWebhookController.php
@@ -79,7 +79,6 @@ class MercadoPagoWebhookController extends Controller
             }
         }
 
-        $webhookType = $request->query('type') ?? $request->input('type');
         $action = $request->input('action');
 
         if ($webhookType === 'subscription_preapproval' || $action === 'subscription_preapproval') {
@@ -114,13 +113,17 @@ class MercadoPagoWebhookController extends Controller
             return response()->json(['status' => 'success']);
         }
 
+        $paymentId = $request->query('data_id') ?? $request->input('data_id');
+        if ($action === 'payment.updated' && empty($paymentId)) {
+            return response()->json(['status' => 'success']);
+        }
+
         // Verify the request is from Mercado Pago
         if (! $this->verifyMercadoPagoRequest($request)) {
             Log::error('Invalid MercadoPago webhook request');
 
             return response()->json(['error' => 'Invalid request'], 400);
         }
-        $paymentId = $request->input('data_id');
         if (! $paymentId) {
             Log::error('No payment ID in webhook request');
 

--- a/app/Http/Controllers/Api/v1/PlatformDonationController.php
+++ b/app/Http/Controllers/Api/v1/PlatformDonationController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace STS\Http\Controllers\Api\v1;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use STS\Http\Controllers\Controller;
+use STS\Models\DonationPayment;
+use STS\Models\DonationSubscription;
+use STS\Services\PlatformDonationService;
+
+class PlatformDonationController extends Controller
+{
+    public function __construct(private PlatformDonationService $platformDonationService)
+    {
+        $this->middleware('logged');
+    }
+
+    public function checkoutOnce(Request $request): JsonResponse
+    {
+        $this->ensureEnabled();
+
+        $validated = $request->validate([
+            'tier_id' => 'nullable|integer|exists:donation_tiers,id',
+            'amount' => 'nullable|integer|min:1',
+            'source' => 'nullable|string|max:64',
+            'trip_id' => 'nullable|integer',
+        ]);
+
+        if (empty($validated['tier_id']) && empty($validated['amount'])) {
+            return response()->json(['error' => 'tier_id or amount is required'], 422);
+        }
+
+        $result = $this->platformDonationService->checkoutOnce($request->user(), $validated);
+
+        return response()->json($result);
+    }
+
+    public function checkoutMonthly(Request $request): JsonResponse
+    {
+        $this->ensureEnabled();
+
+        $validated = $request->validate([
+            'tier_id' => 'nullable|integer|exists:donation_tiers,id',
+            'amount' => 'nullable|integer|min:1',
+            'source' => 'nullable|string|max:64',
+            'trip_id' => 'nullable|integer',
+        ]);
+
+        if (empty($validated['tier_id']) && empty($validated['amount'])) {
+            return response()->json(['error' => 'tier_id or amount is required'], 422);
+        }
+
+        $result = $this->platformDonationService->checkoutMonthly($request->user(), $validated);
+
+        return response()->json($result);
+    }
+
+    public function myDonations(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        $payments = DonationPayment::query()
+            ->with('tier')
+            ->where('user_id', $userId)
+            ->latest()
+            ->limit(50)
+            ->get();
+
+        $subscription = DonationSubscription::query()
+            ->with('tier')
+            ->where('user_id', $userId)
+            ->latest()
+            ->first();
+
+        return response()->json([
+            'payments' => $payments,
+            'subscription' => $subscription,
+        ]);
+    }
+
+    private function ensureEnabled(): void
+    {
+        if (! $this->platformDonationService->isEnabled()) {
+            abort(503, 'Platform donations API is disabled');
+        }
+    }
+}

--- a/app/Jobs/UpdateDonationSubscriptionAmountsJob.php
+++ b/app/Jobs/UpdateDonationSubscriptionAmountsJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace STS\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use STS\Models\DonationAmountAdjustment;
+use STS\Services\PlatformDonationService;
+
+class UpdateDonationSubscriptionAmountsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $adjustmentId) {}
+
+    public function handle(PlatformDonationService $platformDonationService): void
+    {
+        $adjustment = DonationAmountAdjustment::find($this->adjustmentId);
+        if (! $adjustment) {
+            return;
+        }
+
+        $platformDonationService->syncSubscriptionAmountsForAdjustment($adjustment);
+    }
+}

--- a/app/Models/DonationAmountAdjustment.php
+++ b/app/Models/DonationAmountAdjustment.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DonationAmountAdjustment extends Model
+{
+    protected $fillable = [
+        'donation_tier_id',
+        'old_amount_cents',
+        'new_amount_cents',
+        'admin_user_id',
+        'subscriptions_updated',
+        'subscriptions_failed',
+        'applied_at',
+    ];
+
+    protected $casts = [
+        'old_amount_cents' => 'integer',
+        'new_amount_cents' => 'integer',
+        'subscriptions_updated' => 'integer',
+        'subscriptions_failed' => 'integer',
+        'applied_at' => 'datetime',
+    ];
+
+    public function tier(): BelongsTo
+    {
+        return $this->belongsTo(DonationTier::class, 'donation_tier_id');
+    }
+
+    public function adminUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_user_id');
+    }
+}

--- a/app/Models/DonationPayment.php
+++ b/app/Models/DonationPayment.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DonationPayment extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'donation_tier_id',
+        'amount_cents',
+        'currency',
+        'status',
+        'mp_payment_id',
+        'mp_preference_id',
+        'external_reference',
+        'source',
+        'trip_id',
+        'paid_at',
+    ];
+
+    protected $casts = [
+        'amount_cents' => 'integer',
+        'paid_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tier(): BelongsTo
+    {
+        return $this->belongsTo(DonationTier::class, 'donation_tier_id');
+    }
+
+    public function getAmountAttribute(): float
+    {
+        return $this->amount_cents / 100;
+    }
+}

--- a/app/Models/DonationSubscription.php
+++ b/app/Models/DonationSubscription.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DonationSubscription extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'donation_tier_id',
+        'mp_preapproval_id',
+        'mp_preapproval_plan_id',
+        'status',
+        'transaction_amount_cents',
+        'next_payment_date',
+        'last_charged_at',
+        'external_reference',
+        'source',
+        'trip_id',
+    ];
+
+    protected $casts = [
+        'transaction_amount_cents' => 'integer',
+        'next_payment_date' => 'date',
+        'last_charged_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tier(): BelongsTo
+    {
+        return $this->belongsTo(DonationTier::class, 'donation_tier_id');
+    }
+
+    public function charges(): HasMany
+    {
+        return $this->hasMany(DonationSubscriptionCharge::class);
+    }
+}

--- a/app/Models/DonationSubscriptionCharge.php
+++ b/app/Models/DonationSubscriptionCharge.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DonationSubscriptionCharge extends Model
+{
+    protected $fillable = [
+        'donation_subscription_id',
+        'mp_payment_id',
+        'amount_cents',
+        'status',
+        'charged_at',
+    ];
+
+    protected $casts = [
+        'amount_cents' => 'integer',
+        'charged_at' => 'datetime',
+    ];
+
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(DonationSubscription::class, 'donation_subscription_id');
+    }
+}

--- a/app/Models/DonationTier.php
+++ b/app/Models/DonationTier.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace STS\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DonationTier extends Model
+{
+    protected $fillable = [
+        'slug',
+        'label_key',
+        'amount_cents',
+        'icon',
+        'mp_preapproval_plan_id',
+        'is_active',
+        'sort_order',
+        'effective_from',
+    ];
+
+    protected $casts = [
+        'amount_cents' => 'integer',
+        'is_active' => 'boolean',
+        'effective_from' => 'datetime',
+        'sort_order' => 'integer',
+    ];
+
+    public function payments(): HasMany
+    {
+        return $this->hasMany(DonationPayment::class);
+    }
+
+    public function subscriptions(): HasMany
+    {
+        return $this->hasMany(DonationSubscription::class);
+    }
+
+    public function amountAdjustments(): HasMany
+    {
+        return $this->hasMany(DonationAmountAdjustment::class);
+    }
+
+    public function getAmountAttribute(): float
+    {
+        return $this->amount_cents / 100;
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/app/Services/MercadoPagoService.php
+++ b/app/Services/MercadoPagoService.php
@@ -4,10 +4,16 @@ namespace STS\Services;
 
 use MercadoPago\Client\Common\RequestOptions;
 use MercadoPago\Client\Order\OrderClient;
+use MercadoPago\Client\Payment\PaymentClient;
+use MercadoPago\Client\PreApproval\PreApprovalClient;
+use MercadoPago\Client\PreApprovalPlan\PreApprovalPlanClient;
 use MercadoPago\Client\Preference\PreferenceClient;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;
 use STS\Models\Campaign;
+use STS\Models\DonationPayment;
+use STS\Models\DonationSubscription;
+use STS\Models\DonationTier;
 
 class MercadoPagoService
 {
@@ -351,5 +357,192 @@ class MercadoPagoService
             'qr_data' => $qrData,
             'payment_id' => $paymentId,
         ];
+    }
+
+    /**
+     * Create a payment preference for platform donations (one-time).
+     */
+    public function createPaymentPreferenceForPlatformDonation(DonationPayment $payment): \MercadoPago\Resources\Preference
+    {
+        $payment->loadMissing('tier');
+        $tierSlug = $payment->tier?->slug ?? 'unknown';
+
+        $baseUrl = rtrim(config('carpoolear.frontend_url'), '/');
+        if ($baseUrl === '') {
+            throw new \InvalidArgumentException('carpoolear.frontend_url must be set for platform donation checkout');
+        }
+
+        $donationUrls = [
+            'success' => $baseUrl.'/trips?donation=success',
+            'failure' => $baseUrl.'/trips?donation=failed',
+            'pending' => $baseUrl.'/trips?donation=pending',
+        ];
+
+        $preferenceData = [
+            'items' => [
+                [
+                    'title' => 'Donación a Carpoolear',
+                    'quantity' => 1,
+                    'unit_price' => floatval($payment->amount_cents) / 100,
+                    'currency_id' => 'ARS',
+                ],
+            ],
+            'back_urls' => $donationUrls,
+            'auto_return' => 'approved',
+            'external_reference' => $this->createHashedExternalReferenceForPlatformDonation(
+                $payment->id,
+                'once',
+                $payment->user_id ?? 'Anonymous',
+                $tierSlug
+            ),
+        ];
+
+        return $this->createPaymentPreference($preferenceData);
+    }
+
+    /**
+     * Create a Mercado Pago preapproval plan for a donation tier.
+     */
+    public function createPreapprovalPlan(DonationTier $tier): \MercadoPago\Resources\PreApprovalPlan
+    {
+        $this->ensureConfigured();
+
+        $client = new PreApprovalPlanClient;
+        $requestOptions = new RequestOptions;
+        $requestOptions->setAccessToken($this->accessToken);
+
+        $amount = floatval($tier->amount_cents) / 100;
+
+        return $client->create([
+            'reason' => 'Donación mensual Carpoolear - '.$tier->slug,
+            'auto_recurring' => [
+                'frequency' => 1,
+                'frequency_type' => 'months',
+                'transaction_amount' => $amount,
+                'currency_id' => 'ARS',
+            ],
+            'back_url' => rtrim(config('carpoolear.frontend_url'), '/').'/trips?donation=success',
+        ], $requestOptions);
+    }
+
+    /**
+     * Build subscription checkout URL for a pending platform donation subscription.
+     */
+    public function createPreapprovalCheckoutUrl(DonationSubscription $subscription): string
+    {
+        $subscription->loadMissing('tier');
+        $planId = $subscription->mp_preapproval_plan_id ?? $subscription->tier?->mp_preapproval_plan_id;
+
+        if (empty($planId)) {
+            throw new \InvalidArgumentException('Mercado Pago preapproval plan ID is not configured for this tier');
+        }
+
+        $externalReference = $subscription->external_reference;
+        if (empty($externalReference)) {
+            $tierSlug = $subscription->tier?->slug ?? 'unknown';
+            $externalReference = $this->createHashedExternalReferenceForPlatformDonation(
+                $subscription->id,
+                'monthly',
+                $subscription->user_id ?? 'Anonymous',
+                $tierSlug
+            );
+            $subscription->external_reference = $externalReference;
+            $subscription->save();
+        }
+
+        $baseCheckoutUrl = 'https://www.mercadopago.com.ar/subscriptions/checkout';
+        $query = http_build_query([
+            'preapproval_plan_id' => $planId,
+            'external_reference' => $externalReference,
+        ]);
+
+        return $baseCheckoutUrl.'?'.$query;
+    }
+
+    /**
+     * Update the recurring amount on an existing preapproval subscription.
+     */
+    public function updatePreapprovalAmount(string $mpPreapprovalId, int $amountCents): \MercadoPago\Resources\PreApproval
+    {
+        $this->ensureConfigured();
+
+        $client = new PreApprovalClient;
+        $requestOptions = new RequestOptions;
+        $requestOptions->setAccessToken($this->accessToken);
+
+        return $client->update($mpPreapprovalId, [
+            'auto_recurring' => [
+                'transaction_amount' => floatval($amountCents) / 100,
+                'currency_id' => 'ARS',
+            ],
+        ], $requestOptions);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getPreapproval(string $id): ?array
+    {
+        $this->ensureConfigured();
+
+        try {
+            $client = new PreApprovalClient;
+            $requestOptions = new RequestOptions;
+            $requestOptions->setAccessToken($this->accessToken);
+            $preapproval = $client->get($id, $requestOptions);
+            $content = $preapproval->getResponse()?->getContent();
+
+            return is_array($content) ? $content : json_decode((string) $content, true);
+        } catch (MPApiException $e) {
+            \Log::error('MercadoPago getPreapproval error', [
+                'id' => $id,
+                'message' => $e->getMessage(),
+                'response' => $e->getApiResponse()->getContent(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getPayment(string $id): ?array
+    {
+        $this->ensureConfigured();
+
+        try {
+            $client = new PaymentClient;
+            $requestOptions = new RequestOptions;
+            $requestOptions->setAccessToken($this->accessToken);
+            $payment = $client->get($id, $requestOptions);
+            $content = $payment->getResponse()?->getContent();
+
+            return is_array($content) ? $content : json_decode((string) $content, true);
+        } catch (MPApiException $e) {
+            \Log::error('MercadoPago getPayment error', [
+                'id' => $id,
+                'message' => $e->getMessage(),
+                'response' => $e->getApiResponse()->getContent(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Decoded format: "Donación Plataforma ID: {id}; Tipo: {once|monthly}; User ID: {id}; Tier: {slug}"
+     */
+    public function createHashedExternalReferenceForPlatformDonation(int $recordId, string $type, $userId, string $tierSlug): string
+    {
+        $referenceString = sprintf(
+            'Donación Plataforma ID: %d; Tipo: %s; User ID: %s; Tier: %s',
+            $recordId,
+            $type,
+            $userId,
+            $tierSlug
+        );
+
+        return $this->buildHashedReference($referenceString);
     }
 }

--- a/app/Services/PlatformDonationService.php
+++ b/app/Services/PlatformDonationService.php
@@ -1,0 +1,494 @@
+<?php
+
+namespace STS\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use STS\Jobs\UpdateDonationSubscriptionAmountsJob;
+use STS\Models\DonationAmountAdjustment;
+use STS\Models\DonationPayment;
+use STS\Models\DonationSubscription;
+use STS\Models\DonationSubscriptionCharge;
+use STS\Models\DonationTier;
+use STS\Models\User;
+
+class PlatformDonationService
+{
+    public function __construct(private MercadoPagoService $mercadoPagoService) {}
+
+    public function isEnabled(): bool
+    {
+        return (bool) config('carpoolear.platform_donations_api_enabled', false);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listActiveTiers(): array
+    {
+        return DonationTier::query()
+            ->active()
+            ->orderBy('sort_order')
+            ->get()
+            ->map(fn (DonationTier $tier) => $this->formatTier($tier))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function formatTier(DonationTier $tier): array
+    {
+        return [
+            'id' => $tier->id,
+            'slug' => $tier->slug,
+            'label_key' => $tier->label_key,
+            'amount' => (int) ($tier->amount_cents / 100),
+            'amount_cents' => $tier->amount_cents,
+            'icon' => $tier->icon,
+            'is_active' => $tier->is_active,
+            'sort_order' => $tier->sort_order,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{init_point: string, payment_id: int}
+     */
+    public function checkoutOnce(User $user, array $data): array
+    {
+        $tier = $this->resolveTier($data);
+        $payment = DonationPayment::create([
+            'user_id' => $user->id,
+            'donation_tier_id' => $tier->id,
+            'amount_cents' => $tier->amount_cents,
+            'currency' => 'ARS',
+            'status' => 'pending',
+            'source' => $data['source'] ?? null,
+            'trip_id' => $data['trip_id'] ?? null,
+        ]);
+
+        $preference = $this->mercadoPagoService->createPaymentPreferenceForPlatformDonation($payment);
+        $payment->mp_preference_id = $preference->id ?? null;
+        $payment->external_reference = $this->mercadoPagoService->createHashedExternalReferenceForPlatformDonation(
+            $payment->id,
+            'once',
+            $user->id,
+            $tier->slug
+        );
+        $payment->save();
+
+        return [
+            'init_point' => $preference->init_point,
+            'payment_id' => $payment->id,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{init_point: string, subscription_id: int}
+     */
+    public function checkoutMonthly(User $user, array $data): array
+    {
+        $tier = $this->resolveTier($data);
+        if (empty($tier->mp_preapproval_plan_id)) {
+            $plan = $this->mercadoPagoService->createPreapprovalPlan($tier);
+            $tier->mp_preapproval_plan_id = $plan->id ?? null;
+            $tier->save();
+        }
+
+        $subscription = DonationSubscription::create([
+            'user_id' => $user->id,
+            'donation_tier_id' => $tier->id,
+            'mp_preapproval_plan_id' => $tier->mp_preapproval_plan_id,
+            'status' => 'pending',
+            'transaction_amount_cents' => $tier->amount_cents,
+            'source' => $data['source'] ?? null,
+            'trip_id' => $data['trip_id'] ?? null,
+        ]);
+
+        $subscription->external_reference = $this->mercadoPagoService->createHashedExternalReferenceForPlatformDonation(
+            $subscription->id,
+            'monthly',
+            $user->id,
+            $tier->slug
+        );
+        $subscription->save();
+
+        $checkoutUrl = $this->mercadoPagoService->createPreapprovalCheckoutUrl($subscription);
+
+        return [
+            'init_point' => $checkoutUrl,
+            'subscription_id' => $subscription->id,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $mpPayment
+     */
+    public function handlePlatformPayment(array $mpPayment): void
+    {
+        $decodedReference = $this->decodeExternalReference($mpPayment['external_reference'] ?? '');
+        if ($decodedReference === null) {
+            throw new \InvalidArgumentException('Invalid platform donation external reference');
+        }
+
+        if (! preg_match(
+            '/Donación Plataforma ID: (\d+); Tipo: (\w+); User ID: ([^;]+); Tier: (\w+)/',
+            $decodedReference,
+            $matches
+        )) {
+            throw new \InvalidArgumentException('Invalid platform donation reference format');
+        }
+
+        $recordId = (int) $matches[1];
+        $type = $matches[2];
+        $userId = $matches[3] === 'Anonymous' ? null : (int) $matches[3];
+
+        if ($type === 'once') {
+            $this->applyOneTimePayment($recordId, $userId, $mpPayment);
+
+            return;
+        }
+
+        if ($type === 'monthly') {
+            $this->applySubscriptionCharge($recordId, $mpPayment);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $preapproval
+     */
+    public function handleSubscriptionPreapproval(array $preapproval): void
+    {
+        $subscription = $this->findSubscriptionFromPreapproval($preapproval);
+        if (! $subscription) {
+            return;
+        }
+
+        $mpStatus = strtolower((string) ($preapproval['status'] ?? ''));
+        $subscription->mp_preapproval_id = $preapproval['id'] ?? $subscription->mp_preapproval_id;
+        $subscription->status = $this->mapPreapprovalStatus($mpStatus);
+        $subscription->transaction_amount_cents = $this->amountCentsFromMp(
+            $preapproval['auto_recurring']['transaction_amount'] ?? ($subscription->transaction_amount_cents / 100)
+        );
+
+        if (! empty($preapproval['next_payment_date'])) {
+            $subscription->next_payment_date = Carbon::parse($preapproval['next_payment_date'])->toDateString();
+        }
+
+        $subscription->save();
+
+        if ($subscription->user_id) {
+            $user = User::find($subscription->user_id);
+            if ($user) {
+                $user->monthly_donate = $subscription->status === 'authorized';
+                $user->save();
+            }
+        }
+
+        if ($subscription->status === 'authorized') {
+            $this->writeLegacyDonationIntent($subscription->user_id, (float) ($subscription->transaction_amount_cents / 100), true);
+        }
+
+        if ($subscription->status === 'cancelled') {
+            $this->writeLegacyDonationIntent($subscription->user_id, 0, false);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $mpPayment
+     */
+    public function handleSubscriptionAuthorizedPayment(array $mpPayment): void
+    {
+        $preapprovalId = $mpPayment['preapproval_id'] ?? ($mpPayment['metadata']['preapproval_id'] ?? null);
+        $subscription = null;
+
+        if ($preapprovalId) {
+            $subscription = DonationSubscription::query()
+                ->where('mp_preapproval_id', $preapprovalId)
+                ->first();
+        }
+
+        if (! $subscription) {
+            $externalReference = $mpPayment['external_reference'] ?? '';
+            $decodedReference = $this->decodeExternalReference($externalReference);
+            if ($decodedReference && preg_match('/Donación Plataforma ID: (\d+)/', $decodedReference, $matches)) {
+                $subscription = DonationSubscription::find((int) $matches[1]);
+            }
+        }
+
+        if (! $subscription) {
+            return;
+        }
+
+        $this->upsertSubscriptionCharge($subscription, $mpPayment);
+    }
+
+    public function applyInflation(DonationTier $tier, int $newAmountCents, int $adminUserId): DonationAmountAdjustment
+    {
+        $oldAmountCents = $tier->amount_cents;
+        $tier->amount_cents = $newAmountCents;
+        $plan = $this->mercadoPagoService->createPreapprovalPlan($tier);
+
+        $tier->mp_preapproval_plan_id = $plan->id ?? $tier->mp_preapproval_plan_id;
+        $tier->effective_from = now();
+        $tier->save();
+
+        $adjustment = DonationAmountAdjustment::create([
+            'donation_tier_id' => $tier->id,
+            'old_amount_cents' => $oldAmountCents,
+            'new_amount_cents' => $newAmountCents,
+            'admin_user_id' => $adminUserId,
+        ]);
+
+        UpdateDonationSubscriptionAmountsJob::dispatch($adjustment->id);
+
+        return $adjustment;
+    }
+
+    public function syncSubscriptionAmountsForAdjustment(DonationAmountAdjustment $adjustment): void
+    {
+        $tier = $adjustment->tier;
+        $updated = 0;
+        $failed = 0;
+
+        DonationSubscription::query()
+            ->where('donation_tier_id', $tier->id)
+            ->where('status', 'authorized')
+            ->whereNotNull('mp_preapproval_id')
+            ->orderBy('id')
+            ->chunkById(20, function ($subscriptions) use ($adjustment, &$updated, &$failed) {
+                foreach ($subscriptions as $subscription) {
+                    try {
+                        $this->mercadoPagoService->updatePreapprovalAmount(
+                            $subscription->mp_preapproval_id,
+                            $adjustment->new_amount_cents
+                        );
+                        $subscription->transaction_amount_cents = $adjustment->new_amount_cents;
+                        $subscription->save();
+                        $updated++;
+                    } catch (\Throwable $e) {
+                        \Log::error('Failed to update donation subscription amount', [
+                            'subscription_id' => $subscription->id,
+                            'mp_preapproval_id' => $subscription->mp_preapproval_id,
+                            'message' => $e->getMessage(),
+                        ]);
+                        $failed++;
+                    }
+                }
+            });
+
+        $adjustment->subscriptions_updated = $updated;
+        $adjustment->subscriptions_failed = $failed;
+        $adjustment->applied_at = now();
+        $adjustment->save();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summary(): array
+    {
+        $oneTimeTotal = (int) DonationPayment::query()->where('status', 'approved')->sum('amount_cents');
+        $recurringTotal = (int) DonationSubscriptionCharge::query()->where('status', 'approved')->sum('amount_cents');
+        $activeSubscriptions = DonationSubscription::query()->where('status', 'authorized')->count();
+        $mrrCents = (int) DonationSubscription::query()
+            ->where('status', 'authorized')
+            ->sum('transaction_amount_cents');
+
+        return [
+            'total_donated_cents' => $oneTimeTotal + $recurringTotal,
+            'one_time_total_cents' => $oneTimeTotal,
+            'recurring_total_cents' => $recurringTotal,
+            'active_subscriptions' => $activeSubscriptions,
+            'estimated_mrr_cents' => $mrrCents,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function resolveTier(array $data): DonationTier
+    {
+        if (! empty($data['tier_id'])) {
+            return DonationTier::query()->active()->findOrFail($data['tier_id']);
+        }
+
+        if (! empty($data['amount'])) {
+            $amountCents = (int) $data['amount'] * 100;
+
+            return DonationTier::query()
+                ->active()
+                ->where('amount_cents', $amountCents)
+                ->firstOrFail();
+        }
+
+        throw new \InvalidArgumentException('tier_id or amount is required');
+    }
+
+    /**
+     * @param  array<string, mixed>  $mpPayment
+     */
+    private function applyOneTimePayment(int $paymentId, ?int $userId, array $mpPayment): void
+    {
+        $payment = DonationPayment::find($paymentId);
+        if (! $payment) {
+            return;
+        }
+
+        $status = $this->mapPaymentStatus($mpPayment['status'] ?? 'pending');
+        $payment->status = $status;
+        $payment->mp_payment_id = (string) ($mpPayment['id'] ?? $payment->mp_payment_id);
+        if ($status === 'approved') {
+            $payment->paid_at = ! empty($mpPayment['date_approved'])
+                ? Carbon::parse($mpPayment['date_approved'])
+                : now();
+        }
+        $payment->save();
+
+        if ($status === 'approved') {
+            $this->writeLegacyDonationIntent($payment->user_id ?? $userId, (float) ($payment->amount_cents / 100), true);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $mpPayment
+     */
+    private function applySubscriptionCharge(int $subscriptionId, array $mpPayment): void
+    {
+        $subscription = DonationSubscription::find($subscriptionId);
+        if (! $subscription) {
+            return;
+        }
+
+        $this->upsertSubscriptionCharge($subscription, $mpPayment);
+    }
+
+    /**
+     * @param  array<string, mixed>  $mpPayment
+     */
+    private function upsertSubscriptionCharge(DonationSubscription $subscription, array $mpPayment): void
+    {
+        $mpPaymentId = (string) ($mpPayment['id'] ?? '');
+        if ($mpPaymentId === '') {
+            return;
+        }
+
+        $status = $this->mapPaymentStatus($mpPayment['status'] ?? 'pending');
+        $amountCents = $this->amountCentsFromMp(
+            $mpPayment['transaction_amount'] ?? $mpPayment['amount'] ?? 0
+        );
+
+        DonationSubscriptionCharge::updateOrCreate(
+            ['mp_payment_id' => $mpPaymentId],
+            [
+                'donation_subscription_id' => $subscription->id,
+                'amount_cents' => $amountCents,
+                'status' => $status,
+                'charged_at' => ! empty($mpPayment['date_approved'])
+                    ? Carbon::parse($mpPayment['date_approved'])
+                    : now(),
+            ]
+        );
+
+        if ($status === 'approved') {
+            $subscription->last_charged_at = ! empty($mpPayment['date_approved'])
+                ? Carbon::parse($mpPayment['date_approved'])
+                : now();
+            $subscription->save();
+            $this->writeLegacyDonationIntent($subscription->user_id, (float) ($amountCents / 100), true);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $preapproval
+     */
+    private function findSubscriptionFromPreapproval(array $preapproval): ?DonationSubscription
+    {
+        $preapprovalId = $preapproval['id'] ?? null;
+        if ($preapprovalId) {
+            $byMpId = DonationSubscription::query()->where('mp_preapproval_id', $preapprovalId)->first();
+            if ($byMpId) {
+                return $byMpId;
+            }
+        }
+
+        $externalReference = $preapproval['external_reference'] ?? '';
+        $decodedReference = $this->decodeExternalReference($externalReference);
+        if ($decodedReference && preg_match('/Donación Plataforma ID: (\d+)/', $decodedReference, $matches)) {
+            return DonationSubscription::find((int) $matches[1]);
+        }
+
+        return null;
+    }
+
+    private function decodeExternalReference(string $externalReference): ?string
+    {
+        if ($externalReference === '') {
+            return null;
+        }
+
+        if (strpos($externalReference, ':') === false) {
+            return $externalReference;
+        }
+
+        $parts = explode(':', $externalReference, 2);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $referenceString = base64_decode($parts[1]);
+        $salt = config('services.mercadopago.reference_salt', 'carpoolear_2024_secure_salt');
+        $expectedHash = hash('sha256', $referenceString.$salt);
+
+        if (! hash_equals($parts[0], $expectedHash)) {
+            return null;
+        }
+
+        return $referenceString;
+    }
+
+    private function mapPaymentStatus(string $mpStatus): string
+    {
+        return match ($mpStatus) {
+            'approved' => 'approved',
+            'refunded', 'charged_back' => 'refunded',
+            'rejected', 'cancelled' => 'rejected',
+            default => 'pending',
+        };
+    }
+
+    private function mapPreapprovalStatus(string $mpStatus): string
+    {
+        return match ($mpStatus) {
+            'authorized' => 'authorized',
+            'paused' => 'paused',
+            'cancelled' => 'cancelled',
+            default => 'pending',
+        };
+    }
+
+    private function amountCentsFromMp(float|int|string $amount): int
+    {
+        return (int) round(((float) $amount) * 100);
+    }
+
+    private function writeLegacyDonationIntent(?int $userId, float $amount, bool $hasDonated): void
+    {
+        if (! $userId) {
+            return;
+        }
+
+        DB::table('donations')->insert([
+            'user_id' => $userId,
+            'month' => now()->format('Y-m'),
+            'has_donated' => $hasDonated ? 1 : 0,
+            'has_denied' => 0,
+            'ammount' => $amount,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/config/carpoolear.php
+++ b/config/carpoolear.php
@@ -33,6 +33,7 @@ return [
     'module_trip_creation_payment_trips_threshold' => (int) env('MODULE_TRIP_CREATION_PAYMENT_TRIPS_THRESHOLD', 2),
     // Frontend app base URL (e.g. for payment redirects, OAuth callbacks). Defaults to APP_URL.
     'frontend_url' => env('FRONTEND_URL', env('APP_URL', 'http://localhost:8080')),
+    'platform_donations_api_enabled' => filter_var(env('PLATFORM_DONATIONS_API_ENABLED', false), FILTER_VALIDATE_BOOLEAN),
 
     // Minimum app version enforcement for Capacitor (null = no enforcement)
     'min_version_android' => env('MIN_VERSION_ANDROID') ? (int) env('MIN_VERSION_ANDROID') : null,

--- a/database/migrations/2026_08_24_120000_create_platform_donation_tables.php
+++ b/database/migrations/2026_08_24_120000_create_platform_donation_tables.php
@@ -1,0 +1,95 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('donation_tiers', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug', 64)->unique();
+            $table->string('label_key', 128);
+            $table->unsignedInteger('amount_cents');
+            $table->string('icon', 64)->default('fa-heart');
+            $table->string('mp_preapproval_plan_id', 128)->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->timestamp('effective_from')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('donation_payments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id')->nullable();
+            $table->foreignId('donation_tier_id')->nullable()->constrained('donation_tiers')->nullOnDelete();
+            $table->unsignedInteger('amount_cents');
+            $table->string('currency', 8)->default('ARS');
+            $table->enum('status', ['pending', 'approved', 'rejected', 'refunded'])->default('pending');
+            $table->string('mp_payment_id', 64)->nullable()->unique();
+            $table->string('mp_preference_id', 64)->nullable();
+            $table->text('external_reference')->nullable();
+            $table->string('source', 64)->nullable();
+            $table->unsignedInteger('trip_id')->nullable();
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+            $table->index(['user_id', 'status']);
+        });
+
+        Schema::create('donation_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id')->nullable();
+            $table->foreignId('donation_tier_id')->nullable()->constrained('donation_tiers')->nullOnDelete();
+            $table->string('mp_preapproval_id', 64)->nullable()->unique();
+            $table->string('mp_preapproval_plan_id', 128)->nullable();
+            $table->enum('status', ['pending', 'authorized', 'paused', 'cancelled'])->default('pending');
+            $table->unsignedInteger('transaction_amount_cents');
+            $table->date('next_payment_date')->nullable();
+            $table->timestamp('last_charged_at')->nullable();
+            $table->text('external_reference')->nullable();
+            $table->string('source', 64)->nullable();
+            $table->unsignedInteger('trip_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+            $table->index(['user_id', 'status']);
+        });
+
+        Schema::create('donation_subscription_charges', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('donation_subscription_id')->constrained('donation_subscriptions')->cascadeOnDelete();
+            $table->string('mp_payment_id', 64)->unique();
+            $table->unsignedInteger('amount_cents');
+            $table->enum('status', ['pending', 'approved', 'rejected', 'refunded'])->default('pending');
+            $table->timestamp('charged_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('donation_amount_adjustments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('donation_tier_id')->constrained('donation_tiers')->cascadeOnDelete();
+            $table->unsignedInteger('old_amount_cents');
+            $table->unsignedInteger('new_amount_cents');
+            $table->unsignedInteger('admin_user_id')->nullable();
+            $table->unsignedInteger('subscriptions_updated')->default(0);
+            $table->unsignedInteger('subscriptions_failed')->default(0);
+            $table->timestamp('applied_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('admin_user_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('donation_amount_adjustments');
+        Schema::dropIfExists('donation_subscription_charges');
+        Schema::dropIfExists('donation_subscriptions');
+        Schema::dropIfExists('donation_payments');
+        Schema::dropIfExists('donation_tiers');
+    }
+};

--- a/database/seeders/DonationTierSeeder.php
+++ b/database/seeders/DonationTierSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use STS\Models\DonationTier;
+
+class DonationTierSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $tiers = [
+            [
+                'slug' => 'cafe',
+                'label_key' => 'donationTierCafe',
+                'amount_cents' => 500000,
+                'icon' => 'fa-coffee',
+                'sort_order' => 1,
+            ],
+            [
+                'slug' => 'beer',
+                'label_key' => 'donationTierBeer',
+                'amount_cents' => 750000,
+                'icon' => 'fa-beer',
+                'sort_order' => 2,
+            ],
+            [
+                'slug' => 'food',
+                'label_key' => 'donationTierFood',
+                'amount_cents' => 1200000,
+                'icon' => 'fa-cutlery',
+                'sort_order' => 3,
+            ],
+        ];
+
+        foreach ($tiers as $tier) {
+            DonationTier::query()->updateOrCreate(
+                ['slug' => $tier['slug']],
+                array_merge($tier, ['is_active' => true])
+            );
+        }
+    }
+}

--- a/docs/DONATION_MP_WEBHOOK_SETUP.md
+++ b/docs/DONATION_MP_WEBHOOK_SETUP.md
@@ -1,0 +1,39 @@
+# Platform Donations — Mercado Pago Webhook Setup
+
+Platform donations reuse the **main** Carpoolear Mercado Pago application (`MERCADO_PAGO_ACCESS_TOKEN`).
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `MERCADO_PAGO_ACCESS_TOKEN` | Preferences, payments, preapprovals |
+| `MERCADO_PAGO_WEBHOOK_SECRET` | `x-signature` verification |
+| `MERCADO_PAGO_REFERENCE_SALT` | Hashed `external_reference` |
+| `PLATFORM_DONATIONS_API_ENABLED` | Feature flag (`true` to enable checkout API) |
+| `FRONTEND_URL` | Success/failure redirects after checkout |
+
+## Mercado Pago Developers panel
+
+1. Open [Mercado Pago Developers](https://www.mercadopago.com.ar/developers/panel/app) → your app.
+2. **Webhooks** → Production (and Test for staging):
+   - URL: `https://carpoolear.com.ar/webhooks/mercadopago`
+   - Enable topics:
+     - `payment` (already used)
+     - `subscription_preapproval`
+     - `subscription_authorized_payment`
+3. Copy the **webhook secret** into `MERCADO_PAGO_WEBHOOK_SECRET`.
+4. Confirm **Subscriptions / Preapproval** product is enabled for Argentina.
+
+## Sandbox testing
+
+1. Use test credentials in `.env` for staging.
+2. Simulate webhooks from the MP panel or complete a test checkout.
+3. Verify logs for `Donación Plataforma` external references.
+
+## What the backend handles
+
+| Webhook | Action |
+|---------|--------|
+| `payment.created` / `payment.updated` | One-time platform donations (`Donación Plataforma`) |
+| `subscription_preapproval` | Subscription authorized / paused / cancelled |
+| `subscription_authorized_payment` | Each monthly charge |

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,10 @@ use STS\Http\Controllers\Api\Admin\CarColorController as AdminCarColorController
 use STS\Http\Controllers\Api\Admin\CarController as AdminCarController;
 use STS\Http\Controllers\Api\Admin\CarModelController as AdminCarModelController;
 use STS\Http\Controllers\Api\Admin\ChangelogController as AdminChangelogController;
+use STS\Http\Controllers\Api\Admin\DonationPaymentController as AdminDonationPaymentController;
+use STS\Http\Controllers\Api\Admin\DonationSubscriptionController as AdminDonationSubscriptionController;
+use STS\Http\Controllers\Api\Admin\DonationSummaryController as AdminDonationSummaryController;
+use STS\Http\Controllers\Api\Admin\DonationTierController as AdminDonationTierController;
 use STS\Http\Controllers\Api\Admin\ImpersonationController as AdminImpersonationController;
 use STS\Http\Controllers\Api\Admin\MaintenanceController;
 use STS\Http\Controllers\Api\Admin\ManualIdentityValidationController as AdminManualIdentityValidationController;
@@ -33,6 +37,7 @@ use STS\Http\Controllers\Api\v1\ConversationController;
 use STS\Http\Controllers\Api\v1\DataController;
 use STS\Http\Controllers\Api\v1\DebugController;
 use STS\Http\Controllers\Api\v1\DeviceController;
+use STS\Http\Controllers\Api\v1\DonationTierController;
 use STS\Http\Controllers\Api\v1\FriendsController;
 use STS\Http\Controllers\Api\v1\ImpersonationConsumeController;
 use STS\Http\Controllers\Api\v1\ImpersonationStopController;
@@ -42,6 +47,7 @@ use STS\Http\Controllers\Api\v1\MercadoPagoOAuthController;
 use STS\Http\Controllers\Api\v1\NotificationController;
 use STS\Http\Controllers\Api\v1\OsrmProxyController;
 use STS\Http\Controllers\Api\v1\PassengerController;
+use STS\Http\Controllers\Api\v1\PlatformDonationController;
 use STS\Http\Controllers\Api\v1\RatingController;
 use STS\Http\Controllers\Api\v1\ReferencesController;
 use STS\Http\Controllers\Api\v1\RoutesController;
@@ -67,6 +73,9 @@ Route::middleware(['api'])->group(function () {
     Route::get('car-brands', [CarCatalogController::class, 'brands']);
     Route::get('car-brands/{carBrand}/models', [CarCatalogController::class, 'models']);
     Route::get('car-colors', [CarCatalogController::class, 'colors']);
+    Route::get('donation-tiers', [DonationTierController::class, 'index']);
+    Route::post('donations/checkout/once', [PlatformDonationController::class, 'checkoutOnce']);
+    Route::post('donations/checkout/monthly', [PlatformDonationController::class, 'checkoutMonthly']);
 
     Route::post('logout', [AuthController::class, 'logout']);
     Route::post('impersonate/stop', [ImpersonationStopController::class, 'stop'])->middleware('logged');
@@ -103,6 +112,7 @@ Route::middleware(['api'])->group(function () {
 
         Route::post('/', [UserController::class, 'create']);
         Route::get('/me', [UserController::class, 'show']);
+        Route::get('/me/donations', [PlatformDonationController::class, 'myDonations'])->middleware('logged');
         Route::get('/{id}/badges', [UserController::class, 'badges']);
         Route::get('/bank-data', [UserController::class, 'bankData']);
         Route::get('/terms', [UserController::class, 'terms']);
@@ -269,6 +279,12 @@ Route::middleware(['api'])->group(function () {
         Route::apiResource('campaigns.milestones', CampaignMilestoneController::class);
         Route::apiResource('campaigns.donations', CampaignDonationController::class);
         Route::apiResource('campaigns.rewards', CampaignRewardController::class);
+        Route::get('donation-tiers', [AdminDonationTierController::class, 'index']);
+        Route::put('donation-tiers/{donationTier}', [AdminDonationTierController::class, 'update']);
+        Route::post('donation-tiers/{donationTier}/apply-inflation', [AdminDonationTierController::class, 'applyInflation']);
+        Route::get('donation-payments', [AdminDonationPaymentController::class, 'index']);
+        Route::get('donation-subscriptions', [AdminDonationSubscriptionController::class, 'index']);
+        Route::get('donations/summary', [AdminDonationSummaryController::class, 'show']);
         // Car management routes
         Route::apiResource('cars', AdminCarController::class);
         Route::apiResource('car-colors', AdminCarColorController::class)->except(['create', 'edit']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -58,4 +58,12 @@ Schedule::command('car-catalog:sync-argautos --mode=incremental')
     ->weeklyOn(1, '03:00')
     ->timezone('America/Argentina/Buenos_Aires');
 
+Schedule::command('donations:sync-subscription-amounts')
+    ->everyTenMinutes()
+    ->timezone('America/Argentina/Buenos_Aires');
+
+Schedule::command('donations:reconcile')
+    ->dailyAt('06:00')
+    ->timezone('America/Argentina/Buenos_Aires');
+
 Schedule::command('pulse:check --once')->everyMinute();

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -171,6 +171,8 @@ class ScheduleTest extends TestCase
             'manual-identity-validation:purge-rejected-photos',
             'support-tickets:release-expired-assignments',
             'car-catalog:sync-argautos',
+            'donations:sync-subscription-amounts',
+            'donations:reconcile',
         ];
 
         foreach (array_keys($events) as $command) {

--- a/tests/Feature/Http/PlatformDonationApiTest.php
+++ b/tests/Feature/Http/PlatformDonationApiTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Database\Seeders\DonationTierSeeder;
+use MercadoPago\Resources\Preference;
+use STS\Http\Middleware\UserAdmin;
+use STS\Models\DonationPayment;
+use STS\Models\DonationTier;
+use STS\Models\User;
+use Tests\TestCase;
+
+class PlatformDonationApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(DonationTierSeeder::class);
+        config(['carpoolear.platform_donations_api_enabled' => true]);
+        config(['carpoolear.frontend_url' => 'https://app.carpoolear.test']);
+        config(['services.mercadopago.access_token' => 'test-access-token']);
+    }
+
+    public function test_donation_tiers_are_publicly_listed(): void
+    {
+        $response = $this->getJson('/api/donation-tiers');
+
+        $response->assertOk()
+            ->assertJsonCount(3)
+            ->assertJsonFragment(['slug' => 'cafe', 'amount' => 5000]);
+    }
+
+    public function test_checkout_once_requires_authentication(): void
+    {
+        $tier = DonationTier::where('slug', 'cafe')->firstOrFail();
+
+        $this->postJson('/api/donations/checkout/once', ['tier_id' => $tier->id])
+            ->assertUnauthorized();
+    }
+
+    public function test_checkout_once_returns_init_point_when_mp_is_stubbed(): void
+    {
+        $user = User::factory()->create();
+        $tier = DonationTier::where('slug', 'cafe')->firstOrFail();
+
+        $this->mock(\STS\Services\MercadoPagoService::class, function ($mock) {
+            $preference = new Preference;
+            $preference->id = 'pref-123';
+            $preference->init_point = 'https://mp.test/checkout';
+            $mock->shouldReceive('createPaymentPreferenceForPlatformDonation')
+                ->once()
+                ->andReturn($preference);
+            $mock->shouldReceive('createHashedExternalReferenceForPlatformDonation')
+                ->once()
+                ->andReturn('hash:encoded');
+        });
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/donations/checkout/once', [
+                'tier_id' => $tier->id,
+                'source' => 'after_rating',
+                'trip_id' => 99,
+            ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'init_point' => 'https://mp.test/checkout',
+            ]);
+
+        $this->assertDatabaseHas('donation_payments', [
+            'user_id' => $user->id,
+            'donation_tier_id' => $tier->id,
+            'status' => 'pending',
+            'source' => 'after_rating',
+            'trip_id' => 99,
+        ]);
+    }
+
+    public function test_checkout_monthly_creates_pending_subscription(): void
+    {
+        $user = User::factory()->create();
+        $tier = DonationTier::where('slug', 'beer')->firstOrFail();
+        $tier->update(['mp_preapproval_plan_id' => 'plan-test-123']);
+
+        $this->mock(\STS\Services\MercadoPagoService::class, function ($mock) {
+            $mock->shouldReceive('createHashedExternalReferenceForPlatformDonation')
+                ->once()
+                ->andReturn('hash:encoded-monthly');
+            $mock->shouldReceive('createPreapprovalCheckoutUrl')
+                ->once()
+                ->andReturn('https://mp.test/subscription');
+        });
+
+        $response = $this->actingAs($user, 'api')
+            ->postJson('/api/donations/checkout/monthly', [
+                'amount' => 7500,
+                'source' => 'trips',
+            ]);
+
+        $response->assertOk()
+            ->assertJson(['init_point' => 'https://mp.test/subscription']);
+
+        $this->assertDatabaseHas('donation_subscriptions', [
+            'user_id' => $user->id,
+            'status' => 'pending',
+            'source' => 'trips',
+        ]);
+    }
+
+    public function test_admin_donation_summary_returns_totals(): void
+    {
+        $this->withoutMiddleware(UserAdmin::class);
+        $admin = User::factory()->create(['is_admin' => true]);
+        $tier = DonationTier::where('slug', 'cafe')->firstOrFail();
+
+        DonationPayment::create([
+            'user_id' => $admin->id,
+            'donation_tier_id' => $tier->id,
+            'amount_cents' => 500000,
+            'status' => 'approved',
+            'paid_at' => now(),
+        ]);
+
+        $this->actingAs($admin, 'api')
+            ->getJson('/api/admin/donations/summary')
+            ->assertOk()
+            ->assertJsonFragment(['one_time_total_cents' => 500000]);
+    }
+}

--- a/tests/Feature/Http/PlatformDonationWebhookTest.php
+++ b/tests/Feature/Http/PlatformDonationWebhookTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Database\Seeders\DonationTierSeeder;
+use MercadoPago\MercadoPagoConfig;
+use MercadoPago\Net\MPDefaultHttpClient;
+use MercadoPago\Net\MPHttpClient;
+use MercadoPago\Net\MPRequest;
+use MercadoPago\Net\MPResponse;
+use STS\Models\DonationPayment;
+use STS\Models\DonationSubscription;
+use STS\Models\DonationTier;
+use STS\Models\User;
+use Tests\TestCase;
+
+class PlatformDonationWebhookTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        MercadoPagoConfig::setHttpClient(new MPDefaultHttpClient);
+        parent::tearDown();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(DonationTierSeeder::class);
+        config(['services.mercadopago.webhook_secret' => 'wh-secret-test']);
+        config(['services.mercadopago.access_token' => 'test-access-token']);
+        config(['services.mercadopago.reference_salt' => 'carpoolear_2024_secure_salt']);
+    }
+
+    private function hashedPlatformReference(int $recordId, string $type, int $userId, string $tierSlug): string
+    {
+        $referenceString = sprintf(
+            'Donación Plataforma ID: %d; Tipo: %s; User ID: %d; Tier: %s',
+            $recordId,
+            $type,
+            $userId,
+            $tierSlug
+        );
+        $salt = config('services.mercadopago.reference_salt');
+        $hash = hash('sha256', $referenceString.$salt);
+
+        return $hash.':'.base64_encode($referenceString);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function signatureHeaders(string $dataId, string $requestId, string $secret): array
+    {
+        $ts = (string) time();
+        $manifest = "id:{$dataId};request-id:{$requestId};ts:{$ts};";
+        $v1 = hash_hmac('sha256', $manifest, $secret);
+
+        return [
+            'x-request-id' => $requestId,
+            'x-signature' => "ts={$ts},v1={$v1}",
+        ];
+    }
+
+    public function test_platform_payment_webhook_marks_donation_as_approved(): void
+    {
+        $user = User::factory()->create();
+        $tier = DonationTier::where('slug', 'cafe')->firstOrFail();
+        $payment = DonationPayment::create([
+            'user_id' => $user->id,
+            'donation_tier_id' => $tier->id,
+            'amount_cents' => 500000,
+            'status' => 'pending',
+        ]);
+
+        $externalReference = $this->hashedPlatformReference($payment->id, 'once', $user->id, 'cafe');
+        $mpPaymentId = 987654321;
+
+        MercadoPagoConfig::setAccessToken('test-access-token');
+        MercadoPagoConfig::setHttpClient(new class($mpPaymentId, $externalReference) implements MPHttpClient
+        {
+            public function __construct(private int $paymentId, private string $externalReference) {}
+
+            public function send(MPRequest $request): MPResponse
+            {
+                return new MPResponse(200, [
+                    'id' => $this->paymentId,
+                    'status' => 'approved',
+                    'status_detail' => 'accredited',
+                    'transaction_amount' => 5000.0,
+                    'currency_id' => 'ARS',
+                    'payment_method_id' => 'visa',
+                    'payment_type_id' => 'credit_card',
+                    'external_reference' => $this->externalReference,
+                    'description' => 'Donación',
+                    'date_created' => '2026-08-24T12:00:00.000-00:00',
+                    'date_approved' => '2026-08-24T12:00:00.000-00:00',
+                    'date_last_updated' => '2026-08-24T12:00:00.000-00:00',
+                ]);
+            }
+        });
+
+        $headers = $this->signatureHeaders((string) $mpPaymentId, 'req-platform-1', 'wh-secret-test');
+
+        $this->postJson('/webhooks/mercadopago?data_id='.$mpPaymentId, [
+            'action' => 'payment.created',
+            'data_id' => (string) $mpPaymentId,
+        ], $headers)
+            ->assertOk()
+            ->assertExactJson(['status' => 'success']);
+
+        $payment->refresh();
+        $this->assertSame('approved', $payment->status);
+        $this->assertSame((string) $mpPaymentId, $payment->mp_payment_id);
+    }
+
+    public function test_subscription_preapproval_webhook_sets_monthly_donate(): void
+    {
+        $user = User::factory()->create(['monthly_donate' => false]);
+        $tier = DonationTier::where('slug', 'beer')->firstOrFail();
+        $subscription = DonationSubscription::create([
+            'user_id' => $user->id,
+            'donation_tier_id' => $tier->id,
+            'status' => 'pending',
+            'transaction_amount_cents' => 750000,
+            'external_reference' => $this->hashedPlatformReference(1, 'monthly', $user->id, 'beer'),
+        ]);
+
+        $preapprovalId = 'preapproval-test-1';
+        $subscription->update(['mp_preapproval_id' => $preapprovalId]);
+
+        $this->mock(\STS\Services\MercadoPagoService::class, function ($mock) use ($preapprovalId, $subscription) {
+            $mock->shouldReceive('getPreapproval')
+                ->once()
+                ->with($preapprovalId)
+                ->andReturn([
+                    'id' => $preapprovalId,
+                    'status' => 'authorized',
+                    'external_reference' => $subscription->external_reference,
+                    'auto_recurring' => ['transaction_amount' => 7500],
+                    'next_payment_date' => '2026-09-24T00:00:00.000-00:00',
+                ]);
+        });
+
+        $headers = $this->signatureHeaders($preapprovalId, 'req-preapproval-1', 'wh-secret-test');
+
+        $this->postJson('/webhooks/mercadopago?data_id='.$preapprovalId, [
+            'type' => 'subscription_preapproval',
+            'action' => 'subscription_preapproval',
+            'data_id' => $preapprovalId,
+        ], $headers)
+            ->assertOk();
+
+        $subscription->refresh();
+        $user->refresh();
+        $this->assertSame('authorized', $subscription->status);
+        $this->assertTrue($user->monthly_donate);
+    }
+}


### PR DESCRIPTION
## Summary
- Add donation tier/payment/subscription tables, models, and seeder (5000/7500/12000 ARS).
- Expose public checkout APIs (`/api/donation-tiers`, `/api/donations/checkout/once|monthly`) and user donation history.
- Extend Mercado Pago webhooks for platform one-time payments, subscription lifecycle, and recurring charges.
- Add admin tier management, inflation apply job/cron, donation ledgers, and summary reporting.
- Document MP webhook setup in `docs/DONATION_MP_WEBHOOK_SETUP.md` behind `PLATFORM_DONATIONS_API_ENABLED`.

## Test plan
- [ ] Run `php artisan migrate` and `php artisan db:seed --class=DonationTierSeeder`
- [ ] Set `PLATFORM_DONATIONS_API_ENABLED=true` in staging
- [ ] Enable MP webhook topics `subscription_preapproval` and `subscription_authorized_payment`
- [ ] Complete sandbox one-time and monthly donation checkouts
- [ ] Verify webhook updates `donation_payments` / `donation_subscriptions` and `users.monthly_donate`
- [ ] Run `php artisan test --filter=PlatformDonation`