### PR TITLE
Close open manuals when MercadoPago identity verification succeeds

### DIFF
--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -33,7 +33,7 @@ class ManualIdentityValidationController extends Controller
         if (! $this->queryFlagIsTruthy($request->query('show_resolved'))) {
             $query->where(function ($builder) {
                 $builder->whereNull('review_status')
-                    ->orWhereNotIn('review_status', ['approved', 'approve', 'rejected', 'reject']);
+                    ->orWhereNotIn('review_status', ['approved', 'approve', 'rejected', 'reject', 'closed']);
             });
         }
 

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -220,7 +220,7 @@ class ManualIdentityValidationController extends Controller
     public function updateState(Request $request, int $id): JsonResponse
     {
         $validated = $request->validate([
-            'review_status' => 'sometimes|in:pending,awaiting_photos,approved,rejected',
+            'review_status' => 'sometimes|in:pending,awaiting_photos,approved,rejected,closed',
             'paid' => 'sometimes|boolean',
             'photos_submitted' => 'sometimes|boolean',
         ]);
@@ -298,6 +298,10 @@ class ManualIdentityValidationController extends Controller
         if ($reviewStatus === ManualIdentityValidation::REVIEW_STATUS_APPROVED) {
             app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
 
+            return;
+        }
+
+        if ($reviewStatus === ManualIdentityValidation::REVIEW_STATUS_CLOSED) {
             return;
         }
 

--- a/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/Admin/ManualIdentityValidationController.php
@@ -33,7 +33,7 @@ class ManualIdentityValidationController extends Controller
         if (! $this->queryFlagIsTruthy($request->query('show_resolved'))) {
             $query->where(function ($builder) {
                 $builder->whereNull('review_status')
-                    ->orWhereNotIn('review_status', ['approved', 'approve', 'rejected', 'reject', 'closed']);
+                    ->orWhereNotIn('review_status', ManualIdentityValidation::resolvedReviewStatusAliases());
             });
         }
 

--- a/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
+++ b/app/Http/Controllers/Api/v1/ManualIdentityValidationController.php
@@ -212,6 +212,10 @@ class ManualIdentityValidationController extends Controller
             throw new ExceptionWithErrors('Payment is required before submitting images.', [], 422);
         }
 
+        if ($validationRequest->review_status === ManualIdentityValidation::REVIEW_STATUS_CLOSED) {
+            throw new ExceptionWithErrors('This request is closed.', [], 422);
+        }
+
         $isResubmit = $validationRequest->review_status === ManualIdentityValidation::REVIEW_STATUS_REJECTED;
         if ($isResubmit) {
             if (! $resubmitPolicy->canResubmitWithoutPayment($validationRequest)) {

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -106,9 +106,14 @@ class ManualIdentityValidation extends Model
         if ($this->paid_at === null) {
             $this->paid_at = now();
         }
-        if ($this->submitted_at === null) {
+        if ($this->submitted_at === null && ! $this->isResolved()) {
             $this->markAwaitingPhotos();
         }
+    }
+
+    public function isResolved(): bool
+    {
+        return in_array((string) $this->review_status, self::resolvedReviewStatusAliases(), true);
     }
 
     /**

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -19,6 +19,30 @@ class ManualIdentityValidation extends Model
 
     const REVIEW_STATUS_CLOSED = 'closed';
 
+    /**
+     * Terminal review statuses that are hidden from the default admin queue.
+     *
+     * @return list<string>
+     */
+    public static function resolvedReviewStatuses(): array
+    {
+        return [
+            self::REVIEW_STATUS_APPROVED,
+            self::REVIEW_STATUS_REJECTED,
+            self::REVIEW_STATUS_CLOSED,
+        ];
+    }
+
+    /**
+     * Resolved statuses plus historical aliases stored in older rows.
+     *
+     * @return list<string>
+     */
+    public static function resolvedReviewStatusAliases(): array
+    {
+        return array_merge(self::resolvedReviewStatuses(), ['approve', 'reject']);
+    }
+
     protected $fillable = [
         'user_id',
         'submitted_at',

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -17,6 +17,8 @@ class ManualIdentityValidation extends Model
 
     const REVIEW_STATUS_REJECTED = 'rejected';
 
+    const REVIEW_STATUS_CLOSED = 'closed';
+
     protected $fillable = [
         'user_id',
         'submitted_at',

--- a/app/Services/UserIdentityVerificationSuccessService.php
+++ b/app/Services/UserIdentityVerificationSuccessService.php
@@ -18,6 +18,27 @@ class UserIdentityVerificationSuccessService
         $user->identity_validation_rejected_at = null;
         $user->identity_validation_reject_reason = null;
         $user->save();
+
+        if ($validationType === 'mercado_pago') {
+            $this->closeOpenManualIdentityValidationsForUser($user);
+        }
+    }
+
+    private function closeOpenManualIdentityValidationsForUser(User $user): void
+    {
+        ManualIdentityValidation::query()
+            ->where('user_id', $user->id)
+            ->where(function ($query) {
+                $query->whereNull('review_status')
+                    ->orWhereNotIn('review_status', [
+                        ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+                        ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+                        ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+                    ]);
+            })
+            ->update([
+                'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+            ]);
     }
 
     public function clearPriorRejectionState(User $user, array $options = []): void

--- a/app/Services/UserIdentityVerificationSuccessService.php
+++ b/app/Services/UserIdentityVerificationSuccessService.php
@@ -30,7 +30,7 @@ class UserIdentityVerificationSuccessService
             ->where('user_id', $user->id)
             ->where(function ($query) {
                 $query->whereNull('review_status')
-                    ->orWhereNotIn('review_status', ManualIdentityValidation::resolvedReviewStatuses());
+                    ->orWhereNotIn('review_status', ManualIdentityValidation::resolvedReviewStatusAliases());
             })
             ->update([
                 'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,

--- a/app/Services/UserIdentityVerificationSuccessService.php
+++ b/app/Services/UserIdentityVerificationSuccessService.php
@@ -30,11 +30,7 @@ class UserIdentityVerificationSuccessService
             ->where('user_id', $user->id)
             ->where(function ($query) {
                 $query->whereNull('review_status')
-                    ->orWhereNotIn('review_status', [
-                        ManualIdentityValidation::REVIEW_STATUS_APPROVED,
-                        ManualIdentityValidation::REVIEW_STATUS_REJECTED,
-                        ManualIdentityValidation::REVIEW_STATUS_CLOSED,
-                    ]);
+                    ->orWhereNotIn('review_status', ManualIdentityValidation::resolvedReviewStatuses());
             })
             ->update([
                 'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -929,6 +929,38 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->assertSame('manual', (string) $user->identity_validation_type);
     }
 
+    public function test_update_state_accepts_closed_without_changing_user_identity(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create([
+            'identity_validated' => true,
+            'identity_validated_at' => now(),
+            'identity_validation_type' => 'mercado_pago',
+        ]);
+        $row = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $this->postJson('api/admin/manual-identity-validations/'.$row->id.'/state', [
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+        ])->assertOk()->assertJsonPath('data.review_status', ManualIdentityValidation::REVIEW_STATUS_CLOSED);
+
+        $user->refresh();
+        $this->assertTrue((bool) $user->identity_validated);
+        $this->assertSame('mercado_pago', (string) $user->identity_validation_type);
+        $this->assertDatabaseHas('manual_identity_validations', [
+            'id' => $row->id,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+        ]);
+    }
+
     public function test_show_includes_support_tickets_count_for_user(): void
     {
         $admin = $this->admin();

--- a/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
+++ b/tests/Feature/Http/AdminManualIdentityValidationControllerIntegrationTest.php
@@ -183,6 +183,45 @@ class AdminManualIdentityValidationControllerIntegrationTest extends TestCase
         $this->assertContains($approvedUser->id, $resolvedIds);
     }
 
+    public function test_index_treats_closed_rows_as_resolved(): void
+    {
+        $admin = $this->admin();
+        $pendingUser = User::factory()->create();
+        $closedUser = User::factory()->create();
+
+        ManualIdentityValidation::create([
+            'user_id' => $pendingUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        ManualIdentityValidation::create([
+            'user_id' => $closedUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+        ]);
+
+        $this->actingAs($admin, 'api');
+        $this->withoutMiddleware(UserAdmin::class);
+
+        $defaultIds = collect($this->getJson('api/admin/manual-identity-validations')->json('data'))
+            ->pluck('user_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertContains($pendingUser->id, $defaultIds);
+        $this->assertNotContains($closedUser->id, $defaultIds);
+
+        $resolvedIds = collect($this->getJson('api/admin/manual-identity-validations?show_resolved=1')->json('data'))
+            ->pluck('user_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $this->assertContains($pendingUser->id, $resolvedIds);
+        $this->assertContains($closedUser->id, $resolvedIds);
+    }
+
     public function test_index_sorts_by_open_account_verification_tickets_count_desc(): void
     {
         $admin = $this->admin();

--- a/tests/Feature/Http/ManualIdentityValidationApiTest.php
+++ b/tests/Feature/Http/ManualIdentityValidationApiTest.php
@@ -1187,6 +1187,34 @@ class ManualIdentityValidationApiTest extends TestCase
         $this->assertNull($validationRequest->fresh()->submitted_at);
     }
 
+    public function test_submit_on_closed_request_returns_unprocessable_and_keeps_closed(): void
+    {
+        $user = User::factory()->create();
+        $validationRequest = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+        ]);
+
+        $front = UploadedFile::fake()->image('front.jpg', 100, 100)->size(500);
+        $back = UploadedFile::fake()->image('back.jpg', 100, 100)->size(500);
+        $selfie = UploadedFile::fake()->image('selfie.jpg', 100, 100)->size(500);
+
+        $this->actingAs($user, 'api')->post('api/users/manual-identity-validation', [
+            'request_id' => $validationRequest->id,
+            'front_image' => $front,
+            'back_image' => $back,
+            'selfie_image' => $selfie,
+        ])
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'This request is closed.');
+
+        $fresh = $validationRequest->fresh();
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $fresh->review_status);
+        $this->assertNull($fresh->submitted_at);
+    }
+
     public function test_submit_with_missing_selfie_returns_unprocessable(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
+++ b/tests/Feature/Http/MercadoPagoOAuthCallbackTest.php
@@ -343,6 +343,48 @@ class MercadoPagoOAuthCallbackTest extends TestCase
 
     }
 
+    public function test_success_closes_open_manual_identity_validations_for_the_user(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Jane Doe',
+            'nro_doc' => '30.123.456',
+            'identity_validated' => false,
+        ]);
+        $otherUser = User::factory()->create();
+        Cache::put('mp_oauth_state:close-manual-state', ['user_id' => $user->id], 600);
+
+        $openManual = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $otherUserManual = ManualIdentityValidation::create([
+            'user_id' => $otherUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        Http::fake([
+            '*oauth/token*' => Http::response(['access_token' => 'tok'], 200),
+            '*users/me*' => Http::response([
+                'first_name' => 'Jane',
+                'last_name' => 'Doe',
+                'identification' => ['type' => 'DNI', 'number' => '30123456'],
+            ], 200),
+        ]);
+
+        $this->get('/api/mercadopago/oauth/callback?code=auth-code&state=close-manual-state')
+            ->assertRedirect($this->identityRedirect('success'));
+
+        $this->assertTrue($user->fresh()->identity_validated);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $openManual->fresh()->review_status);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $otherUserManual->fresh()->review_status);
+    }
+
     public function test_success_clears_prior_manual_rejection_state(): void
     {
         $user = User::factory()->create([

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -108,6 +108,7 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertSame('awaiting_photos', ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS);
         $this->assertSame('approved', ManualIdentityValidation::REVIEW_STATUS_APPROVED);
         $this->assertSame('rejected', ManualIdentityValidation::REVIEW_STATUS_REJECTED);
+        $this->assertSame('closed', ManualIdentityValidation::REVIEW_STATUS_CLOSED);
     }
 
     public function test_mark_paid_and_awaiting_photos_if_needed_sets_status_only_before_submission(): void

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -147,6 +147,24 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $submitted->fresh()->review_status);
     }
 
+    public function test_mark_paid_and_awaiting_photos_if_needed_does_not_reopen_closed_requests(): void
+    {
+        $user = User::factory()->create();
+        $closed = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+        ]);
+
+        $closed->markPaidAndAwaitingPhotosIfNeeded();
+        $closed->save();
+
+        $fresh = $closed->fresh();
+        $this->assertTrue($fresh->paid);
+        $this->assertNotNull($fresh->paid_at);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $fresh->review_status);
+    }
+
     public function test_table_name_is_manual_identity_validations(): void
     {
         $this->assertSame('manual_identity_validations', (new ManualIdentityValidation)->getTable());

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -109,6 +109,14 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertSame('approved', ManualIdentityValidation::REVIEW_STATUS_APPROVED);
         $this->assertSame('rejected', ManualIdentityValidation::REVIEW_STATUS_REJECTED);
         $this->assertSame('closed', ManualIdentityValidation::REVIEW_STATUS_CLOSED);
+        $this->assertSame(
+            ['approved', 'rejected', 'closed'],
+            ManualIdentityValidation::resolvedReviewStatuses()
+        );
+        $this->assertSame(
+            ['approved', 'rejected', 'closed', 'approve', 'reject'],
+            ManualIdentityValidation::resolvedReviewStatusAliases()
+        );
     }
 
     public function test_mark_paid_and_awaiting_photos_if_needed_sets_status_only_before_submission(): void

--- a/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
+++ b/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
@@ -69,4 +69,75 @@ class UserIdentityVerificationSuccessServiceTest extends TestCase
         $this->assertDatabaseHas('mercado_pago_rejected_validations', ['id' => $preserved->id]);
         $this->assertSame(1, MercadoPagoRejectedValidation::query()->where('user_id', $user->id)->count());
     }
+
+    public function test_apply_verification_with_mercado_pago_closes_open_manual_validations(): void
+    {
+        $user = User::factory()->create(['identity_validated' => false]);
+        $otherUser = User::factory()->create(['identity_validated' => false]);
+
+        $pending = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $awaitingPhotos = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS,
+        ]);
+        $unpaid = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => false,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+        $approved = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+        ]);
+        $alreadyClosed = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
+        ]);
+        $otherUserPending = ManualIdentityValidation::create([
+            'user_id' => $otherUser->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'mercado_pago');
+
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $pending->fresh()->review_status);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $awaitingPhotos->fresh()->review_status);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $unpaid->fresh()->review_status);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_APPROVED, $approved->fresh()->review_status);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $alreadyClosed->fresh()->review_status);
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $otherUserPending->fresh()->review_status);
+    }
+
+    public function test_apply_verification_with_manual_does_not_close_open_manual_validations(): void
+    {
+        $user = User::factory()->create(['identity_validated' => false]);
+
+        $pending = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        app(UserIdentityVerificationSuccessService::class)->applyVerification($user, 'manual');
+
+        $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $pending->fresh()->review_status);
+    }
 }

--- a/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
+++ b/tests/Unit/Services/UserIdentityVerificationSuccessServiceTest.php
@@ -106,6 +106,20 @@ class UserIdentityVerificationSuccessServiceTest extends TestCase
             'paid_at' => now(),
             'review_status' => ManualIdentityValidation::REVIEW_STATUS_CLOSED,
         ]);
+        $historicalApprove = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => 'approve',
+        ]);
+        $historicalReject = ManualIdentityValidation::create([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => now(),
+            'submitted_at' => now(),
+            'review_status' => 'reject',
+        ]);
         $otherUserPending = ManualIdentityValidation::create([
             'user_id' => $otherUser->id,
             'paid' => true,
@@ -121,6 +135,8 @@ class UserIdentityVerificationSuccessServiceTest extends TestCase
         $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $unpaid->fresh()->review_status);
         $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_APPROVED, $approved->fresh()->review_status);
         $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_CLOSED, $alreadyClosed->fresh()->review_status);
+        $this->assertSame('approve', $historicalApprove->fresh()->review_status);
+        $this->assertSame('reject', $historicalReject->fresh()->review_status);
         $this->assertSame(ManualIdentityValidation::REVIEW_STATUS_PENDING, $otherUserPending->fresh()->review_status);
     }
 


### PR DESCRIPTION
## Summary
- Add a `closed` review status for manual identity validations (shown as Cerrado in the admin UI).
- When MercadoPago identity verification succeeds, close that user's open manuals so they leave the admin queue.
- Admins can set `closed` via `POST /api/admin/manual-identity-validations/{id}/state` without clearing the user's identity.
- Closed rows stay out of the default admin list (`show_resolved=1` still includes them). Payment confirmation and photo submit cannot reopen a closed request.

Companion frontend PR: STS-Rosario/carpoolear `verify-mp-close-manual`.

## Test plan
- [x] `php artisan test --filter='ManualIdentityValidationTest|UserIdentityVerificationSuccessServiceTest|MercadoPagoOAuthCallbackTest|AdminManualIdentityValidationControllerIntegrationTest'` (63 passed)
- [x] `php artisan test --filter=test_submit_on_closed_request_returns_unprocessable_and_keeps_closed`
- [ ] Complete MercadoPago identity verification for a user who has a pending/unpaid manual request and confirm that request is `closed`
- [ ] Confirm the closed request is hidden from `/admin/manual-identity-validations` unless "show resolved" is on
- [ ] As admin, set a pending request to Cerrado and confirm the user's identity flags are unchanged
- [ ] A late payment webhook on a closed unpaid request marks it paid but leaves `review_status` as `closed`