### PR TITLE
Remind users to upload photos after paying for manual verification

### DIFF
--- a/app/Console/Commands/RemindManualIdentityValidationPhotoUpload.php
+++ b/app/Console/Commands/RemindManualIdentityValidationPhotoUpload.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace STS\Console\Commands;
+
+use Illuminate\Console\Command;
+use STS\Models\ManualIdentityValidation;
+use STS\Services\ManualIdentityValidationUploadReminderNotifier;
+
+class RemindManualIdentityValidationPhotoUpload extends Command
+{
+    protected $signature = 'manual-identity-validation:remind-upload-photos';
+
+    protected $description = 'Remind users who paid for manual identity validation but have not uploaded photos';
+
+    public function __construct(
+        private readonly ManualIdentityValidationUploadReminderNotifier $uploadReminderNotifier,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $week2Threshold = now()->subDays(14);
+        $week1Threshold = now()->subDays(7);
+
+        $items = ManualIdentityValidation::query()
+            ->with('user')
+            ->where('paid', true)
+            ->whereNotNull('paid_at')
+            ->whereNull('submitted_at')
+            ->where(function ($query) {
+                $query->whereNull('review_status')
+                    ->orWhereNotIn('review_status', ['approved', 'approve', 'rejected', 'reject', 'closed']);
+            })
+            ->where(function ($query) use ($week1Threshold, $week2Threshold) {
+                $query->where(function ($week2) use ($week2Threshold) {
+                    $week2->where('paid_at', '<=', $week2Threshold)
+                        ->whereNull('photos_upload_reminder_week2_sent_at');
+                })->orWhere(function ($week1) use ($week1Threshold) {
+                    $week1->where('paid_at', '<=', $week1Threshold)
+                        ->whereNull('photos_upload_reminder_week1_sent_at');
+                });
+            })
+            ->get();
+
+        $sentCount = 0;
+
+        foreach ($items as $item) {
+            if (! $item->user) {
+                continue;
+            }
+
+            $this->uploadReminderNotifier->notify($item->user, $item);
+
+            $sentAt = now();
+            $week2Due = $item->paid_at !== null
+                && $item->paid_at->lte($week2Threshold)
+                && $item->photos_upload_reminder_week2_sent_at === null;
+
+            if ($week2Due) {
+                $item->photos_upload_reminder_week2_sent_at = $sentAt;
+                if ($item->photos_upload_reminder_week1_sent_at === null) {
+                    $item->photos_upload_reminder_week1_sent_at = $sentAt;
+                }
+            } else {
+                $item->photos_upload_reminder_week1_sent_at = $sentAt;
+            }
+
+            $item->save();
+            $sentCount++;
+        }
+
+        $this->info('Manual identity validation photo upload reminders sent: '.$sentCount);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/ManualIdentityValidation.php
+++ b/app/Models/ManualIdentityValidation.php
@@ -34,6 +34,8 @@ class ManualIdentityValidation extends Model
         'private_admin_note',
         'manual_validation_started_at',
         'images_purged_at',
+        'photos_upload_reminder_week1_sent_at',
+        'photos_upload_reminder_week2_sent_at',
     ];
 
     protected function casts(): array
@@ -46,6 +48,8 @@ class ManualIdentityValidation extends Model
             'reviewed_at' => 'datetime',
             'manual_validation_started_at' => 'datetime',
             'images_purged_at' => 'datetime',
+            'photos_upload_reminder_week1_sent_at' => 'datetime',
+            'photos_upload_reminder_week2_sent_at' => 'datetime',
         ];
     }
 

--- a/app/Notifications/ManualIdentityValidationUploadReminderNotification.php
+++ b/app/Notifications/ManualIdentityValidationUploadReminderNotification.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace STS\Notifications;
+
+use STS\Services\Notifications\BaseNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+
+class ManualIdentityValidationUploadReminderNotification extends BaseNotification
+{
+    protected $via = [
+        DatabaseChannel::class,
+        PushChannel::class,
+    ];
+
+    public function toString()
+    {
+        return __('notifications.manual_identity_validation.upload_photos_reminder');
+    }
+
+    public function getExtras()
+    {
+        return [
+            'type' => 'identity_validation_manual',
+            'request_id' => (int) $this->getAttribute('request_id'),
+        ];
+    }
+
+    public function toPush($user, $device)
+    {
+        $requestId = (int) $this->getAttribute('request_id');
+
+        return [
+            'message' => __('notifications.manual_identity_validation.upload_photos_reminder'),
+            'url' => '/app/setting/identity-validation/manual?request_id='.$requestId,
+            'type' => 'identity_validation_manual',
+            'extras' => [
+                'request_id' => $requestId,
+            ],
+            'image' => 'https://carpoolear.com.ar/app/static/img/carpoolear_logo.png',
+        ];
+    }
+}

--- a/app/Services/ManualIdentityValidationUploadReminderNotifier.php
+++ b/app/Services/ManualIdentityValidationUploadReminderNotifier.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace STS\Services;
+
+use STS\Models\ManualIdentityValidation;
+use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationUploadReminderNotification;
+
+class ManualIdentityValidationUploadReminderNotifier
+{
+    public function notify(User $user, ManualIdentityValidation $validation): void
+    {
+        $notification = new ManualIdentityValidationUploadReminderNotification;
+        $notification->setAttribute('request_id', $validation->id);
+
+        try {
+            $notification->notify($user);
+        } catch (\Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/database/migrations/2026_09_02_120000_add_photo_upload_reminder_sent_at_to_manual_identity_validations.php
+++ b/database/migrations/2026_09_02_120000_add_photo_upload_reminder_sent_at_to_manual_identity_validations.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->timestamp('photos_upload_reminder_week1_sent_at')->nullable()->after('images_purged_at');
+            $table->timestamp('photos_upload_reminder_week2_sent_at')->nullable()->after('photos_upload_reminder_week1_sent_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('manual_identity_validations', function (Blueprint $table) {
+            $table->dropColumn([
+                'photos_upload_reminder_week1_sent_at',
+                'photos_upload_reminder_week2_sent_at',
+            ]);
+        });
+    }
+};

--- a/resources/lang/arg/notifications.php
+++ b/resources/lang/arg/notifications.php
@@ -122,4 +122,5 @@ return [
     'manual_identity_validation.approved' => 'Tu verificación de cuenta fue aprobada. Click acá para ver más información.',
     'manual_identity_validation.rejected' => 'Tu verificación de cuenta fue rechazada. Click acá para ver más información.',
     'manual_identity_validation.photos_purged' => 'Las fotos de tu validación manual fueron eliminadas, volvelas a subir para continuar',
+    'manual_identity_validation.upload_photos_reminder' => 'Pagaste la verificación manual, no te olvides de subir las imágenes así te verificamos la cuenta. ¿Tuviste problemas? Entrá al Menú -> Mesa de ayuda y te ayudamos',
 ];

--- a/resources/lang/chl/notifications.php
+++ b/resources/lang/chl/notifications.php
@@ -116,4 +116,5 @@ return [
     'manual_identity_validation.approved' => 'Tu verificación de cuenta fue aprobada. Click acá para ver más información.',
     'manual_identity_validation.rejected' => 'Tu verificación de cuenta fue rechazada. Click acá para ver más información.',
     'manual_identity_validation.photos_purged' => 'Las fotos de tu validación manual fueron eliminadas, volvelas a subir para continuar',
+    'manual_identity_validation.upload_photos_reminder' => 'Pagaste la verificación manual, no te olvides de subir las imágenes así te verificamos la cuenta. ¿Tuviste problemas? Entrá al Menú -> Mesa de ayuda y te ayudamos',
 ];

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -117,4 +117,5 @@ return [
     'manual_identity_validation.approved' => 'Your account verification was approved. Click here for more information.',
     'manual_identity_validation.rejected' => 'Your account verification was rejected. Click here for more information.',
     'manual_identity_validation.photos_purged' => 'Your manual validation photos were deleted. Upload them again to continue.',
+    'manual_identity_validation.upload_photos_reminder' => 'You paid for manual verification. Don\'t forget to upload your photos so we can verify your account. Having trouble? Go to Menu -> Help desk and we\'ll help you.',
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -50,6 +50,11 @@ Schedule::command('manual-identity-validation:purge-rejected-photos')
     ->dailyAt('05:00')
     ->timezone('America/Argentina/Buenos_Aires');
 
+// Remind users who paid for manual validation but have not uploaded photos
+Schedule::command('manual-identity-validation:remind-upload-photos')
+    ->dailyAt('10:00')
+    ->timezone('America/Argentina/Buenos_Aires');
+
 Schedule::command('support-tickets:release-expired-assignments')
     ->everyMinute()
     ->timezone('America/Argentina/Buenos_Aires');

--- a/routes/console.php
+++ b/routes/console.php
@@ -52,7 +52,7 @@ Schedule::command('manual-identity-validation:purge-rejected-photos')
 
 // Remind users who paid for manual validation but have not uploaded photos
 Schedule::command('manual-identity-validation:remind-upload-photos')
-    ->dailyAt('10:00')
+    ->dailyAt('20:00')
     ->timezone('America/Argentina/Buenos_Aires');
 
 Schedule::command('support-tickets:release-expired-assignments')

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -125,6 +125,13 @@ class ScheduleTest extends TestCase
         $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
     }
 
+    public function test_manual_identity_validation_remind_upload_photos_is_scheduled_daily_at10_am()
+    {
+        $event = $this->findEvent('manual-identity-validation:remind-upload-photos');
+        $this->assertEquals('0 10 * * *', $event->expression);
+        $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
+    }
+
     public function test_support_tickets_release_expired_assignments_is_scheduled_every_minute()
     {
         $event = $this->findEvent('support-tickets:release-expired-assignments');
@@ -169,6 +176,7 @@ class ScheduleTest extends TestCase
             'auth:cleanup-reset-tokens',
             'support-tickets:autoclose',
             'manual-identity-validation:purge-rejected-photos',
+            'manual-identity-validation:remind-upload-photos',
             'support-tickets:release-expired-assignments',
             'car-catalog:sync-argautos',
         ];

--- a/tests/Feature/Commands/ScheduleTest.php
+++ b/tests/Feature/Commands/ScheduleTest.php
@@ -125,10 +125,10 @@ class ScheduleTest extends TestCase
         $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
     }
 
-    public function test_manual_identity_validation_remind_upload_photos_is_scheduled_daily_at10_am()
+    public function test_manual_identity_validation_remind_upload_photos_is_scheduled_daily_at8_pm()
     {
         $event = $this->findEvent('manual-identity-validation:remind-upload-photos');
-        $this->assertEquals('0 10 * * *', $event->expression);
+        $this->assertEquals('0 20 * * *', $event->expression);
         $this->assertEquals('America/Argentina/Buenos_Aires', $event->timezone);
     }
 

--- a/tests/Unit/Console/Commands/RemindManualIdentityValidationPhotoUploadTest.php
+++ b/tests/Unit/Console/Commands/RemindManualIdentityValidationPhotoUploadTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use Carbon\Carbon;
+use STS\Models\ManualIdentityValidation;
+use STS\Models\User;
+use STS\Notifications\ManualIdentityValidationUploadReminderNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+use STS\Services\Notifications\NotificationServices;
+use Tests\TestCase;
+
+class RemindManualIdentityValidationPhotoUploadTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPaidAwaitingPhotos(User $user, array $overrides = []): ManualIdentityValidation
+    {
+        return ManualIdentityValidation::create(array_merge([
+            'user_id' => $user->id,
+            'paid' => true,
+            'paid_at' => Carbon::now()->subDays(8),
+            'submitted_at' => null,
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_AWAITING_PHOTOS,
+        ], $overrides));
+    }
+
+    public function test_handle_sends_week1_reminder_seven_days_after_payment_when_photos_are_missing(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+        $row = $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(7),
+        ]);
+
+        $this->expectReminderSentTo($user, $row, 1);
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 1')
+            ->assertExitCode(0);
+
+        $fresh = $row->fresh();
+        $this->assertNotNull($fresh->photos_upload_reminder_week1_sent_at);
+        $this->assertNull($fresh->photos_upload_reminder_week2_sent_at);
+    }
+
+    public function test_handle_does_not_send_week1_reminder_before_seven_days(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+        $row = $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(6),
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) {
+            $mock->shouldReceive('send')->never();
+        });
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 0')
+            ->assertExitCode(0);
+
+        $this->assertNull($row->fresh()->photos_upload_reminder_week1_sent_at);
+    }
+
+    public function test_handle_does_not_send_when_photos_were_already_submitted(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+        $row = $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(10),
+            'submitted_at' => Carbon::now()->subDays(1),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_PENDING,
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) {
+            $mock->shouldReceive('send')->never();
+        });
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 0')
+            ->assertExitCode(0);
+
+        $this->assertNull($row->fresh()->photos_upload_reminder_week1_sent_at);
+    }
+
+    public function test_handle_does_not_resend_week1_reminder(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+        $row = $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(10),
+            'photos_upload_reminder_week1_sent_at' => Carbon::now()->subDays(3),
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) {
+            $mock->shouldReceive('send')->never();
+        });
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            '2026-08-30 10:00:00',
+            $row->fresh()->photos_upload_reminder_week1_sent_at->format('Y-m-d H:i:s')
+        );
+    }
+
+    public function test_handle_sends_week2_reminder_fourteen_days_after_payment_when_photos_are_missing(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+        $row = $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(14),
+            'photos_upload_reminder_week1_sent_at' => Carbon::now()->subDays(7),
+        ]);
+
+        $this->expectReminderSentTo($user, $row, 1);
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 1')
+            ->assertExitCode(0);
+
+        $fresh = $row->fresh();
+        $this->assertNotNull($fresh->photos_upload_reminder_week2_sent_at);
+        $this->assertSame(
+            '2026-08-26 10:00:00',
+            $fresh->photos_upload_reminder_week1_sent_at->format('Y-m-d H:i:s')
+        );
+    }
+
+    public function test_handle_sends_only_week2_when_both_reminders_are_due(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+        $row = $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(15),
+        ]);
+
+        $this->expectReminderSentTo($user, $row, 1);
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 1')
+            ->assertExitCode(0);
+
+        $fresh = $row->fresh();
+        $this->assertNotNull($fresh->photos_upload_reminder_week1_sent_at);
+        $this->assertNotNull($fresh->photos_upload_reminder_week2_sent_at);
+    }
+
+    public function test_handle_does_not_send_for_unpaid_or_resolved_requests(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 9, 2, 10, 0, 0));
+        $user = User::factory()->create();
+
+        $this->createPaidAwaitingPhotos($user, [
+            'paid' => false,
+            'paid_at' => null,
+        ]);
+        $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(20),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_APPROVED,
+        ]);
+        $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(20),
+            'review_status' => ManualIdentityValidation::REVIEW_STATUS_REJECTED,
+        ]);
+        $this->createPaidAwaitingPhotos($user, [
+            'paid_at' => Carbon::now()->subDays(20),
+            'review_status' => 'closed',
+        ]);
+
+        $this->mock(NotificationServices::class, function ($mock) {
+            $mock->shouldReceive('send')->never();
+        });
+
+        $this->artisan('manual-identity-validation:remind-upload-photos')
+            ->expectsOutput('Manual identity validation photo upload reminders sent: 0')
+            ->assertExitCode(0);
+    }
+
+    private function expectReminderSentTo(User $user, ManualIdentityValidation $row, int $times): void
+    {
+        $this->mock(NotificationServices::class, function ($mock) use ($user, $row, $times) {
+            $mock->shouldReceive('send')
+                ->times($times * 2)
+                ->withArgs(function ($notification, $recipient, $channel) use ($user, $row) {
+                    if (! $notification instanceof ManualIdentityValidationUploadReminderNotification) {
+                        return false;
+                    }
+                    if ((int) $notification->getAttribute('request_id') !== (int) $row->id) {
+                        return false;
+                    }
+                    if (! $recipient instanceof User || (int) $recipient->id !== (int) $user->id) {
+                        return false;
+                    }
+
+                    return in_array($channel, [
+                        DatabaseChannel::class,
+                        PushChannel::class,
+                    ], true);
+                });
+        });
+    }
+}

--- a/tests/Unit/Models/ManualIdentityValidationTest.php
+++ b/tests/Unit/Models/ManualIdentityValidationTest.php
@@ -78,6 +78,22 @@ class ManualIdentityValidationTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $row->fresh()->images_purged_at);
     }
 
+    public function test_photo_upload_reminder_sent_at_fields_are_cast_to_datetime(): void
+    {
+        $user = User::factory()->create();
+
+        $row = $this->makeRow($user, [
+            'photos_upload_reminder_week1_sent_at' => '2026-08-20 10:00:00',
+            'photos_upload_reminder_week2_sent_at' => '2026-08-27 10:00:00',
+        ]);
+
+        $fresh = $row->fresh();
+        $this->assertInstanceOf(Carbon::class, $fresh->photos_upload_reminder_week1_sent_at);
+        $this->assertInstanceOf(Carbon::class, $fresh->photos_upload_reminder_week2_sent_at);
+        $this->assertSame('2026-08-20 10:00:00', $fresh->photos_upload_reminder_week1_sent_at->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-08-27 10:00:00', $fresh->photos_upload_reminder_week2_sent_at->format('Y-m-d H:i:s'));
+    }
+
     public function test_has_images_detects_any_uploaded_path(): void
     {
         $user = User::factory()->create();
@@ -162,6 +178,8 @@ class ManualIdentityValidationTest extends TestCase
             'private_admin_note',
             'manual_validation_started_at',
             'images_purged_at',
+            'photos_upload_reminder_week1_sent_at',
+            'photos_upload_reminder_week2_sent_at',
         ], (new ManualIdentityValidation)->getFillable());
     }
 

--- a/tests/Unit/Notifications/ManualIdentityValidationUploadReminderNotificationTest.php
+++ b/tests/Unit/Notifications/ManualIdentityValidationUploadReminderNotificationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Notifications;
+
+use STS\Notifications\ManualIdentityValidationUploadReminderNotification;
+use STS\Services\Notifications\Channels\DatabaseChannel;
+use STS\Services\Notifications\Channels\PushChannel;
+use Tests\TestCase;
+
+class ManualIdentityValidationUploadReminderNotificationTest extends TestCase
+{
+    public function test_via_contains_database_and_push_channels(): void
+    {
+        $notification = new ManualIdentityValidationUploadReminderNotification;
+
+        $this->assertSame([
+            DatabaseChannel::class,
+            PushChannel::class,
+        ], $notification->getVia());
+    }
+
+    public function test_to_string_returns_upload_reminder_message_in_argentine_spanish(): void
+    {
+        app()->setLocale('arg');
+        $notification = new ManualIdentityValidationUploadReminderNotification;
+
+        $this->assertSame(
+            'Pagaste la verificación manual, no te olvides de subir las imágenes así te verificamos la cuenta. ¿Tuviste problemas? Entrá al Menú -> Mesa de ayuda y te ayudamos',
+            $notification->toString()
+        );
+    }
+
+    public function test_get_extras_returns_manual_validation_type_and_request_id(): void
+    {
+        $notification = new ManualIdentityValidationUploadReminderNotification;
+        $notification->setAttribute('request_id', 42);
+
+        $this->assertSame([
+            'type' => 'identity_validation_manual',
+            'request_id' => 42,
+        ], $notification->getExtras());
+    }
+
+    public function test_to_push_builds_manual_validation_upload_url(): void
+    {
+        app()->setLocale('arg');
+        $notification = new ManualIdentityValidationUploadReminderNotification;
+        $notification->setAttribute('request_id', 42);
+
+        $push = $notification->toPush(null, null);
+
+        $this->assertSame(
+            'Pagaste la verificación manual, no te olvides de subir las imágenes así te verificamos la cuenta. ¿Tuviste problemas? Entrá al Menú -> Mesa de ayuda y te ayudamos',
+            $push['message']
+        );
+        $this->assertSame('/app/setting/identity-validation/manual?request_id=42', $push['url']);
+        $this->assertSame('identity_validation_manual', $push['type']);
+        $this->assertSame(42, $push['extras']['request_id']);
+        $this->assertSame('https://carpoolear.com.ar/app/static/img/carpoolear_logo.png', $push['image']);
+    }
+}


### PR DESCRIPTION
## Summary
- Sends a push + in-app reminder 1 week after `paid_at` if the user still has not uploaded photos (`submitted_at` is null), and a second reminder at 2 weeks.
- Copy (ARG/CHL): `Pagaste la verificación manual, no te olvides de subir las imágenes así te verificamos la cuenta. ¿Tuviste problemas? Entrá al Menú -> Mesa de ayuda y te ayudamos`
- Daily artisan command `manual-identity-validation:remind-upload-photos` at 20:00 `America/Argentina/Buenos_Aires`. If both reminders are due in the same run, only one notification is sent and both timestamps are stamped. Deeplink: `/app/setting/identity-validation/manual?request_id={id}`.

## Test plan
- [ ] Run migration and confirm `photos_upload_reminder_week1_sent_at` / `photos_upload_reminder_week2_sent_at` exist on `manual_identity_validations`
- [ ] Pay for a manual validation, leave photos unsent, set `paid_at` to 7 days ago, run `php artisan manual-identity-validation:remind-upload-photos` and confirm the notification is created with the exact copy and the identity-validation URL
- [ ] Run the command again the same day and confirm it does not resend week 1
- [ ] Set `paid_at` to 14 days ago with week 1 already sent; confirm week 2 is sent once
- [ ] Confirm no reminder is sent if photos were already submitted, or if the request is unpaid / approved / rejected / closed
- [ ] Confirm scheduler lists the command daily at 20:00 Argentina time
