### PR TITLE
Allow users to reply to profile references

### DIFF
--- a/app/Http/Controllers/Api/v1/ReferencesController.php
+++ b/app/Http/Controllers/Api/v1/ReferencesController.php
@@ -2,7 +2,7 @@
 
 namespace STS\Http\Controllers\Api\v1;
 
-use Illuminate\Http\Request; 
+use Illuminate\Http\Request;
 use STS\Http\Controllers\Controller;
 use STS\Http\ExceptionWithErrors;
 use STS\Services\Logic\ReferencesManager;
@@ -35,5 +35,22 @@ class ReferencesController extends Controller
         } else {
             throw new ExceptionWithErrors('User not logged.');
         }
+    }
+
+    public function reply($userId, Request $request)
+    {
+        $this->user = auth()->user();
+
+        if ($this->user) {
+            $comment = $request->get('comment');
+            $response = $this->referencesLogic->reply($this->user, $userId, $comment);
+            if ($response) {
+                return response()->json(['data' => 'ok']);
+            }
+
+            throw new ExceptionWithErrors('Could not reply to reference.', $this->referencesLogic->getErrors());
+        }
+
+        throw new ExceptionWithErrors('User not logged.');
     }
 }

--- a/app/Models/References.php
+++ b/app/Models/References.php
@@ -3,8 +3,6 @@
 namespace STS\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use STS\Models\User;
 
 class References extends Model
 {
@@ -13,13 +11,22 @@ class References extends Model
     protected $fillable = [
         'user_id_from',
         'user_id_to',
-        'comment'
-    ]; 
+        'comment',
+        'reply_comment',
+        'reply_comment_created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'reply_comment_created_at' => 'datetime',
+        ];
+    }
 
     protected $hidden = [];
 
     protected $appends = [
-        'from'
+        'from',
     ];
 
     public function from()

--- a/app/Repository/ReferencesRepository.php
+++ b/app/Repository/ReferencesRepository.php
@@ -10,4 +10,16 @@ class ReferencesRepository
     {
         return $reference->save();
     }
+
+    public function get($userFromId, $userToId)
+    {
+        return ReferencesModel::where('user_id_from', $userFromId)
+            ->where('user_id_to', $userToId)
+            ->first();
+    }
+
+    public function update(ReferencesModel $reference)
+    {
+        return $reference->save();
+    }
 }

--- a/app/Services/Logic/ReferencesManager.php
+++ b/app/Services/Logic/ReferencesManager.php
@@ -2,6 +2,7 @@
 
 namespace STS\Services\Logic;
 
+use Carbon\Carbon;
 use STS\Models\References as ReferencesModel;
 use STS\Models\User as UserModel;
 use STS\Repository\ReferencesRepository;
@@ -60,5 +61,19 @@ class ReferencesManager extends BaseManager
         $this->referencesRepo->create($reference);
 
         return $reference;
+    }
+
+    public function reply($userTo, $userFromId, $comment)
+    {
+        $reference = $this->referencesRepo->get($userFromId, $userTo->id);
+        if ($reference && ! $reference->reply_comment_created_at) {
+            $reference->reply_comment_created_at = Carbon::now();
+            $reference->reply_comment = $comment;
+
+            return $this->referencesRepo->update($reference);
+        }
+
+        $this->setErrors(['error' => 'user_have_already_replay']);
+
     }
 }

--- a/app/Transformers/ReferenceTransformer.php
+++ b/app/Transformers/ReferenceTransformer.php
@@ -14,6 +14,10 @@ class ReferenceTransformer extends TransformerAbstract
             'user_id_from' => $reference->user_id_from,
             'user_id_to' => $reference->user_id_to,
             'comment' => $reference->comment,
+            'reply_comment' => $reference->reply_comment,
+            'reply_comment_created_at' => $reference->reply_comment_created_at
+                ? $reference->reply_comment_created_at->toDateTimeString()
+                : null,
         ];
     }
 }

--- a/database/migrations/2026_08_30_180000_add_reply_fields_to_users_references_table.php
+++ b/database/migrations/2026_08_30_180000_add_reply_fields_to_users_references_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users_references', function (Blueprint $table) {
+            $table->text('reply_comment')->nullable();
+            $table->dateTime('reply_comment_created_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users_references', function (Blueprint $table) {
+            $table->dropColumn(['reply_comment', 'reply_comment_created_at']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -255,6 +255,7 @@ Route::middleware(['api'])->group(function () {
 
     Route::prefix('references')->group(function () {
         Route::post('/', [ReferencesController::class, 'create']);
+        Route::post('/reply/{userId}', [ReferencesController::class, 'reply']);
     });
 
     // Admin routes

--- a/tests/Feature/Http/ReferencesApiTest.php
+++ b/tests/Feature/Http/ReferencesApiTest.php
@@ -134,4 +134,55 @@ class ReferencesApiTest extends TestCase
             ->assertUnprocessable()
             ->assertJsonPath('message', 'Could not rate user.');
     }
+
+    public function test_reply_route_requires_authentication(): void
+    {
+        $this->postJson('api/references/reply/1', ['comment' => 'Thanks'])
+            ->assertUnauthorized()
+            ->assertJson(['message' => 'Unauthorized.']);
+    }
+
+    public function test_reply_persists_comment_and_returns_ok(): void
+    {
+        $author = User::factory()->create();
+        $recipient = User::factory()->create();
+        References::query()->create([
+            'user_id_from' => $author->id,
+            'user_id_to' => $recipient->id,
+            'comment' => 'Reliable partner.',
+        ]);
+
+        $this->actingAs($recipient, 'api')
+            ->postJson("api/references/reply/{$author->id}", [
+                'comment' => 'Thanks for writing.',
+            ])
+            ->assertOk()
+            ->assertExactJson(['data' => 'ok']);
+
+        $this->assertDatabaseHas('users_references', [
+            'user_id_from' => $author->id,
+            'user_id_to' => $recipient->id,
+            'reply_comment' => 'Thanks for writing.',
+        ]);
+    }
+
+    public function test_reply_second_attempt_fails(): void
+    {
+        $author = User::factory()->create();
+        $recipient = User::factory()->create();
+        References::query()->create([
+            'user_id_from' => $author->id,
+            'user_id_to' => $recipient->id,
+            'comment' => 'Hi',
+            'reply_comment' => 'First',
+            'reply_comment_created_at' => now()->subMinute(),
+        ]);
+
+        $this->actingAs($recipient, 'api')
+            ->postJson("api/references/reply/{$author->id}", [
+                'comment' => 'Again',
+            ])
+            ->assertUnprocessable()
+            ->assertJsonFragment(['message' => 'Could not reply to reference.']);
+    }
 }

--- a/tests/Unit/Models/ReferencesTest.php
+++ b/tests/Unit/Models/ReferencesTest.php
@@ -2,12 +2,43 @@
 
 namespace Tests\Unit\Models;
 
+use Carbon\Carbon;
 use STS\Models\References;
 use STS\Models\User;
 use Tests\TestCase;
 
 class ReferencesTest extends TestCase
 {
+    public function test_fillable_contains_reply_fields(): void
+    {
+        $this->assertSame([
+            'user_id_from',
+            'user_id_to',
+            'comment',
+            'reply_comment',
+            'reply_comment_created_at',
+        ], (new References)->getFillable());
+    }
+
+    public function test_reply_comment_created_at_casts_to_carbon(): void
+    {
+        $author = User::factory()->create();
+        $subject = User::factory()->create();
+
+        $ref = References::query()->create([
+            'user_id_from' => $author->id,
+            'user_id_to' => $subject->id,
+            'comment' => 'Reliable carpool partner.',
+            'reply_comment' => 'Thanks!',
+            'reply_comment_created_at' => '2026-08-30 12:00:00',
+        ]);
+
+        $ref = $ref->fresh();
+        $this->assertInstanceOf(Carbon::class, $ref->reply_comment_created_at);
+        $this->assertSame('2026-08-30 12:00:00', $ref->reply_comment_created_at->format('Y-m-d H:i:s'));
+        $this->assertSame('Thanks!', $ref->reply_comment);
+    }
+
     public function test_from_and_to_relationships_resolve_users(): void
     {
         $author = User::factory()->create();

--- a/tests/Unit/Repository/ReferencesRepositoryTest.php
+++ b/tests/Unit/Repository/ReferencesRepositoryTest.php
@@ -79,4 +79,59 @@ class ReferencesRepositoryTest extends TestCase
 
         $this->assertTrue($this->repo()->create($reference));
     }
+
+    public function test_get_returns_reference_for_from_and_to(): void
+    {
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $other = User::factory()->create();
+        References::query()->create([
+            'user_id_from' => $other->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Noise',
+        ]);
+        $expected = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Target',
+        ]);
+
+        $found = $this->repo()->get($from->id, $to->id);
+
+        $this->assertNotNull($found);
+        $this->assertSame($expected->id, $found->id);
+        $this->assertSame('Target', $found->comment);
+    }
+
+    public function test_get_returns_null_when_no_reference_exists(): void
+    {
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+
+        $this->assertNull($this->repo()->get($from->id, $to->id));
+    }
+
+    public function test_update_persists_reply_fields(): void
+    {
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $reference = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Original',
+        ]);
+
+        $reference->reply_comment = 'Thanks for writing.';
+        $reference->reply_comment_created_at = '2026-08-30 15:00:00';
+
+        $this->assertTrue($this->repo()->update($reference));
+        $this->assertDatabaseHas('users_references', [
+            'id' => $reference->id,
+            'reply_comment' => 'Thanks for writing.',
+        ]);
+        $this->assertSame(
+            '2026-08-30 15:00:00',
+            $reference->fresh()->reply_comment_created_at->format('Y-m-d H:i:s')
+        );
+    }
 }

--- a/tests/Unit/Services/Logic/ReferencesManagerTest.php
+++ b/tests/Unit/Services/Logic/ReferencesManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Logic;
 
+use Carbon\Carbon;
 use STS\Models\References;
 use STS\Models\User;
 use STS\Repository\ReferencesRepository;
@@ -189,5 +190,42 @@ class ReferencesManagerTest extends TestCase
             'user_id_to' => $from->id,
             'comment' => 'Reverse',
         ]);
+    }
+
+    public function test_reply_persists_comment_once(): void
+    {
+        Carbon::setTestNow('2026-08-30 18:00:00');
+        $author = User::factory()->create();
+        $recipient = User::factory()->create();
+        References::create([
+            'user_id_from' => $author->id,
+            'user_id_to' => $recipient->id,
+            'comment' => 'Great person.',
+        ]);
+
+        $manager = $this->manager();
+        $this->assertTrue($manager->reply($recipient, $author->id, 'Thanks!'));
+
+        $row = (new ReferencesRepository)->get($author->id, $recipient->id);
+        $this->assertSame('Thanks!', $row->reply_comment);
+        $this->assertNotNull($row->reply_comment_created_at);
+        $this->assertSame('2026-08-30 18:00:00', $row->reply_comment_created_at->format('Y-m-d H:i:s'));
+
+        $this->assertNull($manager->reply($recipient, $author->id, 'Again'));
+        $this->assertSame('user_have_already_replay', $manager->getErrors()['error']);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_reply_sets_error_when_reference_does_not_exist(): void
+    {
+        $author = User::factory()->create();
+        $recipient = User::factory()->create();
+        $manager = $this->manager();
+
+        $result = $manager->reply($recipient, $author->id, 'No row');
+
+        $this->assertNull($result);
+        $this->assertSame('user_have_already_replay', $manager->getErrors()['error']);
     }
 }

--- a/tests/Unit/Transformers/ReferenceTransformerTest.php
+++ b/tests/Unit/Transformers/ReferenceTransformerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Transformers;
+
+use STS\Models\References;
+use STS\Models\User;
+use STS\Transformers\ReferenceTransformer;
+use Tests\TestCase;
+
+class ReferenceTransformerTest extends TestCase
+{
+    public function test_transform_includes_reply_fields(): void
+    {
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $reference = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'Great person.',
+            'reply_comment' => 'Thanks!',
+            'reply_comment_created_at' => '2026-08-30 18:00:00',
+        ]);
+
+        $payload = (new ReferenceTransformer)->transform($reference->fresh());
+
+        $this->assertSame($reference->id, $payload['id']);
+        $this->assertSame('Great person.', $payload['comment']);
+        $this->assertSame('Thanks!', $payload['reply_comment']);
+        $this->assertSame('2026-08-30 18:00:00', $payload['reply_comment_created_at']);
+    }
+
+    public function test_transform_formats_null_reply_created_at(): void
+    {
+        $from = User::factory()->create();
+        $to = User::factory()->create();
+        $reference = References::query()->create([
+            'user_id_from' => $from->id,
+            'user_id_to' => $to->id,
+            'comment' => 'No reply yet.',
+        ]);
+
+        $payload = (new ReferenceTransformer)->transform($reference->fresh());
+
+        $this->assertNull($payload['reply_comment']);
+        $this->assertNull($payload['reply_comment_created_at']);
+    }
+}


### PR DESCRIPTION
## Summary
- Persist `reply_comment` and `reply_comment_created_at` on `users_references`.
- Add `POST /api/references/reply/{userId}` so the profile owner can reply once to a reference, matching rating replies.
- Include reply fields in `ReferenceTransformer` (they also serialize on profile `references_data`).

Companion frontend PR: STS-Rosario/carpoolear `responder-referencias`.

## Test plan
- [x] `php artisan test --filter='ReferencesTest|ReferencesRepositoryTest|ReferencesManagerTest|ReferencesApiTest|ReferenceTransformerTest'` (40 passed)
- [x] Full backend suite (`3524` passed, `3` skipped, `1` pre-existing risky)
- [ ] Migrate, then on your own profile reply to a reference and confirm it persists
- [ ] A second reply to the same reference returns 422
- [ ] Unauthenticated `POST /api/references/reply/{id}` returns 401